### PR TITLE
`debian/machinekit.postinst`:  don't modify `/etc/security/limits.conf`

### DIFF
--- a/debian/machinekit.postinst
+++ b/debian/machinekit.postinst
@@ -4,12 +4,6 @@
 
 [ -x /etc/init.d/udev ] && /etc/init.d/udev restart
 
-if [ -f /etc/security/limits.conf ]; then
-    if ! grep -q "EMC2" /etc/security/limits.conf; then
-	echo '* - memlock 20480 #EMC2' >> /etc/security/limits.conf
-    fi
-fi
-
 # setup emcweb var files
 rm -rf /var/cache/linuxcnc/www
 mkdir -p /var/cache/linuxcnc/www/data


### PR DESCRIPTION
This is correctly done in `/etc/security/limits.d/machinekit.conf`
