### PR TITLE
Fix TCL/TK build deps in packaging

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -7,6 +7,16 @@
 # List of supported kernel arches for kthreads
 KTHREAD_ARCHES="i386 amd64"
 
+# Distro info
+#
+# This should run on non-Debian distros; lsb_release is only used for
+# TCL/TK version detection, which can be passed in through the '-t
+# VERSION' switch
+if test -x /usr/bin/lsb_release; then
+    DISTRO_ID=$(lsb_release -is)  # Debian or Ubuntu 
+    DISTRO_RELEASE=$(lsb_release -rs)   # 8.1, 14.04, etc.
+fi
+
 # Work out of the debian/ directory
 cd "$(dirname $0)"
 
@@ -165,6 +175,22 @@ do_docs() {
     echo "debian/rules:  enabled doc builds" >&2
 }
 
+do_tcl_tk_version() {
+    TCL_TK_VER="$1"
+    if test -z "$TCL_TK_VER"; then
+        # No -t option specified; to ensure a reproducible package,
+        # use the latest version from the distro
+	TCL_TK_VER=8.6
+	case "$DISTRO_ID" in
+	    Debian)  test "${DISTRO_RELEASE/.*/}" -lt 8 && TCL_TK_VER=8.5 ;;
+	    Ubuntu)  test "${DISTRO_RELEASE/.*/}" -lt 14 && TCL_TK_VER=8.5 ;;
+	    *)  usage "Unknown distro '${DISTRO_ID}'" ;;
+	esac
+    fi
+    TCL_TK_BUILD_DEPS="tcl${TCL_TK_VER}-dev, tk${TCL_TK_VER}-dev"
+    TCL_TK_DEPS="tcl${TCL_TK_VER}, tk${TCL_TK_VER}"
+    echo "debian/control:  Set tcl/tk build deps to version $TCL_TK_VER" >&2
+}
 
 usage() {
     {
@@ -176,6 +202,7 @@ usage() {
 	echo "   -x		build Xenomai threads"
 	echo "   -X <kver>	build Xenomai-kernel threads ***"
 	echo "   -R <kver>	build RTAI-kernel threads ***"
+	echo "   -t <tclver>	set tcl/tk version"
 	echo "   -d		enable documentation build"
 	echo "      *** Argument may be repeated for multiple kernels"
     } >&2
@@ -206,7 +233,7 @@ cp rules.in rules; chmod +x rules
 echo "debian/rules:  copied base template" >&2
 
 # read command line options
-while getopts dprxR:X:?h ARG; do
+while getopts dprxR:X:t:?h ARG; do
     case $ARG in
 	d) do_docs ;;
 	p) do_posix ;;
@@ -214,17 +241,24 @@ while getopts dprxR:X:?h ARG; do
 	x) do_xenomai ;;
 	R) do_rtai_kernel "$OPTARG" ;;
 	X) do_xenomai_kernel "$OPTARG" ;;
+	t) TCL_TK_VER="$OPTARG" ;;
 	?|h) usage ;;
 	*) usage "Unknown arg: '-$ARG'" ;;
     esac
 done
+
+# Determine tcl/tk version
+do_tcl_tk_version "$TCL_TK_VER"
 
 # Set kthreads headers
 rules_set_kthreads_headers xenomai-kernel $XENOMAI_KERNEL_HEADERS
 rules_set_kthreads_headers rtai-kernel $RTAI_KERNEL_HEADERS
 
 # Set control Build-Depends:
-sed -i control -e "s/@BUILD_DEPS@/${BUILD_DEPS}/"
+sed -i control \
+    -e "s/@BUILD_DEPS@/${BUILD_DEPS}/" \
+    -e "s/@TCL_TK_BUILD_DEPS@/${TCL_TK_BUILD_DEPS}/" \
+    -e "s/@TCL_TK_DEPS@/${TCL_TK_DEPS}/"
 echo "debian/control:  add final Build-Depends: list" >&2
 
 # Warn if no flavor configured

--- a/debian/control.in
+++ b/debian/control.in
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 6),
     libglib2.0-dev, libglu1-mesa-dev, libgtk2.0-dev, libmodbus-dev (>= 3.0),
     libncurses-dev, libreadline-dev, libusb-1.0-0-dev, libxmu-dev,
     libxmu-headers, python, python-dev, python-support, pkg-config, psmisc,
-    python-tk, tcl8.5-dev, tk8.5-dev, libxaw7-dev, libboost-serialization-dev,
+    python-tk, libxaw7-dev, libboost-serialization-dev,
     libsodium-dev (>= 0.5.0), libzmq4-dev (>= 4.0.4),
     libczmq-dev (>= 2.2.0), libjansson-dev (>= 2.5), libwebsockets-dev (>= 2.2),
     python-zmq (>= 14.3), procps, kmod,
@@ -16,12 +16,12 @@ Build-Depends: debhelper (>= 6),
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
     python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
     python-avahi, python-netifaces,python-simplejson,libtk-img,
-    libboost-thread-dev, @BUILD_DEPS@
+    libboost-thread-dev, @BUILD_DEPS@ @TCL_TK_BUILD_DEPS@
 Standards-Version: 2.1.0
 
 Package: machinekit-dev
 Architecture: any
-Depends: make, g++, ${tcl-tk-dev},
+Depends: make, g++, @TCL_TK_BUILD_DEPS@,
     python (>= 2.6), python (<< 2.8),
     ${python:Depends}, ${misc:Depends},
     machinekit (= ${binary:Version}),
@@ -40,7 +40,7 @@ Breaks: linuxcnc
 Replaces: linuxcnc
 Architecture: any
 Suggests: machinekit-doc-en | machinekit-doc, 
-Depends: ${shlibs:Depends}, machinekit-rt-threads, ${tcl-tk},
+Depends: ${shlibs:Depends}, machinekit-rt-threads, @TCL_TK_DEPS@,
     bwidget (>= 1.7), libtk-img (>=1.13),
     python (>= 2.6), python (<< 2.8),
     ${python:Depends}, ${misc:Depends},


### PR DESCRIPTION
TCL/TK versions are bumped to 8.6 in Trusty, although 8.5 also exists.

Make packaging always insist on the latest version depending on the
distro and release to enforce reproducible packaging.
