### PR TITLE
gladevcp - bug if filename has several dots

### DIFF
--- a/lib/python/gladevcp/iconview.py
+++ b/lib/python/gladevcp/iconview.py
@@ -267,7 +267,7 @@ class IconFileSelection(gtk.HBox):
                         number += 1
                     else:
                         try:
-                            name, ext = fl.split(".")
+                            name, ext = fl.rsplit(".", 1)
                             if "*" in self.filetypes:
                                 files.append(fl)
                                 number += 1


### PR DESCRIPTION
The store will not contain names with several dots in its
name, because of a using split instead of rsplit.
So names like:

Pocket 2.5 test(1).ngc

was not shown.

The error has been solved
