### PR TITLE
Fix for issue #274

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -13,7 +13,7 @@ Standards-Version: 2.1.0
 
 Package: machinekit-dev
 Architecture: any
-Depends: g++, ${tcl-tk-dev},
+Depends: make, g++, ${tcl-tk-dev},
     python (>= 2.6), python (<< 2.8),
     ${python:Depends}, ${misc:Depends},
     machinekit (= ${binary:Version}),

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -185,6 +185,13 @@ binary-arch: build install debian/substvars
 	dh_pysupport
 	dh_makeshlibs
 	dh_installdeb
+
+	# delete files that should be in machinekit-dev package
+	rm -f debian/machinekit/usr/bin/comp
+	rm -f debian/machinekit/usr/share/man/man1/comp.1.gz
+	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.modinc
+	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.inc
+
 	cat debian/machinekit/DEBIAN/shlibs debian/shlibs.pre > \
 	    debian/shlibs.local
 	dh_shlibdeps -l debian/machinekit/usr/lib


### PR DESCRIPTION
debian/control.in:
    make is needed by comp
debian/rules.in:
    removed files that should be in machinekit-deb package
