### PR TITLE
gmoccapy_1_2_2 - does now support also matchbox-keyboard

### DIFF
--- a/lib/python/gladevcp/tooledit_widget.py
+++ b/lib/python/gladevcp/tooledit_widget.py
@@ -153,7 +153,7 @@ class ToolEdit(gtk.VBox):
         # clear the current liststore, search the tool file, and add each tool
         if self.toolfile == None:return
         self.model.clear()
-        print "toolfile:",self.toolfile
+        # print "toolfile:",self.toolfile
         if not os.path.exists(self.toolfile):
             print "Toolfile does not exist"
             return

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -5754,7 +5754,6 @@ actions</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="has_default">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">enter manual mode to jog axis by hand or touch off</property>
                     <property name="use_action_appearance">False</property>

--- a/src/emc/usr_intf/gmoccapy/release_notes.txt
+++ b/src/emc/usr_intf/gmoccapy/release_notes.txt
@@ -1,3 +1,16 @@
+ver. 1.2.2
+- changed the way the window size and position is 
+  handled, as bevore the default values did apear 
+  several times in the code
+- If no virtual keyboard could be initialized, we 
+  disable now the coresponding part on the settings
+  page and the related button. Check will be done
+  for <onboard> and <matchbox-keyboard>
+- starting gmoccapy did throw an error to the terminal
+  that a widget could not get default. Finally I found 
+  the reason, the glade file did contain a property
+  "has_default" and that is not allowed by builder.
+
 ver. 1.2.1
 - due to the behavior of XFCE of the new hybrid.iso I 
   had to change the width settings of several button


### PR DESCRIPTION
ver. 1.2.2
- changed the way the window size and position is
  handled, as before the default values did appear
  several times in the code
- If no virtual keyboard could be initialized, we
  disable now the corresponding part on the settings
  page and the related button. Check will be done
  for onboard and matchbox-keyboard
- starting gmoccapy did throw an error to the terminal
  that a widget could not get default. Finally I found
  the reason, the glade file did contain a property
  "has_default" and that is not allowed by builder.
