### PR TITLE
fix for #317

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -16,7 +16,7 @@ Build-Depends: debhelper (>= 6),
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
     python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
     python-avahi, python-netifaces,python-simplejson,libtk-img,
-    libboost-thread-dev, @BUILD_DEPS@ @TCL_TK_BUILD_DEPS@
+    libboost-thread-dev, python-pyftpdlib, @BUILD_DEPS@ @TCL_TK_BUILD_DEPS@
 Standards-Version: 2.1.0
 
 Package: machinekit-dev


### PR DESCRIPTION
debian/control.in: added python-pyftpdlib build dependency
