### PR TITLE
Fix startup failure due to unknown count=1 parameter to pepper component

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/lineardelta.hal
@@ -29,7 +29,7 @@ loadrt hal_bb_gpio output_pins=107,126,224,226 input_pins=108,109,110,114,117,11
 loadrt [PRUCONF](DRIVER) prucode=$(LINUXCNC_HOME)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
 loadrt pid num_chan=2
 loadrt limit1 count=2
-loadrt pepper count=1
+loadrt pepper
 
 # Python user-mode HAL module to read ADC value and generate a thermostat output for PWM
 # t = Thermistor table (only epcos_B57560G1104 or 1 supported for now)


### PR DESCRIPTION
This bug was reported and solved by Dejay. It's code leakage from the development tree.
