### PR TITLE
Partial fix for #185

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 6),
     libglib2.0-dev, libglu1-mesa-dev, libgtk2.0-dev, libmodbus-dev (>= 3.0),
     libncurses-dev, libreadline-dev, libusb-1.0-0-dev, libxmu-dev,
     libxmu-headers, python, python-dev, python-support, pkg-config, psmisc,
-    @BUILD_DEPS@python-tk, tcl-dev, tk-dev
+    @BUILD_DEPS@python-tk, tcl8.5-dev, tk8.5-dev, libxaw7-dev
 Standards-Version: 2.1.0
 
 Package: linuxcnc-dev


### PR DESCRIPTION
fixed missing libxaw7-dev build dependency.

forced tcl/tk version to 8.5 (this is valid everywhere except for Lucid)
