### PR TITLE
Updated Redame, - missing autogen.sh

### DIFF
--- a/README
+++ b/README
@@ -45,6 +45,7 @@ From the top level directory, switch to the source directory:
 
 In the source directory, build LinuxCNC:
 
+  ./autogen.sh
   ./configure
   [or, if you do not have a realtime kernel:]
   ./configure --enable-simulator


### PR DESCRIPTION
After cloning the repo a autogen.sh is needed before the configure.
I added that step to the Quickstart.

IMHO the make clean is not needed in every case, but it does not destroy thinks.
