### PR TITLE
`make install` installs `../include/userpci`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -168,6 +168,8 @@ MAKEFLAGS += w
 # as a "substitute at assignment time" variable
 TARGETS :=
 PYTARGETS :=
+# Add to this list directories to be created during 'make install'
+INSTALL_DIRS :=
 
 # Submakefiles from each of these directories will be included if they exist
 SUBDIRS := \
@@ -796,7 +798,8 @@ install-dirs:
 		$(DESTDIR)$(sysconfdir)/rsyslog.d \
 		$(DESTDIR)$(sysconfdir)/security/limits.d \
 		$(DESTDIR)$(sysconfdir)/udev/rules.d \
-		$(DESTDIR)$(sampleconfsdir)
+		$(DESTDIR)$(sampleconfsdir) \
+		$(addprefix $(DESTDIR), $(INSTALL_DIRS))
 ifeq ($(BUILD_EMCWEB),yes)
 	$(DIR)	$(DESTDIR)$(datadir)/linuxcnc/doc-root/css/images \
 		$(DESTDIR)$(datadir)/linuxcnc/doc-root/js \

--- a/src/rtapi/userpci/Submakefile
+++ b/src/rtapi/userpci/Submakefile
@@ -15,6 +15,7 @@ $(USERPCI_HEADERS): ../include/userpci/%.h: rtapi/userpci/%.h
 ifeq ($(USERMODE_PCI),yes)
 # These headers need to remain in the 'userpci' subdirectory
 SUBDIRECTORY_HEADERS += $(USERPCI_HEADERS)
+INSTALL_DIRS += ../include/userpci
 
 hostmot2-objs +=			  \
     rtapi/userpci/device.o		  \


### PR DESCRIPTION
Add a way from a `Submakefile` for directories to be installed during
`make install`; use it to install `../include/userpci` to fix errors:

```
  install: cannot stat ‘../include/userpci/device.h’: No such file
  or directory
  [...]
```

fixes #298
