### PR TITLE
Fix printk() header inclusion for older kernels

### DIFF
--- a/src/rtapi/xeno_math/k_standard.c
+++ b/src/rtapi/xeno_math/k_standard.c
@@ -17,7 +17,7 @@ static char rcsid[] = "$NetBSD: k_standard.c,v 1.6 1995/05/10 20:46:35 jtc Exp $
 #include "rtapi_math.h"
 #include "mathP.h"
 #include <linux/errno.h>		/* FIXME */
-#include <linux/printk.h>		/* FIXME */
+#include <linux/kernel.h>		/* FIXME */
 
 extern int libm_errno;
 


### PR DESCRIPTION
This was tickled when `xeno_math` became the default math kmodule for
RTAI in #235, and Janos Bujtar tried building against the older kernel
packages distributed by the LinuxCNC project ([reported here](https://groups.google.com/forum/#!topic/machinekit/PXjZfJqOfPg)).

`printk()` was moved from `linux/kernel.h` to `linux/printk.h` in
[late 2010](https://lkml.org/lkml/2010/11/9/606).  However, `linux/kernel.h` includes `linux/printk.h`.

Alternatively, `printk()` could be defined by including
`linux/module.h`.  I don't know which is better.
