### PR TITLE
configs : Fix Xylotex.ShuttleXpress.ini

### DIFF
--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.ShuttleXpress.ini
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.ShuttleXpress.ini
@@ -169,6 +169,10 @@ DIRHOLD    =              200
 STEPLEN    =              1000
 STEPSPACE  =              1000
 
+# Set to one for active low step pulses
+STEP_INVERT =           0
+
+
 # PID tuning params
 DEADBAND =              0
 P =                     50
@@ -213,6 +217,9 @@ DIRHOLD    =              200
 STEPLEN    =              1000
 STEPSPACE  =              1000
 
+# Set to one for active low step pulses
+STEP_INVERT =           0
+
 # PID tuning params
 DEADBAND =              0
 P =                     50
@@ -256,6 +263,9 @@ DIRSETUP   =              200
 DIRHOLD    =              200
 STEPLEN    =              1000
 STEPSPACE  =              1000
+
+# Set to one for active low step pulses
+STEP_INVERT =           0
 
 # PID tuning params
 DEADBAND =              0
@@ -302,6 +312,9 @@ DIRSETUP   =              200
 DIRHOLD    =              200
 STEPLEN    =              1000
 STEPSPACE  =              1000
+
+# Set to one for active low step pulses
+STEP_INVERT =           0
 
 # PID tuning params
 DEADBAND =              0


### PR DESCRIPTION
Missing STEP_INVERT settings for each axis

Signed-off-by: Charles Steinkuehler charles@steinkuehler.net
