### PR TITLE
webtalk: make initialisation more robust

### DIFF
--- a/src/machinetalk/webtalk/Submakefile
+++ b/src/machinetalk/webtalk/Submakefile
@@ -16,6 +16,7 @@ WEBTALK_SRCS :=  $(addprefix $(WEBTALK_DIR)/, \
 	webtalk_jsonpolicy.cc	\
 	webtalk_plugin.cc	\
 	webtalk_echo.cc 	\
+	webtalk_initproto.cc 	\
 	webtalk_main.cc 	\
 	cencode.c 		\
 	cdecode.c )

--- a/src/machinetalk/webtalk/webtalk.hh
+++ b/src/machinetalk/webtalk/webtalk.hh
@@ -224,6 +224,10 @@ int wt_zeroconf_withdraw(wtself_t *self);
 void echo_thread(void *args, zctx_t *ctx, void *pipe);
 
 // webtalk_proxy.cc:
+int callback_http(struct libwebsocket_context *context,
+		  struct libwebsocket *wsi,
+		  enum libwebsocket_callback_reasons reason, void *user,
+		  void *in, size_t len);
 int wt_proxy_new(wtself_t *self);
 int wt_proxy_add_policy(wtself_t *self, const char *name, zwscvt_cb cb);
 int service_timer_callback(zloop_t *loop, int  timer_id, void *context);
@@ -239,3 +243,7 @@ int default_policy(wtself_t *self, zws_session_t *wss, zwscb_type type);
 
 // webtalk_plugin.cc:
 int wt_add_plugin(wtself_t *self, const char *sopath);
+
+// webtalk_initproto.cc
+extern struct libwebsocket_protocols *protocols;
+void init_protocols(void);

--- a/src/machinetalk/webtalk/webtalk_initproto.cc
+++ b/src/machinetalk/webtalk/webtalk_initproto.cc
@@ -1,0 +1,64 @@
+// initialize libwebsockets_protocols structs
+
+#include "webtalk.hh"
+
+
+struct libwebsocket_protocols *protocols;
+
+#ifdef EXPERIMENTAL_ZWS_SUPPORT
+#define NPROTOS 6
+#else
+#define NPROTOS 3
+#endif
+
+void init_protocols(void)
+{
+    // size must be number of protos + 1 - libwebsockets requires a zero delimiter struct
+    struct libwebsocket_protocols *p = protocols = 
+	(struct libwebsocket_protocols *) calloc(NPROTOS,
+						 sizeof (struct libwebsocket_protocols));
+    assert(p != 0);
+
+    //  first protocol must always be HTTP handler
+    p->name = "http";
+    p->callback = callback_http;
+    p->per_session_data_size = sizeof(zws_session_t);
+    p->id = PROTO_FRAMING_NONE|PROTO_ENCODING_NONE;
+    p++;
+
+    // machinekit specific framing
+    p->name = "machinekit1.0";
+    p->callback = callback_http;
+    p->per_session_data_size = sizeof(zws_session_t);
+    p->id = PROTO_FRAMING_MACHINEKIT|PROTO_ENCODING_JSON|PROTO_VERSION(0);
+    p++;
+
+
+#ifdef EXPERIMENTAL_ZWS_SUPPORT
+    // experimentally enable "ZWS1.0" as legit ws protocol
+    // https://github.com/somdoron/rfc/blob/master/spec_39.txt
+    p->name = "ZWS1.0";
+    p->callback = callback_http;
+    p->per_session_data_size = sizeof(zws_session_t);
+    p->id = PROTO_FRAMING_ZWS|PROTO_ENCODING_PROTOBUF|PROTO_VERSION(0);
+    p++;
+
+    // mhaberler's protobuf-based framing method
+    // assumes https://github.com/dcodeIO/ProtoBuf.js or manual decoding
+    // client-side
+    p->name = "ZWS1.0-proto";
+    p->callback = callback_http;
+    p->per_session_data_size = sizeof(zws_session_t);
+    p->id = PROTO_FRAMING_ZWSPROTO|PROTO_ENCODING_PROTOBUF|PROTO_VERSION(0);
+    p++;
+
+
+    // wrapped in base64 - binary-safe version of above for text-only ws transports
+    p->name = "ZWS1.0-protob-ase64";
+    p->callback = callback_http;
+    p->per_session_data_size = sizeof(zws_session_t);
+    p->id = PROTO_WRAP_BASE64|PROTO_FRAMING_ZWSPROTO|PROTO_ENCODING_PROTOBUF|PROTO_VERSION(0);
+    p++;
+#endif
+
+};

--- a/src/machinetalk/webtalk/webtalk_main.cc
+++ b/src/machinetalk/webtalk/webtalk_main.cc
@@ -436,6 +436,7 @@ int main (int argc, char *argv[])
     retval = zmq_init(&self);
     if (retval) exit(retval);
 
+    init_protocols();
     retval = wt_proxy_new(&self);
     if (retval) exit(retval);
 


### PR DESCRIPTION
dont rely on the number of fields in struct libwebsockets_protocols,
which changes with the libwebsockets API on and off
