### PR TITLE
hal/cython: depend .c on .pyx/.pxd only when cython is installed.

### DIFF
--- a/src/hal/cython/Submakefile
+++ b/src/hal/cython/Submakefile
@@ -20,9 +20,10 @@ USERSRCS += $(HALSO_SRCS)
 $(call TOOBJSDEPS, $(HALSO_SRCS)) : EXTRAFLAGS=-fPIC -Ihal/utils -I.
 $(call TOOBJSDEPS, $(HALSO_CXXSRCS)) : EXTRAFLAGS=-fPIC -Ihal/utils -I.
 
+ifeq ($(HAVE_CYTHON),yes)
 # shotgun approach to dependencies: will alwas hit the target (and more).
 $(HALNGMKDIR)/hal.c: $(wildcard $(HALNGMKDIR)/*.pyx $(HALNGMKDIR)/*.pxd)
-
+endif
 
 TARGETS += ../lib/python/machinekit/hal.so
 ../lib/python/machinekit/hal.so:	../lib/liblinuxcnchal.so.0 \
@@ -36,7 +37,9 @@ TARGETS += ../lib/python/machinekit/hal.so
 RTAPISO_CSRCS := $(addprefix $(HALNGMKDIR)/, \
 	rtapi.c)
 
+ifeq ($(HAVE_CYTHON),yes)
 $(RTAPISO_CSRCS): $(wildcard $(HALNGMKDIR)/*.pyx $(HALNGMKDIR)/*.pxd)
+endif
 
 RTAPISO_CXXSRCS := \
 	hal/utils/halcmd_rtapiapp.cc
@@ -59,11 +62,12 @@ TARGETS += ../lib/python/machinekit/rtapi.so
 	$(CC) -g $(LDFLAGS) -shared -o $@ $^
 
 
-#$(HALNGMKDIR)/compat.c: $(wildcard $(HALNGMKDIR)/*.pyx $(HALNGMKDIR)/*.pxd)
-
 COMPATSO_CSRCS := $(addprefix $(HALNGMKDIR)/, \
 	compat.c)
+
+ifeq ($(HAVE_CYTHON),yes)
 $(COMPATSO_CSRCS): $(wildcard $(HALNGMKDIR)/*.pyx $(HALNGMKDIR)/*.pxd)
+endif
 
 USERSRCS += $(COMPATSO_CSRCS)
 $(call TOOBJSDEPS, $(COMPATSO_CSRCS)) : EXTRAFLAGS=-fPIC
@@ -89,10 +93,7 @@ TARGETS += ../lib/python/machinekit/shmcommon.so
 	@mkdir -p $(dir $@)
 	$(CC) -g  -shared -o $@ $^ $(LDFLAGS) -lrt
 
-$(HALNGDIR)/machinekit/%.c: $(addprefix $(HALNGDIR)/machinekit/, %.pyx %.pxd)
 ifeq ($(HAVE_CYTHON),yes)
+$(HALNGDIR)/machinekit/%.c: $(addprefix $(HALNGDIR)/machinekit/, %.pyx %.pxd)
 	$(CYTHON) -o $@ $<
-else
-	$(ECHO) cannot re-cython - you need to install cython minimum version 0.19
-	@exit 1
 endif


### PR DESCRIPTION
Duh. Thanks to Charles!
