### PR TITLE
Use `xeno_math` by default for RTAI math

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -200,7 +200,7 @@ AC_DEFUN([_cfg_flavor_params],
 [FLAVOR_DOES_IO|FLAVOR_KERNEL_BUILD],[xeno_math]],
 	 [[rtai-kernel],[4],[kbuild],[rtai-kernel],[.ko],[.so],dnl
 [FLAVOR_DOES_IO|FLAVOR_KERNEL_BUILD],dnl
-[rtai_hal rtai_sched rtai_math]]])
+[rtai_hal rtai_sched xeno_math]]])
 
 
 dnl #--------------------------------------------------------#

--- a/src/rtapi/xeno_math/Submakefile
+++ b/src/rtapi/xeno_math/Submakefile
@@ -1,4 +1,4 @@
-ifeq ($(BUILD_SYS)-$(threads),kbuild-xenomai-kernel)
+ifeq ($(BUILD_SYS),kbuild)
 
 ccflags-y := 	$(KERNEL_MATH_CFLAGS) \
 	-D_IEEE_LIBM \


### PR DESCRIPTION
Reported by Mick/Schooner/@ArcEye

The ShabbyX/RTAI 4.0 `rtai_math` kmodule misses the `ceil` and `floor`
functions.  I haven't investigated to see where they went.

Michael Haberler added `ceil` in commit 9898998 and `floor` has been there
since the `xeno_math` library initial commit.

This patch builds the `xeno_math` kmodule for all kernel thread
flavors, including RTAI, and configures runtime to load `xeno_math`
instead of `rtai_math` for `rtai-kernel` threads.
