### PR TITLE
scripts/check-system-configuration.sh:  suppress error

### DIFF
--- a/scripts/check-system-configuration.sh
+++ b/scripts/check-system-configuration.sh
@@ -83,6 +83,7 @@ check-ulimits() {
     export LC_COLLATE=C
     memlock=0
     for f in /etc/security/limits.conf /etc/security/limits.d/*.conf; do
+	test -f $f || continue
 	mtmp=$(awk '/^[^#]/ && $3=="memlock" {m=$4} END {print m}' $f)
 	test -n "$mtmp" && memlock=$mtmp
     done


### PR DESCRIPTION
Don't print errors if /etc/security/....conf doesn't exist
