### PR TITLE
Fix debian package builds for xenomai and rtai

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -8,9 +8,9 @@ cd "$(dirname $0)"
 
 FLAVORS=
 
-# Check if xenomai is installed, headers is not needed
+# Check if xenomai dev is installed
 check_xeno() {
-    XENO_KVER="$(dpkg-query -W -f '${binary:Package}\n' linux-image-\*xenom\* 2> /dev/null)"
+    dpkg-query -W libxenomai-dev >&/dev/null
 }
 
 #FIXME: testing needed
@@ -118,14 +118,6 @@ build_rules() {
 build_substvars() {
     # init empty substvars file
     >substvars
-
-    # add Xenomai deps, if found
-    if check_xeno; then
-	set -- $XENO_KVER
-	XENO_KVER="${1//linux-image-/}"
-	test -z "$XENO_KVER" || \
-	    echo "xenomai-kver=$XENO_KVER" >> substvars
-    fi
 
     if check_rtai; then
 	set -- $RTAI_KVER

--- a/debian/control.rtai-kernel.in
+++ b/debian/control.rtai-kernel.in
@@ -1,5 +1,5 @@
 
-Package: linuxcnc-rtai
+Package: linuxcnc-rtai-kernel
 Conflicts: emc2, emc2-sim, linuxcnc-sim
 Architecture: any
 Depends: linuxcnc (= ${binary:Version}), ${shlibs:Depends},

--- a/debian/control.xenomai.in
+++ b/debian/control.xenomai.in
@@ -3,7 +3,7 @@ Package: linuxcnc-xenomai
 Conflicts: emc2, emc2-sim, linuxcnc-sim
 Architecture: any
 Depends: linuxcnc (= ${binary:Version}), ${shlibs:Depends},
-	libxenomai1, xenomai-runtime, linux-image-${xenomai-kver}
+	libxenomai1, xenomai-runtime, linux-image-xenomai
 Recommends: hostmot2-firmware
 Enhances: linuxcnc
 Description: PC based motion controller for real-time Linux

--- a/debian/linuxcnc-rtai-kernel.files.in
+++ b/debian/linuxcnc-rtai-kernel.files.in
@@ -1,0 +1,3 @@
+lib/modules/*-rtai*/linuxcnc/Module.symvers
+lib/modules/*-rtai*/linuxcnc/*.ko
+usr/lib/linuxcnc/ulapi-rtai-kernel.so

--- a/debian/linuxcnc-rtai.files.in
+++ b/debian/linuxcnc-rtai.files.in
@@ -1,3 +1,0 @@
-lib/modules/*/linuxcnc/Module.symvers
-lib/modules/*/linuxcnc/*.ko
-usr/lib/linuxcnc/ulapi-rtai-kernel.so


### PR DESCRIPTION
- Build Xenomai if libxenomai-dev pkg is installed
  - linux-image-_xeno_ is not a build dep
- Remove linux-image-xenomai version dependency in linuxcnc-xenomai pkg
  - xeno-user threads are kversion independent
- Fix linuxcnc-rtai-kernel package file globs
- Fix things needing to be called 'rtai-kernel' to be picked up properly

Fixes #155
