### PR TITLE
added M109 file for waiting for temperature when using a fdm printer

### DIFF
--- a/nc_files/M109
+++ b/nc_files/M109
@@ -6,8 +6,22 @@
 # temperature to be achieved.
 # Example: M109 S185 
 
+temp_required=$1
+temp_actual=$(halcmd getp Therm.temp0)
 
-echo FIXME: $0
-
+halcmd sets e0.temp.set $temp_required
+#bash cannot do floating point comparison
+T_extruder_smaller_than_T_required=`echo "scale=3; ($temp_actual < $temp_required)"| bc -l`
+#echo "Ta<Tr? $T_extruder_smaller_than_T_required"
+while [ "$T_extruder_smaller_than_T_required" != "0" ]
+do
+  echo enter while loop
+  temp_actual=$(halcmd getp Therm.temp0)
+#  echo temp_actual= $temp_actual
+  sleep 1
+  T_extruder_smaller_than_T_required=`echo "scale=3; ($temp_actual < $temp_required)"| bc -l`
+#  echo "Ta<Tr? $T_extruder_smaller_than_T_required"
+done
+#echo temp reached
 exit 0
 


### PR DESCRIPTION
I made the M109 Pxxx (xxx being temperature) able to be used when setting the temperature generated from i.e. slic3r or other slicing software.
- bc needs to be installed for computing and comparing the values of current and set temperature
- waiting only works for set temperatures being higher than the current temp. when i.e. you want to wait for the program to wait until the temp is dropped to a certain temperature it doesn't work yet
