### PR TITLE
Re-add LinuxCNC_Developer_Manual

### DIFF
--- a/debian/extras/usr/share/applications/linuxcnc-developer.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-developer.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Version=
+Encoding=UTF-8
+Name=LinuxCNC Developer Manual
+Type=Application
+Exec=/usr/bin/see /usr/share/doc/linuxcnc/LinuxCNC_Developer_Manual.pdf
+Icon=gnome-help
+X-GNOME-DocPath=
+Terminal=false
+Comment=Advanced configuration hints
+StartupNotify=false
+Categories=X-CNC;
+GenericName[en_US]=
+Comment[en_US]=Developer Manual

--- a/debian/machinekit-doc-en.install
+++ b/debian/machinekit-doc-en.install
@@ -2,7 +2,9 @@ usr/share/doc/linuxcnc/LinuxCNC_HAL_Manual.pdf
 usr/share/doc/linuxcnc/LinuxCNC_User_Manual.pdf
 usr/share/doc/linuxcnc/LinuxCNC_Integrator_Manual.pdf
 usr/share/doc/linuxcnc/LinuxCNC_Getting_Started.pdf
+usr/share/doc/linuxcnc/LinuxCNC_Developer_Manual.pdf
 usr/share/applications/linuxcnc-gettingstarted.desktop
 usr/share/applications/linuxcnc-halmanual.desktop
 usr/share/applications/linuxcnc-integratormanual.desktop
 usr/share/applications/linuxcnc-usermanual.desktop
+usr/share/applications/linuxcnc-developer.desktop

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -137,15 +137,13 @@ install: build
 	mkdir -p debian/tmp/usr/lib debian/tmp/usr/include/linuxcnc
 	cp lib/*.a debian/tmp/usr/lib
 ifdef BUILDDOCS
-	mkdir -p debian/tmp/usr/share/doc/linuxcnc-dev
-	mv debian/tmp/usr/share/doc/linuxcnc/LinuxCNC_Developer_Manual.pdf \
-		debian/tmp/usr/share/doc/linuxcnc-dev/
 	rm debian/tmp/usr/share/doc/linuxcnc/LinuxCNC_Manual_Pages.pdf
 else
-	rm debian/tmp/usr/share/applications/linuxcnc-user*
-	rm debian/tmp/usr/share/applications/linuxcnc-hal*
-	rm debian/tmp/usr/share/applications/linuxcnc-inte*
-	rm debian/tmp/usr/share/applications/linuxcnc-get*
+	rm debian/tmp/usr/share/applications/linuxcnc-usermanual*.desktop
+	rm debian/tmp/usr/share/applications/linuxcnc-halmanual*.desktop
+	rm debian/tmp/usr/share/applications/linuxcnc-integratormanual*.desktop
+	rm debian/tmp/usr/share/applications/linuxcnc-gettingstarted*.desktop
+	rm debian/tmp/usr/share/applications/linuxcnc-developer*.desktop
 endif
 
 	cp docs/html/gcode*.html debian/tmp/usr/share/doc/linuxcnc/


### PR DESCRIPTION
**MAINTAINERS** please don't merge until the Buildbot passes.  I'll update this PR when it passes.

This was removed from the -dev package since it's an arch-independent
build artifact but -dev is an arch-dependent package.

Adding back to the -doc package.
