### PR TITLE
tests: rearrange invocation of halsampler to avoid race conditions

### DIFF
--- a/tests/abs.0/test.hal
+++ b/tests/abs.0/test.hal
@@ -1,6 +1,8 @@
 setexact_for_test_suite_only
 
 loadrt sampler cfg=ff depth=350
+loadusr -Wn halsampler halsampler -N halsampler -n 7
+
 loadrt streamer cfg=f depth=350
 loadrt abs
 loadrt threads name1=fast period1=300000
@@ -12,7 +14,7 @@ addf streamer.0 fast
 addf abs.0 fast
 addf sampler.0 fast
 
-loadusr -Wn halsampler halsampler -N halsampler -n 7
 loadusr -w sh runstreamer
 start
+waitusr halsampler
 

--- a/tests/and-or-not-mux.0/test.hal
+++ b/tests/and-or-not-mux.0/test.hal
@@ -9,6 +9,8 @@ loadrt mux2
 loadrt mux4
 
 loadrt sampler depth=1000 cfg=bbbff
+loadusr -Wn halsampler halsampler -N halsampler -n 16
+
 loadrt streamer depth=32 cfg=bbbb
 
 
@@ -51,4 +53,4 @@ addf sampler.0 fast
 
 loadusr -w sh runstreamer
 start
-loadusr -w halsampler -n 16
+waitusr halsampler

--- a/tests/counter-encoder.0/test.hal
+++ b/tests/counter-encoder.0/test.hal
@@ -1,6 +1,8 @@
 setexact_for_test_suite_only
 
 loadrt sampler cfg=sss depth=3500
+loadusr  -Wn halsampler halsampler -N halsampler  -n 3500
+
 loadrt stepgen step_type=2
 loadrt encoder num_chan=3
 loadrt threads name1=fast period1=100000
@@ -26,4 +28,4 @@ setp encoder.1.x4-mode 0
 setp encoder.2.counter-mode 1
 
 start
-loadusr -w halsampler -n 3500
+waitusr halsampler

--- a/tests/edge/both-starting-high/test.hal
+++ b/tests/edge/both-starting-high/test.hal
@@ -1,9 +1,12 @@
 setexact_for_test_suite_only
 
+
+loadrt sampler cfg=bbb depth=500
+loadusr -Wn halsampler halsampler -N halsampler -n 10
+
 loadrt threads name1=fast period1=100000
 loadrt edge
 
-loadrt sampler cfg=bbb depth=500
 loadrt streamer cfg=b depth=500
 
 net in         streamer.0.pin.0  => sampler.0.pin.0 edge.0.in
@@ -22,4 +25,4 @@ setp edge.0.out-width-ns 25000
 
 loadusr -w sh runstreamer
 start
-loadusr -w halsampler -n 10
+waitusr halsampler

--- a/tests/edge/both/test.hal
+++ b/tests/edge/both/test.hal
@@ -1,9 +1,11 @@
 setexact_for_test_suite_only
 
+loadrt sampler cfg=bbb depth=500
+loadusr -Wn halsampler halsampler -N halsampler -n 10
+
 loadrt threads name1=fast period1=100000
 loadrt edge
 
-loadrt sampler cfg=bbb depth=500
 loadrt streamer cfg=b depth=500
 
 net in         streamer.0.pin.0  => sampler.0.pin.0 edge.0.in
@@ -22,4 +24,5 @@ setp edge.0.out-width-ns 25000
 
 loadusr -w sh runstreamer
 start
-loadusr -w halsampler -n 10
+waitusr halsampler
+

--- a/tests/edge/falling-starting-high/test.hal
+++ b/tests/edge/falling-starting-high/test.hal
@@ -4,6 +4,8 @@ loadrt threads name1=fast period1=100000
 loadrt edge
 
 loadrt sampler cfg=bbb depth=500
+loadusr -Wn halsampler halsampler -N halsampler -n 10
+
 loadrt streamer cfg=b depth=500
 
 net in         streamer.0.pin.0  => sampler.0.pin.0 edge.0.in
@@ -22,4 +24,4 @@ setp edge.0.out-width-ns 25000
 
 loadusr -w sh runstreamer
 start
-loadusr -w halsampler -n 10
+waitusr halsampler

--- a/tests/edge/falling/test.hal
+++ b/tests/edge/falling/test.hal
@@ -1,9 +1,11 @@
 setexact_for_test_suite_only
 
+loadrt sampler cfg=bbb depth=500
+loadusr -Wn halsampler halsampler -N halsampler -n 10
+
 loadrt threads name1=fast period1=100000
 loadrt edge
 
-loadrt sampler cfg=bbb depth=500
 loadrt streamer cfg=b depth=500
 
 net in         streamer.0.pin.0  => sampler.0.pin.0 edge.0.in
@@ -22,4 +24,6 @@ setp edge.0.out-width-ns 25000
 
 loadusr -w sh runstreamer
 start
-loadusr -w halsampler -n 10
+waitusr halsampler
+
+

--- a/tests/edge/rising-starting-high/test.hal
+++ b/tests/edge/rising-starting-high/test.hal
@@ -1,9 +1,11 @@
 setexact_for_test_suite_only
 
+loadrt sampler cfg=bbb depth=500
+loadusr -Wn halsampler halsampler -N halsampler -n 10
+
 loadrt threads name1=fast period1=100000
 loadrt edge
 
-loadrt sampler cfg=bbb depth=500
 loadrt streamer cfg=b depth=500
 
 net in         streamer.0.pin.0  => sampler.0.pin.0 edge.0.in
@@ -22,4 +24,4 @@ setp edge.0.out-width-ns 25000
 
 loadusr -w sh runstreamer
 start
-loadusr -w halsampler -n 10
+waitusr halsampler

--- a/tests/edge/rising/test.hal
+++ b/tests/edge/rising/test.hal
@@ -1,9 +1,12 @@
 setexact_for_test_suite_only
 
+
+loadrt sampler cfg=bbb depth=500
+loadusr -Wn halsampler halsampler -N halsampler -n 10
+
 loadrt threads name1=fast period1=100000
 loadrt edge
 
-loadrt sampler cfg=bbb depth=500
 loadrt streamer cfg=b depth=500
 
 net in         streamer.0.pin.0  => sampler.0.pin.0 edge.0.in
@@ -22,4 +25,5 @@ setp edge.0.out-width-ns 25000
 
 loadusr -w sh runstreamer
 start
-loadusr -w halsampler -n 10
+waitusr halsampler
+

--- a/tests/flipflop.0/test.hal
+++ b/tests/flipflop.0/test.hal
@@ -2,6 +2,7 @@ loadrt threads name1=fast period1=100000
 loadrt flipflop
 
 loadrt sampler depth=1000 cfg=b
+loadusr -Wn halsampler halsampler -N halsampler -n 10
 loadrt streamer depth=32 cfg=bbbb
 
 
@@ -23,4 +24,4 @@ addf sampler.0 fast
 
 loadusr -w sh runstreamer
 start
-loadusr -w halsampler -n 10
+waitusr halsampler

--- a/tests/limit3.0/test.hal
+++ b/tests/limit3.0/test.hal
@@ -1,6 +1,8 @@
 setexact_for_test_suite_only
 
 loadrt sampler cfg=f depth=4096
+loadusr -Wn halsampler halsampler -N halsampler -t -n 800
+
 #loadrt limit3
 loadrt limit3
 loadrt threads name1=t period1=1000000
@@ -14,4 +16,4 @@ addf sampler.0 t
 setp limit3.0.in 500
 
 start
-loadusr -w halsampler -t -n 800
+waitusr halsampler

--- a/tests/limit3.1/test.hal
+++ b/tests/limit3.1/test.hal
@@ -1,6 +1,8 @@
 setexact_for_test_suite_only
 
 loadrt sampler cfg=f depth=4096
+loadusr -Wn halsampler halsampler -N halsampler -t -n 800
+
 loadrt limit3
 #loadrt blocks limit3=1
 loadrt threads name1=t period1=1000000
@@ -14,4 +16,4 @@ addf sampler.0 t
 setp limit3.0.in 500
 
 start
-loadusr -w halsampler -t -n 800
+waitusr halsampler

--- a/tests/limit3.2/test.hal
+++ b/tests/limit3.2/test.hal
@@ -1,6 +1,8 @@
 setexact_for_test_suite_only
 
 loadrt sampler cfg=f depth=4096
+loadusr -Wn halsampler halsampler -N halsampler -t -n 800
+
 loadrt limit3
 #loadrt blocks limit3=1
 loadrt threads name1=t period1=1000000
@@ -16,4 +18,5 @@ addf sampler.0 t
 setp limit3.0.in 500
 
 start
-loadusr -w halsampler -t -n 800
+waitusr halsampler
+

--- a/tests/multiclick/test.hal
+++ b/tests/multiclick/test.hal
@@ -3,6 +3,8 @@ loadrt threads name1=millisecond period1=1000000
 
 loadrt multiclick count=2
 loadrt sampler depth=100 cfg=bbbbbbbbbsbbbbbbbbbs
+loadusr -Wn halsampler halsampler -N halsampler -n 105
+
 loadrt streamer depth=100 cfg=bb
 
 
@@ -55,5 +57,5 @@ loadusr halstreamer input-signals
 loadusr -w sleep 0.5
 
 start
-loadusr -w halsampler -n 105
+waitusr halsampler
 

--- a/tests/mux/test.hal
+++ b/tests/mux/test.hal
@@ -3,6 +3,7 @@ loadrt threads name1=slow period1=1000000
 loadrt mux_generic config="b2b,b2f,b2s,b2u,f2b,f2f,f2s,f2u,s2b,s2f,s2s,s2u,u2b,u2f,u2s,u2u,b2b,f5f"
 loadrt streamer depth=100 cfg=bu
 loadrt sampler depth=100 cfg=bfsubfsubfsubfsubfbu
+loadusr -Wn halsampler halsampler -N halsampler -n 105
 
 addf streamer.0 slow
 addf mux-gen.00 slow
@@ -84,6 +85,6 @@ loadusr halstreamer input-signals
 loadusr -w sleep 0.5
 
 start
-loadusr -w halsampler -n 105
+waitusr halsampler
 
 

--- a/tests/near.0/test.hal
+++ b/tests/near.0/test.hal
@@ -4,6 +4,8 @@ setp near.0.scale 1.5
 setp near.1.difference 1.5
 
 loadrt sampler depth=1000 cfg=ffbb
+loadusr -Wn halsampler halsampler -N halsampler -n 122
+
 loadrt streamer depth=256 cfg=ff
 
 net in1 streamer.0.pin.0 => near.0.in1 near.1.in1 sampler.0.pin.0
@@ -18,4 +20,5 @@ addf sampler.0 fast
 
 loadusr -w sh runstreamer
 start
-loadusr -w halsampler -n 122
+waitusr halsampler
+

--- a/tests/source.0/test.hal
+++ b/tests/source.0/test.hal
@@ -1,7 +1,10 @@
+
+loadrt sampler depth=1000 cfg=b
+loadusr -Wn halsampler halsampler -N halsampler  -n 10
+
 loadrt threads name1=fast period1=100000
 loadrt flipflop
 
-loadrt sampler depth=1000 cfg=b
 loadrt streamer depth=32 cfg=bbbb
 
 source sourced.hal
@@ -12,4 +15,4 @@ addf sampler.0 fast
 
 loadusr -w sh runstreamer
 start
-loadusr -w halsampler -n 10
+waitusr halsampler

--- a/tests/stepgen.0/test.hal
+++ b/tests/stepgen.0/test.hal
@@ -1,6 +1,8 @@
 setexact_for_test_suite_only
 
 loadrt sampler cfg=bb depth=4096
+loadusr -Wn halsampler halsampler -N halsampler -n 3500
+
 loadrt stepgen step_type=0
 loadrt threads name1=fast period1=100000
 
@@ -19,4 +21,4 @@ setp stepgen.0.enable 1
 setp stepgen.0.position-scale 32000
 
 start
-loadusr -w halsampler -n 3500
+waitusr halsampler

--- a/tests/stepgen.1/test.hal
+++ b/tests/stepgen.1/test.hal
@@ -1,6 +1,8 @@
 setexact_for_test_suite_only
 
 loadrt sampler cfg=bbs depth=4000
+loadusr -Wn halsampler halsampler -N halsampler  -n 3500
+
 loadrt stepgen step_type=2
 loadrt threads name1=fast period1=100000
 
@@ -20,4 +22,4 @@ setp stepgen.0.enable 1
 setp stepgen.0.position-scale 32000
 
 start
-loadusr -w halsampler -n 3500
+waitusr halsampler

--- a/tests/stepgen.2/test.hal
+++ b/tests/stepgen.2/test.hal
@@ -1,6 +1,8 @@
 setexact_for_test_suite_only
 
 loadrt sampler cfg=bb depth=4096
+loadusr -Wn halsampler halsampler -N halsampler -n 3500
+
 loadrt stepgen step_type=0
 loadrt threads name1=fast period1=100000
 
@@ -19,4 +21,5 @@ setp stepgen.0.enable 1
 setp stepgen.0.position-scale 32000
 
 start
-loadusr -w halsampler -n 3500
+waitusr halsampler
+

--- a/tests/threads.0/test.hal
+++ b/tests/threads.0/test.hal
@@ -1,8 +1,9 @@
 setexact_for_test_suite_only
+loadrt sampler cfg=u depth=4096
+loadusr -Wn halsampler halsampler -N halsampler -n 3500
 
 loadrt threads name1=fast period1=100000 name2=slow period2=1000000
 loadrt threadtest count=1
-loadrt sampler cfg=u depth=4096
 
 net count <= threadtest.0.count
 net count => sampler.0.pin.0
@@ -13,4 +14,4 @@ addf sampler.0 fast
 addf threadtest.0.reset slow
 
 start
-loadusr -w halsampler -n 3500
+waitusr halsampler

--- a/tests/timedelay.0/test.hal
+++ b/tests/timedelay.0/test.hal
@@ -1,4 +1,6 @@
 loadrt sampler cfg=bb depth=100
+loadusr -Wn halsampler halsampler -N halsampler -t -n 64
+
 loadrt timedelay
 loadrt not
 loadrt threads name1=thread period1=1953125
@@ -17,4 +19,4 @@ addf timedelay.0 thread
 addf sampler.0 thread
 
 start
-loadusr -w halsampler -t -n 64
+waitusr halsampler

--- a/tests/trajectory-planner/circular-arcs/tp_data_export.hal
+++ b/tests/trajectory-planner/circular-arcs/tp_data_export.hal
@@ -1,5 +1,7 @@
 loadrt sampler depth=1000 cfg=fffffffffb
 
+loadusr -Wn halsampler halsampler -N halsampler -c 0 constraints.log
+
 net Xacc => sampler.0.pin.0
 net Yacc => sampler.0.pin.1
 net Zacc => sampler.0.pin.2
@@ -14,5 +16,3 @@ net constraints-ok => sampler.0.pin.9
 
 net coord_mode <= motion.coord-mode => sampler.0.enable
 addf sampler.0 servo-thread
-
-loadusr halsampler -c 0 constraints.log


### PR DESCRIPTION
see also: https://github.com/machinekit/machinekit/issues/202

this fixes a wide range of runtests errors, from 'overrun detected, re-running tests' to runtests with truncated output files from halsampler

Signed-off-by: Michael Haberler git@mah.priv.at
