### PR TITLE
Max out syslog-async buffers

### DIFF
--- a/src/rtapi/rtapi_app.cc
+++ b/src/rtapi/rtapi_app.cc
@@ -948,6 +948,8 @@ int main(int argc, char **argv)
     rtapi_set_msg_handler(rtapi_app_msg_handler);
     openlog_async(argv[0], LOG_NDELAY, LOG_LOCAL1);
     setlogmask_async(LOG_UPTO(LOG_DEBUG));
+    // max out async syslog buffers for slow system in debug mode
+    tunelog_async(99,1000);
 
     while (1) {
 	int option_index = 0;

--- a/src/rtapi/rtapi_msgd.c
+++ b/src/rtapi/rtapi_msgd.c
@@ -685,6 +685,8 @@ int main(int argc, char **argv)
     snprintf(proctitle, sizeof(proctitle), "msgd:%d",rtapi_instance);
 
     openlog_async(proctitle, option , SYSLOG_FACILITY);
+    // max out async syslog buffers for slow system in debug mode
+    tunelog_async(99,1000);
 
     // set new process name
     argv0_len = strlen(argv[0]);


### PR DESCRIPTION
I/O constrained systems running in debug mode may drop messages with
the default buffer of 5 lines.

Raise to the max 99 lines.
