### PR TITLE
Revert "add a symbolic link to help machinekit/BBB find Chips icon (#305...

### DIFF
--- a/debian/extras/usr/share/icons/linuxcncicon.png
+++ b/debian/extras/usr/share/icons/linuxcncicon.png
@@ -1,1 +1,0 @@
-../linuxcnc/linuxcncicon.png


### PR DESCRIPTION
Reverts machinekit/machinekit#310

Didn't build. Log here:

http://buildbot.dovetail-automata.com/builders/d7-32-pkg/builds/378/steps/chroot-build-binary-package/logs/stdio

```
dh_install: usr/share/icons/linuxcncicon.png exists in debian/tmp but is not installed to anywhere
dh_install: missing files, aborting
make: *** [install] Error 2
dpkg-buildpackage: error: fakeroot debian/rules binary-arch gave error exit status 2
```
