### PR TITLE
Fix wildcards in `debian/rules.in`

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -132,7 +132,7 @@ install: build
 	dh_installdirs
 # start the install
 	mkdir -p debian/tmp
-	-(cd debian/extras && cp -a * ../tmp)
+	(cd debian/extras && cp -a * ../tmp)
 	(cd src; export DESTDIR=`pwd`/../debian/tmp; $(MAKE) $@)
 	mkdir -p debian/tmp/usr/lib debian/tmp/usr/include/linuxcnc
 	cp lib/*.a debian/tmp/usr/lib
@@ -148,8 +148,7 @@ endif
 
 	cp docs/html/gcode*.html debian/tmp/usr/share/doc/linuxcnc/
 	rm -rf debian/tmp/usr/share/doc/linuxcnc/html
-	-rm debian/machinekit-{rtai,xenomai}-kernel*.install
-	-rm -f debian/tmp/usr/share/linuxcnc/examples/sample-configs/*/*position*.txt
+	rm -f debian/tmp/usr/share/linuxcnc/examples/sample-configs/*/*position*.txt
 	# update emcweb.hal
 	sed 's/#NC_FILES_DIR/NC_FILES_DIR/' -i debian/tmp/usr/share/linuxcnc/examples/sample-configs/sim/emcweb.ini
 


### PR DESCRIPTION
**MAINTAINERS** please be sure [Buildbot](http://buildbot.dovetail-automata.com/grid) package builds succeed before merging.

GNU Make's built-in shell is old-school Bourne shell, and doesn't
recognize the bash `foo-{bar,baz}`-style wildcards.  (This simple fact
seems to be a steep learning curve for YT.)

Also, use `rm -f` and remove the initial `-` from statements: `rm -f`
doesn't fail if the file doesn't exist, but does fail if the file
exists but can't be removed.  The latter case is a true error that
shouldn't be suppressed.
