### PR TITLE
xeno_math: replace manifest declaration of printk() with kernel include

### DIFF
--- a/src/rtapi/xeno_math/k_standard.c
+++ b/src/rtapi/xeno_math/k_standard.c
@@ -17,10 +17,9 @@ static char rcsid[] = "$NetBSD: k_standard.c,v 1.6 1995/05/10 20:46:35 jtc Exp $
 #include "rtapi_math.h"
 #include "mathP.h"
 #include <linux/errno.h>		/* FIXME */
+#include <linux/printk.h>		/* FIXME */
 
 extern int libm_errno;
-
-extern int printk(const char *, ...);
 
 #define	WRITE2(u,v) printk("%.*s",v,u)
 


### PR DESCRIPTION
The explicit declaration tripped an error on some kernel version.
