### PR TITLE
module-loading/shared-test.sh:  fix race & print debug output

### DIFF
--- a/tests/module-loading/shared-test.sh
+++ b/tests/module-loading/shared-test.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-halrun setup.hal > hal-output 2>&1
+outpipe=pipe-stdout
+mkfifo $outpipe
+
+tee hal-output < $outpipe | egrep $(cat PIN_NAME_REGEX) | wc -l \
+    > NUM_PINS_FOUND & pid=$!
+
+halrun setup.hal > $outpipe
 RESULT=$?
 
-NUM_PINS=$(cat hal-output | egrep $(cat PIN_NAME_REGEX) | wc -l)
+wait $pid
 
 if [ $RESULT -ne $(cat RESULT) ]; then
     echo "Test exited with status $RESULT; output:"
@@ -11,12 +17,11 @@ if [ $RESULT -ne $(cat RESULT) ]; then
     exit 1
 fi
 
-if [ "$NUM_PINS" -ne $(cat NUM_PINS) ]; then
+if [ "$(cat NUM_PINS_FOUND)" -ne "$(cat NUM_PINS)" ]; then
     echo "Error:  number of pins found != number expected"
-    echo "Pins found: '$NUM_PINS'"
-    echo "Pins expected:  $(cat NUM_PINS)"
+    echo "Pins found '$(cat NUM_PINS_FOUND)' !=" \
+        "Pins expected '$(cat NUM_PINS)'"
     exit 1
 fi
 
 exit 0
-


### PR DESCRIPTION
This test contains a race condition where the 'egrep' command reads
the output file before it is finished being written.  In addition, the
problem can't be determined from debug output because 'halrun' output
is directed into a file.

This happens because of the weird pipe redirect stuff in runtests.

Fix race by doing more weird pipe redirect stuff in test.

Fix debug output by not redirecting stderr into 'hal-output' file and
by dumping the hal-output file to stdout on failure.
