### PR TITLE
Restrict use of 'pepper' component to userland rt threads (on BeagleBone...

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1089,8 +1089,6 @@ obj-$(CONFIG_SIGGEN) += siggen.o
 siggen-objs := hal/components/siggen.o $(MATHSTUB)
 obj-$(CONFIG_PID) += pid.o
 pid-objs := hal/components/pid.o $(MATHSTUB)
-obj-$(CONFIG_PEPPER) += pepper.o
-pepper-objs := hal/components/pepper.o $(MATHSTUB)
 obj-$(CONFIG_AT_PID) += at_pid.o
 at_pid-objs := hal/components/at_pid.o $(MATHSTUB)
 obj-$(CONFIG_PID) += threads.o
@@ -1155,6 +1153,8 @@ ifeq ($(TARGET_PLATFORM), beaglebone)
 ifeq ($(BUILD_SYS),user-dso)
 obj-$(CONFIG_HAL_GPIO) += hal_bb_gpio.o
 hal_bb_gpio-objs := hal/drivers/hal_bb_gpio.o 
+obj-$(CONFIG_PEPPER) += pepper.o
+pepper-objs := hal/components/pepper.o $(MATHSTUB)
 endif
 endif
 
@@ -1428,7 +1428,6 @@ $(RTLIBDIR)/pwmgen$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(pwmgen-objs))
 $(RTLIBDIR)/siggen$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(siggen-objs))
 $(RTLIBDIR)/at_pid$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(at_pid-objs))
 $(RTLIBDIR)/pid$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(pid-objs))
-$(RTLIBDIR)/pepper$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(pepper-objs))
 $(RTLIBDIR)/threads$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(threads-objs))
 $(RTLIBDIR)/supply$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(supply-objs))
 $(RTLIBDIR)/sim_encoder$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(sim_encoder-objs))
@@ -1460,6 +1459,7 @@ $(RTLIBDIR)/hal_pru_generic$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hal_pru_gener
 $(RTLIBDIR)/hal_prudebug$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hal_prudebug-objs))
 $(RTLIBDIR)/hal_gpio$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hal_gpio-objs))
 $(RTLIBDIR)/hal_bb_gpio$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hal_bb_gpio-objs))
+$(RTLIBDIR)/pepper$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(pepper-objs))
 endif
 endif
 

--- a/src/hal/components/pepper.c
+++ b/src/hal/components/pepper.c
@@ -92,6 +92,11 @@ MODULE_AUTHOR("Bas Laarhoven");
 MODULE_DESCRIPTION("Pepper Board Configuration Component for EMC HAL");
 MODULE_LICENSE("GPL");
 
+
+#if !defined( BUILD_SYS_USER_DSO)
+#error "This driver is for usermode threads only"
+#endif
+
 /***********************************************************************
 *                STRUCTURES AND GLOBAL VARIABLES                       *
 ************************************************************************/
@@ -144,8 +149,6 @@ static int comp_id;             /* component ID */
 static int  pepper_export( hal_pepper_t* addr, const char* prefix);
 static void pepper_update( void *arg, long period);
 static int  pepper_spi_prepare( hal_pepper_t* data);
-static int  pepper_spi_start( void);
-static int  pepper_spi_end( void);
 static int  pepper_spi_next_bit( int* spi_data);
 
 /***********************************************************************


### PR DESCRIPTION
Fix the build error caused by the missing stdint.h on some platforms. Use of this code is now restricted to the BeagleBone platform with Xenomai userland threads.

Please review carefully as I was unable to test these changes myself (some configuration issues).

-- Bas
