### PR TITLE
motion: add motion.current-motion pin.

### DIFF
--- a/docs/man/man9/motion.9
+++ b/docs/man/man9/motion.9
@@ -141,6 +141,10 @@ When Feed Stop Control is enabled with M53 P1, and this bit is TRUE, the feed ra
 TRUE if the machine is in position.
 
 .TP
+\fBmotion.current-motion\fR OUT S32
+Indicates the currently executing motion type. Zero if no motion in progress, or paused. Otherwise, the meanings are: 1 for traverse move, 2 for linear feed move, 3 for arc move, 4 for toolchange, 5 for probing, 6 for indexrotary action.
+
+.TP
 \fBmotion.probe-input\fR IN BIT 
 G38.x uses the value on this pin to determine when the probe has made contact. TRUE for probe contact closed (touching), FALSE for probe contact open.
 

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -2011,9 +2011,11 @@ static void output_to_hal(void)
     *(emcmot_hal_data->spindle_forward) = (*emcmot_hal_data->spindle_speed_out > 0) ? 1 : 0;
     *(emcmot_hal_data->spindle_reverse) = (*emcmot_hal_data->spindle_speed_out < 0) ? 1 : 0;
     *(emcmot_hal_data->spindle_brake) = (emcmotStatus->spindle.brake != 0) ? 1 : 0;
-    
+
     *(emcmot_hal_data->program_line) = emcmotStatus->id;
+    *(emcmot_hal_data->current_motion_type) = emcmotStatus->motionType;
     *(emcmot_hal_data->distance_to_go) = emcmotStatus->distance_to_go;
+
     if(GET_MOTION_COORD_FLAG()) {
         *(emcmot_hal_data->current_vel) = emcmotStatus->current_vel;
         *(emcmot_hal_data->requested_vel) = emcmotStatus->requested_vel;

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -194,6 +194,9 @@ typedef struct {
     hal_bit_t *pause_offset_in_range;    // current offset ok with joint limits
 
     hal_s32_t *paused_at_motion_type;  // see motion_types.h; the move active when FH was pressed
+    hal_s32_t *current_motion_type;    // see motion_types.h; zero if no motion in progress
+
+
     //hal_s32_t *fh_stoppable_motions;  // mask of stoppable move types
 
     // out: when the above happened, assert the following pin

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -576,6 +576,9 @@ static int init_hal_io(void)
     if ((retval = hal_pin_s32_newf(HAL_OUT, &(emcmot_hal_data->paused_at_motion_type),
 				   mot_comp_id, "motion.paused-at-motion")) < 0) return retval;
 
+    if ((retval = hal_pin_s32_newf(HAL_OUT, &(emcmot_hal_data->current_motion_type),
+				   mot_comp_id, "motion.current-motion")) < 0) return retval;
+
     if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->pause_offset_in_range),
 				   mot_comp_id, "motion.pause-offset-in-range")) < 0) return retval;
 


### PR DESCRIPTION
This reflects the current motion type:
# define EMC_MOTION_TYPE_TRAVERSE 1
# define EMC_MOTION_TYPE_FEED 2
# define EMC_MOTION_TYPE_ARC 3
# define EMC_MOTION_TYPE_TOOLCHANGE 4
# define EMC_MOTION_TYPE_PROBING 5
# define EMC_MOTION_TYPE_INDEXROTARY 6

In a paused state or when not currently executing a motion, the pin is
set to zero.

See also the thread on https://groups.google.com/forum/#!topic/machinekit/HaBUZZyrsyE - this might be useful for extruder-type and lasercutter printers where some tool-related action can be tied to the current motion mode (eg laser off during rapids)
