### PR TITLE
xeno_math: add __powidf2()

### DIFF
--- a/src/rtapi/xeno_math/Submakefile
+++ b/src/rtapi/xeno_math/Submakefile
@@ -35,6 +35,7 @@ xeno_math-objs += rtapi/xeno_math/s_cbrt.o
 xeno_math-objs += rtapi/xeno_math/s_copysign.o
 xeno_math-objs += rtapi/xeno_math/s_finite.o
 xeno_math-objs += rtapi/xeno_math/s_rint.o
+xeno_math-objs += rtapi/xeno_math/powidf.o
 
 $(RTLIBDIR)/xeno_math$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(xeno_math-objs))
 

--- a/src/rtapi/xeno_math/libm.c
+++ b/src/rtapi/xeno_math/libm.c
@@ -73,3 +73,6 @@ EXPORT_SYMBOL(pow);
 EXPORT_SYMBOL(ceil);
 EXPORT_SYMBOL(floor);
 EXPORT_SYMBOL(cbrt);
+
+
+EXPORT_SYMBOL(__powidf2);

--- a/src/rtapi/xeno_math/mathP.h
+++ b/src/rtapi/xeno_math/mathP.h
@@ -272,4 +272,5 @@ extern float __kernel_cosf __P((float,float));
 extern float __kernel_tanf __P((float,float,int));
 extern int   __kernel_rem_pio2f __P((float*,float*,int,int,int,const int*));
 
+extern double __powidf2(double a, int b);
 #endif /* _MATH_PRIVATE_H_ */

--- a/src/rtapi/xeno_math/powidf.c
+++ b/src/rtapi/xeno_math/powidf.c
@@ -1,0 +1,37 @@
+/* ===-- powidf2.cpp - Implement __powidf2 ---------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __powidf2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * from: http://opensource.apple.com/source/clang/clang-137/src/projects/compiler-rt/lib/
+ */
+typedef      int si_int;
+
+//#include "int_lib.h"
+
+/* Returns: a ^ b */
+
+double
+__powidf2(double a, int b)
+{
+    const int recip = b < 0;
+    double r = 1;
+    while (1)
+    {
+        if (b & 1)
+            r *= a;
+        b /= 2;
+        if (b == 0)
+            break;
+        a *= a;
+    }
+    return recip ? 1/r : r;
+}


### PR DESCRIPTION
looks like gcc4.8 requires this
taken from: http://opensource.apple.com/source/clang/clang-137/src/projects/compiler-rt/lib/
MIT licensed
