### PR TITLE
Debian packaging dependency rework

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -6,8 +6,8 @@ Build-Depends: debhelper (>= 6),
     autoconf (>= 2.63), bwidget, libboost-python-dev, libgl1-mesa-dev,
     libglib2.0-dev, libglu1-mesa-dev, libgtk2.0-dev, libmodbus-dev (>= 3.0),
     libncurses-dev, libreadline-dev, libusb-1.0-0-dev, libxmu-dev,
-    libxmu-headers, python, python-dev, python-support, pkg-config, psmisc,
-    python-tk, libxaw7-dev, libboost-serialization-dev,
+    libxmu-headers, python (>= 2.6.6-3~), python-dev (>= 2.6.6-3~), dh-python,
+    pkg-config, psmisc, python-tk, libxaw7-dev, libboost-serialization-dev,
     libsodium-dev (>= 0.5.0), libzmq4-dev (>= 4.0.4),
     libczmq-dev (>= 2.2.0), libjansson-dev (>= 2.5), libwebsockets-dev (>= 2.2),
     python-zmq (>= 14.3), procps, kmod,
@@ -22,8 +22,7 @@ Standards-Version: 2.1.0
 Package: machinekit-dev
 Architecture: any
 Depends: make, g++, @TCL_TK_BUILD_DEPS@,
-    python (>= 2.6), python (<< 2.8),
-    ${python:Depends}, ${misc:Depends},
+    ${misc:Depends}, ${shlibs:Depends},
     machinekit (= ${binary:Version}),
     yapps2-runtime
 Section: libs
@@ -42,17 +41,12 @@ Architecture: any
 Suggests: machinekit-doc-en | machinekit-doc, 
 Depends: ${shlibs:Depends}, machinekit-rt-threads, @TCL_TK_DEPS@,
     bwidget (>= 1.7), libtk-img (>=1.13),
-    python (>= 2.6), python (<< 2.8),
+    python (= ${python:Versions}),
     ${python:Depends}, ${misc:Depends},
-    python${python-version}-tk,
-    python${python-version}-gnome2 | python-gnome2,
-    python${python-version}-glade2 | python-glade2,
-    python${python-version}-numpy | python-numpy,
-    python${python-version}-imaging,
-    python${python-version}-imaging-tk | python-imaging-tk,
-    python-gtksourceview2,
-    python-vte,
-    python-xlib, python-gtkglext1, python-configobj,
+    python-tk, python-imaging, python-imaging-tk,
+    python-gnome2, python-glade2,
+    python-numpy, python-gtksourceview2,
+    python-vte, python-xlib, python-gtkglext1, python-configobj,
     python-zmq, python-protobuf, python-gst0.10,
     tclreadline, bc, procps, psmisc, module-init-tools | kmod
 Description: PC based motion controller for real-time Linux

--- a/debian/control.rt-preempt.in
+++ b/debian/control.rt-preempt.in
@@ -2,7 +2,10 @@
 Package: machinekit-rt-preempt
 Architecture: any
 Depends: machinekit (= ${binary:Version}), ${shlibs:Depends},
-	linux-image-rt-${preempt-rt-ext}
+# These Debian-style RT_PREEMPT package names are restricted by
+# architecture; ARM arch SOCs are all incompatible, so this can't be
+# easily done for ARM.
+ linux-image-rt.x86-686-pae [i386], linux-image-rt.x86-amd64 [amd64]
 Provides:  machinekit-rt-threads
 Suggests: hostmot2-firmware-all [!armhf]
 Enhances: machinekit

--- a/debian/control.rtai-kernel.in
+++ b/debian/control.rtai-kernel.in
@@ -2,7 +2,7 @@
 Package: machinekit-rtai-kernel-@KVER@
 Architecture: @ARCH@
 Depends: machinekit (= ${binary:Version}), ${shlibs:Depends},
-	linux-image-@KVER@, rtai-modules-@KVER@
+	linux-image-@KVER@
 Provides:  machinekit-rt-threads, machinekit-rtai-kernel
 Suggests: hostmot2-firmware-all [!armhf]
 Enhances: machinekit

--- a/debian/control.xenomai.in
+++ b/debian/control.xenomai.in
@@ -2,7 +2,11 @@
 Package: machinekit-xenomai
 Architecture: any
 Depends: machinekit (= ${binary:Version}), ${shlibs:Depends},
-	libxenomai1, xenomai-runtime
+ xenomai-runtime,
+# These Debian-style RT_PREEMPT package names are restricted by
+# architecture; ARM arch SOCs are all incompatible, so this can't be
+# easily done for ARM.
+ linux-image-xenomai.x86-686-pae [i386], linux-image-xenomai.x86-amd64 [amd64]
 Provides:  machinekit-rt-threads
 Recommends: hostmot2-firmware-all [!armhf]
 Enhances: machinekit

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -17,6 +17,15 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+# Parallel make jobs
+ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
+    NUMJOBS = $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
+    MAKEFLAGS += -j$(NUMJOBS)
+endif
+
+# Host arch used in computing package names
+DEB_HOST_ARCH := $(shell dpkg-architecture -qDEB_HOST_ARCH)
+
 # Enable packaging of the PDF docs
 #BUILDDOCS = --enable-build-documentation=pdf
 
@@ -36,31 +45,6 @@ THREADS_RTAI_KERNEL = --without-rtai-kernel
 #HEADERS_XENOMAI_KERNEL_amd64 = --with-xenomai-kernel-sources=""
 #HEADERS_RTAI_KERNEL_amd64 = --with-rtai-kernel-sources=""
 #HEADERS_RTAI_KERNEL_i386 = --with-rtai-kernel-sources=""
-
-#
-# debian/substvars contains variable definitions used to fill in
-# debian/control file variables.
-#
-# The file is filled-in by the the variables here.
-DEB_HOST_ARCH := $(shell dpkg-architecture -qDEB_HOST_ARCH)
-
-PYTHON_VERSION := $(shell python -c \
-	'import sys; print "%d.%d" % sys.version_info[:2]')
-
-ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
-    NUMJOBS = $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
-    MAKEFLAGS += -j$(NUMJOBS)
-endif
-
-debian/substvars: debian/control
-	> debian/substvars
-	echo "python-version=$(PYTHON_VERSION)" >> debian/substvars
-# PREEMPT_RT kernels don't have easily derivable names
-ifeq ($(DEB_HOST_ARCH),amd64)
-	echo "preempt-rt-ext=amd64" >> debian/substvars
-else ifeq ($(DEB_HOST_ARCH),i386)
-	echo "preempt-rt-ext=686-pae" >> debian/substvars
-endif
 
 
 debian/control: debian/configure
@@ -101,7 +85,7 @@ ifdef BUILDDOCS
 endif
 	touch build-stamp
 
-clean: debian/control debian/substvars
+clean: debian/control
 	dh_testdir
 	dh_testroot
 	rm -f build-stamp
@@ -168,7 +152,7 @@ binary-indep: build install
 # We have nothing to do by default.
 
 # Build architecture-dependent files here.
-binary-arch: build install debian/substvars
+binary-arch: build install
 	dh_testdir
 	dh_testroot
 	dh_installchangelogs
@@ -181,7 +165,7 @@ binary-arch: build install debian/substvars
 	dh_compress -X.pdf -X.txt -X.hal -X.ini -X.clp -X.var -X.nml \
 	    -X.tbl -X.xml -Xsample-configs
 	dh_fixperms -X/linuxcnc_module_helper -X/rtapi_app_
-	dh_pysupport
+	dh_python2 --ignore-shebangs --no-guessing-versions
 	dh_makeshlibs
 	dh_installdeb
 
@@ -194,7 +178,7 @@ binary-arch: build install debian/substvars
 	cat debian/machinekit/DEBIAN/shlibs debian/shlibs.pre > \
 	    debian/shlibs.local
 	dh_shlibdeps -l debian/machinekit/usr/lib
-	dh_gencontrol -- -Tdebian/substvars
+	dh_gencontrol
 	dh_md5sums
 	dh_builddeb
 


### PR DESCRIPTION
These commits rework (and simplify) Debian packaging dependencies again.  Problems addressed:
- Automatic install of kernel package dependencies from flavor module packages
- Fix substvars `unused/unknown substitution variable` warnings
- Clean up python deps
- Convert `preempt-rt` module package kernel deps from `substvars`
- Remove `debian/substvars`
- Migrate from deprecated `python-support` to `dh_python2`
See commit log for lots of detail.
