### PR TITLE
gmoccapy_1_3_2 - updated to current status, several bug fixes

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="2.16"/>
   <!-- interface-requires gladevcp 0.0 -->
+  <requires lib="gtk+" version="2.16"/>
   <!-- interface-naming-policy project-wide -->
+  <object class="EMC_Action_Stop" id="hal_action_stop"/>
+  <object class="EMC_ToggleAction_Pause" id="hal_tgl_pause"/>
   <object class="GtkAdjustment" id="adf_probe_vel">
     <property name="upper">100</property>
     <property name="value">10</property>
@@ -71,7 +73,7 @@
     <signal name="value-changed" handler="on_adj_scale_jog_vel_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="adj_scale_max_vel">
-    <property name="lower">0.10000000022351742</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">1000</property>
     <property name="value">1</property>
     <property name="step_increment">0.10000000000000001</property>
@@ -157,12 +159,9 @@
   <object class="EMC_Action_Open" id="hal_action_open"/>
   <object class="EMC_Action_Reload" id="hal_action_reload"/>
   <object class="EMC_Action_Save" id="hal_action_save">
-    <property name="stock_id">gtk-save</property>
     <property name="textview">gcode_view</property>
   </object>
   <object class="EMC_Action_SaveAs" id="hal_action_saveas">
-    <property name="stock_id">gtk-save-as</property>
-    <property name="icon_name">document-save</property>
     <property name="textview">gcode_view</property>
   </object>
   <object class="EMC_Stat" id="hal_status">
@@ -240,7 +239,7 @@
   <object class="GtkImage" id="img_dir_up">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-sort-ascending</property>
+    <property name="icon_name">go-up</property>
   </object>
   <object class="GtkImage" id="img_editor">
     <property name="visible">True</property>
@@ -2318,6 +2317,7 @@
                                                             <object class="HAL_LED" id="spindle_at_speed_led">
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">False</property>
+                                                            <property name="led_blink_rate">0</property>
                                                             <property name="on_color">green</property>
                                                             </object>
                                                             <packing>
@@ -2677,30 +2677,14 @@
                           <object class="GtkTable" id="tbl_search">
                             <property name="height_request">50</property>
                             <property name="can_focus">False</property>
-                            <property name="n_columns">7</property>
-                            <child>
-                              <object class="GtkEntry" id="search_entry">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="invisible_char">●</property>
-                                <property name="primary_icon_activatable">False</property>
-                                <property name="secondary_icon_activatable">False</property>
-                                <property name="primary_icon_sensitive">True</property>
-                                <property name="secondary_icon_sensitive">True</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">3</property>
-                                <property name="right_attach">4</property>
-                                <property name="y_options">GTK_SHRINK</property>
-                              </packing>
-                            </child>
+                            <property name="n_columns">16</property>
                             <child>
                               <object class="GtkButton" id="btn_undo">
-                                <property name="label" translatable="yes">undo</property>
+                                <property name="label" translatable="yes">Undo</property>
                                 <property name="height_request">48</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="receives_default">False</property>
                                 <property name="use_action_appearance">False</property>
                                 <signal name="clicked" handler="on_btn_undo_clicked" swapped="no"/>
                               </object>
@@ -2711,12 +2695,12 @@
                             </child>
                             <child>
                               <object class="GtkButton" id="btn_search_back">
-                                <property name="label" translatable="yes">search
+                                <property name="label" translatable="yes">Search
  back</property>
                                 <property name="height_request">48</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="receives_default">False</property>
                                 <property name="use_action_appearance">False</property>
                                 <signal name="clicked" handler="on_btn_search_back_clicked" swapped="no"/>
                               </object>
@@ -2729,35 +2713,35 @@
                             </child>
                             <child>
                               <object class="GtkButton" id="btn_search_forward">
-                                <property name="label" translatable="yes">search
+                                <property name="label" translatable="yes">Search
   fwd</property>
                                 <property name="height_request">48</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="receives_default">False</property>
                                 <property name="use_action_appearance">False</property>
                                 <signal name="clicked" handler="on_btn_search_forward_clicked" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="left_attach">4</property>
-                                <property name="right_attach">5</property>
+                                <property name="left_attach">10</property>
+                                <property name="right_attach">11</property>
                                 <property name="x_options">GTK_SHRINK</property>
                                 <property name="y_options">GTK_SHRINK</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="btn_redo">
-                                <property name="label" translatable="yes">redo</property>
+                                <property name="label" translatable="yes">Redo</property>
                                 <property name="height_request">48</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="receives_default">False</property>
                                 <property name="use_action_appearance">False</property>
                                 <signal name="clicked" handler="on_btn_redo_clicked" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="left_attach">6</property>
-                                <property name="right_attach">7</property>
+                                <property name="left_attach">15</property>
+                                <property name="right_attach">16</property>
                                 <property name="x_options">GTK_SHRINK</property>
                                 <property name="y_options">GTK_SHRINK</property>
                               </packing>
@@ -2778,8 +2762,139 @@
                                 <property name="can_focus">False</property>
                               </object>
                               <packing>
+                                <property name="left_attach">6</property>
+                                <property name="right_attach">7</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="lbl_replace_text">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Replace
+  Text:</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">7</property>
+                                <property name="right_attach">8</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="chk_replace_all">
+                                <property name="label" translatable="yes">Replace
+   All</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">12</property>
+                                <property name="right_attach">13</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="chk_ignore_case">
+                                <property name="label" translatable="yes">Ignore
+ Case</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="active">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">11</property>
+                                <property name="right_attach">12</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="lbl_spac1">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">9</property>
+                                <property name="right_attach">10</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="btn_replace">
+                                <property name="label" translatable="yes">Replace</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
+                                <signal name="clicked" handler="on_btn_replace_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left_attach">13</property>
+                                <property name="right_attach">14</property>
+                                <property name="x_options">GTK_SHRINK</property>
+                                <property name="y_options">GTK_SHRINK</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="lbl_search_text">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Search
+  Text:</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">4</property>
+                                <property name="right_attach">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="lbl_spac2">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">3</property>
+                                <property name="right_attach">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="lbl_spac3">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">14</property>
+                                <property name="right_attach">15</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="search_entry">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="invisible_char">●</property>
+                                <property name="primary_icon_activatable">False</property>
+                                <property name="secondary_icon_activatable">False</property>
+                                <property name="primary_icon_sensitive">True</property>
+                                <property name="secondary_icon_sensitive">True</property>
+                              </object>
+                              <packing>
                                 <property name="left_attach">5</property>
                                 <property name="right_attach">6</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="replace_entry">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="invisible_char">●</property>
+                                <property name="primary_icon_activatable">False</property>
+                                <property name="secondary_icon_activatable">False</property>
+                                <property name="primary_icon_sensitive">True</property>
+                                <property name="secondary_icon_sensitive">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">8</property>
+                                <property name="right_attach">9</property>
                               </packing>
                             </child>
                           </object>
@@ -3709,157 +3824,135 @@ Aux Screen</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkVBox" id="vbox3">
+                                  <object class="GtkFrame" id="frm_preview">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
+                                    <property name="label_xalign">0.5</property>
                                     <child>
-                                      <object class="GtkFrame" id="frm_preview">
+                                      <object class="GtkAlignment" id="ali_preview">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="label_xalign">0.5</property>
+                                        <property name="top_padding">5</property>
+                                        <property name="bottom_padding">5</property>
+                                        <property name="left_padding">5</property>
+                                        <property name="right_padding">5</property>
                                         <child>
-                                          <object class="GtkAlignment" id="ali_preview">
+                                          <object class="GtkVBox" id="vbox_preview">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="top_padding">5</property>
-                                            <property name="bottom_padding">5</property>
-                                            <property name="left_padding">5</property>
-                                            <property name="right_padding">5</property>
                                             <child>
-                                              <object class="GtkVBox" id="vbox5">
+                                              <object class="GtkCheckButton" id="chk_show_offsets">
+                                                <property name="label" translatable="yes">Show offsets</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="use_action_appearance">False</property>
+                                                <property name="draw_indicator">True</property>
+                                                <signal name="toggled" handler="on_chk_show_offsets_toggled" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="chk_show_dro">
+                                                <property name="label" translatable="yes">Show DRO</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="use_action_appearance">False</property>
+                                                <property name="draw_indicator">True</property>
+                                                <signal name="toggled" handler="on_chk_show_dro_toggled" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="chk_show_dtg">
+                                                <property name="label" translatable="yes">Show DTG</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="use_action_appearance">False</property>
+                                                <property name="xalign">1</property>
+                                                <property name="draw_indicator">True</property>
+                                                <signal name="toggled" handler="on_chk_show_dtg_toggled" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkHSeparator" id="hseparator2">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="chk_show_offsets">
-                                                    <property name="label" translatable="yes">Show offsets</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="use_action_appearance">False</property>
-                                                    <property name="draw_indicator">True</property>
-                                                    <signal name="toggled" handler="on_chk_show_offsets_toggled" swapped="no"/>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="chk_show_dro">
-                                                    <property name="label" translatable="yes">Show DRO</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="use_action_appearance">False</property>
-                                                    <property name="draw_indicator">True</property>
-                                                    <signal name="toggled" handler="on_chk_show_dro_toggled" swapped="no"/>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="chk_show_dtg">
-                                                    <property name="label" translatable="yes">Show DTG</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="use_action_appearance">False</property>
-                                                    <property name="xalign">1</property>
-                                                    <property name="draw_indicator">True</property>
-                                                    <signal name="toggled" handler="on_chk_show_dtg_toggled" swapped="no"/>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">2</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkHSeparator" id="hseparator2">
-                                                    <property name="visible">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">3</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="lbl_mouse_mode">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">&lt;b&gt;Mouse Button mode&lt;/b&gt;</property>
+                                                <property name="use_markup">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">4</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxEntry" id="cmb_mouse_button_mode">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="model">lst_button_mode</property>
+                                                <property name="active">4</property>
+                                                <property name="text_column">1</property>
+                                                <signal name="changed" handler="on_cmb_mouse_button_mode_changed" swapped="no"/>
+                                                <child internal-child="entry">
+                                                  <object class="GtkEntry" id="comboboxentry-entry2">
                                                     <property name="can_focus">False</property>
+                                                    <property name="primary_icon_activatable">False</property>
+                                                    <property name="secondary_icon_activatable">False</property>
+                                                    <property name="primary_icon_sensitive">True</property>
+                                                    <property name="secondary_icon_sensitive">True</property>
                                                   </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">3</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel" id="lbl_mouse_mode">
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="label" translatable="yes">&lt;b&gt;Mouse Button mode&lt;/b&gt;</property>
-                                                    <property name="use_markup">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">4</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkComboBoxEntry" id="cmb_mouse_button_mode">
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="model">lst_button_mode</property>
-                                                    <property name="active">4</property>
-                                                    <property name="text_column">1</property>
-                                                    <signal name="changed" handler="on_cmb_mouse_button_mode_changed" swapped="no"/>
-                                                    <child internal-child="entry">
-                                                      <object class="GtkEntry" id="comboboxentry-entry2">
-                                                        <property name="can_focus">False</property>
-                                                        <property name="primary_icon_activatable">False</property>
-                                                        <property name="secondary_icon_activatable">False</property>
-                                                        <property name="primary_icon_sensitive">True</property>
-                                                        <property name="secondary_icon_sensitive">True</property>
-                                                      </object>
-                                                    </child>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">5</property>
-                                                  </packing>
                                                 </child>
                                               </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">5</property>
+                                              </packing>
                                             </child>
                                           </object>
                                         </child>
-                                        <child type="label">
-                                          <object class="GtkLabel" id="lbl_frm_preview">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">&lt;b&gt;Preview&lt;/b&gt;</property>
-                                            <property name="use_markup">True</property>
-                                          </object>
-                                        </child>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
-                                    <child>
-                                      <object class="GtkLabel" id="label2">
+                                    <child type="label">
+                                      <object class="GtkLabel" id="lbl_frm_preview">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">&lt;b&gt;Preview&lt;/b&gt;</property>
+                                        <property name="use_markup">True</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
@@ -4142,7 +4235,7 @@ Aux Screen</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkLabel" id="label3">
+                                  <object class="GtkLabel" id="lbl_spa">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                   </object>
@@ -6177,7 +6270,7 @@ actions</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Stop the running program</property>
-                    <property name="use_action_appearance">False</property>
+                    <property name="related_action">hal_action_stop</property>
                     <property name="image">img_stop</property>
                     <signal name="clicked" handler="on_btn_stop_clicked" swapped="no"/>
                   </object>
@@ -6195,7 +6288,7 @@ actions</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Pause the running program</property>
-                    <property name="use_action_appearance">False</property>
+                    <property name="related_action">hal_tgl_pause</property>
                     <signal name="toggled" handler="on_tbtn_pause_toggled" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="img_pause">
@@ -7087,11 +7180,19 @@ selected</property>
                 <property name="can_focus">False</property>
                 <property name="homogeneous">True</property>
                 <child>
-                  <object class="GtkLabel" id="lbl_space_14">
-                    <property name="width_request">85</property>
-                    <property name="height_request">56</property>
+                  <object class="GtkButton" id="btn_save1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="related_action">hal_action_reload</property>
+                    <property name="use_underline">True</property>
+                    <child>
+                      <object class="GtkImage" id="img_save1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">view-refresh</property>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -7114,21 +7215,16 @@ selected</property>
                 </child>
                 <child>
                   <object class="GtkButton" id="btn_save">
-                    <property name="width_request">85</property>
-                    <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">save the file with the original name</property>
+                    <property name="tooltip_text" translatable="yes">save the file using the original name</property>
                     <property name="related_action">hal_action_save</property>
-                    <property name="image_position">right</property>
                     <child>
                       <object class="GtkImage" id="img_save">
-                        <property name="width_request">48</property>
-                        <property name="height_request">48</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="stock">gtk-save</property>
+                        <property name="icon_name">document-save</property>
                       </object>
                     </child>
                   </object>
@@ -7143,17 +7239,15 @@ selected</property>
                     <property name="width_request">85</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">save the file with a new name</property>
                     <property name="related_action">hal_action_saveas</property>
                     <child>
                       <object class="GtkImage" id="img_save_as">
-                        <property name="width_request">48</property>
-                        <property name="height_request">48</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="stock">gtk-save-as</property>
+                        <property name="icon_name">document-save-as</property>
                       </object>
                     </child>
                   </object>
@@ -7168,8 +7262,8 @@ selected</property>
                     <property name="width_request">85</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">save the program reload it and run it</property>
                     <property name="use_action_appearance">False</property>
                     <signal name="clicked" handler="on_btn_save_and_run_clicked" swapped="no"/>
@@ -7207,8 +7301,8 @@ selected</property>
                     <property name="width_request">85</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">clear the edit field and make a new file</property>
                     <property name="use_action_appearance">False</property>
                     <signal name="clicked" handler="on_btn_new_clicked" swapped="no"/>
@@ -7246,8 +7340,8 @@ selected</property>
                     <property name="width_request">85</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">Show or hide the virtual keyboard</property>
                     <property name="use_action_appearance">False</property>
                     <signal name="clicked" handler="on_btn_show_kbd_clicked" swapped="no"/>
@@ -7272,8 +7366,8 @@ selected</property>
                     <property name="width_request">85</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">Go back to main button list</property>
                     <property name="use_action_appearance">False</property>
                     <property name="image">img_back_zero1</property>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -84,7 +84,7 @@ if debug:
 
 # constants
 #          # gmoccapy  #"
-_RELEASE = "   1.2.2"
+_RELEASE = "   1.3.2"
 _INCH = 0                           # imperial units are active
 _MM = 1                             # metric units are active
 _TEMPDIR = tempfile.gettempdir()    # Now we know where the tempdir is, usualy /tmp
@@ -191,10 +191,8 @@ class gmoccapy(object):
         self.width = 979                # The width of the main Window
         self.height = 750               # The heigh of the main Window
 
-
         # the default theme = System Theme we store here to be able to go back to that one later
         self.default_theme = gtk.settings_get_default().get_property("gtk-theme-name")
-
 
         # the sounds to play if an error or message rises
         self.alert_sound = "/usr/share/sounds/ubuntu/stereo/bell.ogg"
@@ -263,7 +261,6 @@ class gmoccapy(object):
         self.widgets.adj_spindle_bar_max.set_value(self.max_spindle_rev)
         self.widgets.spindle_feedback_bar.set_property("min", float(self.min_spindle_rev))
         self.widgets.spindle_feedback_bar.set_property("max", float(self.max_spindle_rev))
-
 
         # Popup Messages position and size
         self.widgets.adj_x_pos_popup.set_value(self.prefs.getpref("x_pos_popup", 45, float))
@@ -390,10 +387,12 @@ class gmoccapy(object):
             print(_("**** disabled tool measurement ****"))
         else:
             self.widgets.lbl_tool_measurement.hide()
-            self.widgets.chk_use_tool_measurement.set_active(self.prefs.getpref("use_toolmeasurement", False, bool))
             self.widgets.spbtn_probe_height.set_value(self.prefs.getpref("probeheight", -1.0, float))
             self.widgets.spbtn_search_vel.set_value(self.prefs.getpref("searchvel", 75.0, float))
             self.widgets.spbtn_probe_vel.set_value(self.prefs.getpref("probevel", 10.0, float))
+            self.widgets.chk_use_tool_measurement.set_active(self.prefs.getpref("use_toolmeasurement", False, bool))
+            # to set the hal pin with correct values we emit a toogled
+            self.widgets.chk_use_tool_measurement.emit("toggled")
             self.widgets.lbl_x_probe.set_label(str(xpos))
             self.widgets.lbl_y_probe.set_label(str(ypos))
             self.widgets.lbl_z_probe.set_label(str(zpos))
@@ -2999,10 +2998,16 @@ class gmoccapy(object):
             self.widgets.frm_probe_pos.set_sensitive(True)
             self.widgets.frm_probe_vel.set_sensitive(True)
             self.halcomp["toolmeasurement"] = True
+            self.halcomp["searchvel"] = self.widgets.spbtn_search_vel.get_value()
+            self.halcomp["probevel"] = self.widgets.spbtn_probe_vel.get_value()
+            self.halcomp["probeheight"] = self.widgets.spbtn_probe_height.get_value()
         else:
             self.widgets.frm_probe_pos.set_sensitive(False)
             self.widgets.frm_probe_vel.set_sensitive(False)
             self.halcomp["toolmeasurement"] = False
+            self.halcomp["searchvel"] = 0.0
+            self.halcomp["probevel"] = 0.0
+            self.halcomp["probeheight"] = 0.0
         self.prefs.putpref("use_toolmeasurement", widget.get_active(), bool)
 
     def on_chk_hide_axis_4_toggled(self, widget, data = None):
@@ -3564,17 +3569,30 @@ class gmoccapy(object):
             self.widgets.box_info.set_size_request(-1, 50)
         self.widgets.tbl_search.show()
 
-    # search forward while in edit mode
-    def on_btn_search_forward_clicked(self, widget, data = None):
-        self.widgets.gcode_view.text_search(direction = True, text = self.widgets.search_entry.get_text())
-
-    # search backward while in edit mode
-    def on_btn_search_back_clicked(self, widget, data = None):
-        self.widgets.gcode_view.text_search(direction = False, text = self.widgets.search_entry.get_text())
-
+# Search and replace handling in edit mode
     # undo changes while in edit mode
     def on_btn_undo_clicked(self, widget, data = None):
         self.widgets.gcode_view.undo()
+
+    # search backward while in edit mode
+    def on_btn_search_back_clicked(self, widget, data = None):
+        self.widgets.gcode_view.text_search(direction = False,
+                                            mixed_case = self.widgets.chk_ignore_case.get_active(),
+                                            text = self.widgets.search_entry.get_text())
+
+    # search forward while in edit mode
+    def on_btn_search_forward_clicked(self, widget, data = None):
+        self.widgets.gcode_view.text_search(direction = True,
+                                            mixed_case = self.widgets.chk_ignore_case.get_active(),
+                                            text = self.widgets.search_entry.get_text())
+
+    # replace text in edit mode
+    def on_btn_replace_clicked(self, widget, data = None):
+        self.widgets.gcode_view.replace_text_search(direction = True,
+                                                    mixed_case = self.widgets.chk_ignore_case.get_active(),
+                                                    text = self.widgets.search_entry.get_text(),
+                                                    re_text = self.widgets.replace_entry.get_text(),
+                                                    replace_all = self.widgets.chk_replace_all.get_active())
 
     # redo changes while in edit mode
     def on_btn_redo_clicked(self, widget, data = None):
@@ -3654,13 +3672,15 @@ class gmoccapy(object):
     # this can not be done with the status widget,
     # because it will not emit a RESUME signal
     def on_tbtn_pause_toggled(self, widget, data = None):
-        if widget.get_active():
-            self.command.auto(linuxcnc.AUTO_PAUSE)
-        else:
-            self.command.auto(linuxcnc.AUTO_RESUME)
         self._add_alarm_entry("Pause toggled to be %s" % widget.get_active())
         widgetlist = ["btn_step", "rbt_forward", "rbt_reverse", "rbt_stop"]
         self._sensitize_widgets(widgetlist, widget.get_active())
+
+    def on_btn_stop_clicked(self, widget, data = None):
+        print("stop clicked")
+        self.start_line = 0
+        self.widgets.gcode_view.set_line_number(0)
+        self.widgets.tbtn_pause.set_active(False)
 
     def on_btn_run_clicked(self, widget, data = None):
         self.command.auto(linuxcnc.AUTO_RUN, self.start_line)
@@ -3675,12 +3695,6 @@ class gmoccapy(object):
         if state == gtk.STATE_INSENSITIVE:
             self.stepping = False
             self.widgets.tbtn_pause.set_sensitive(True)
-
-    def on_btn_stop_clicked(self, widget, data = None):
-        self.command.abort()
-        self.start_line = 0
-        self.widgets.gcode_view.set_line_number(0)
-        self.widgets.tbtn_pause.set_active(False)
 
     def on_btn_from_line_clicked(self, widget, data = None):
         self._add_alarm_entry("Restart the program from line clicked")

--- a/src/emc/usr_intf/gmoccapy/notification.py
+++ b/src/emc/usr_intf/gmoccapy/notification.py
@@ -108,7 +108,17 @@ class Notification(gtk.Window):
         label.set_size_request(self.message_width, -1)
         font_desc = pango.FontDescription(self.font)
         label.modify_font(font_desc)
-        label.set_markup(text)
+        # As messages may contain non pango conform syntax like "vel <= 0" we will have to check that to avoid an error
+        pango_ok = True
+        try:
+            # The GError exception is raised if an error occurs while parsing the markup text.
+            pango.parse_markup(text)        
+        except:
+            pango_ok = False
+        if pango_ok:
+            label.set_markup(text)
+        else:
+            label.set_text(text)
         hbox.pack_start(label)
         btn_close = gtk.Button()
         image = gtk.Image()
@@ -134,7 +144,6 @@ class Notification(gtk.Window):
 # we do not show the labelnumber, but we use it for the handling
 #        labelnumber.show()
         self.vbox.show()
-#        self.popup.show()
 
     # add a message, the message is a string, it will be line wraped
     # if to long for the frame
@@ -236,10 +245,9 @@ class Notification(gtk.Window):
         if name in self.__gproperties.keys():
             return getattr(self, name)
         else:
-            raise AttributeError('unknown iconview get_property %s' % property.name)
+            raise AttributeError('unknown notification get_property %s' % property.name)
 
     def do_set_property(self, property, value):
-#        print(property,"=",value)
         try:
             name = property.name.replace('-', '_')
             if name in self.__gproperties.keys():
@@ -262,7 +270,7 @@ class Notification(gtk.Window):
                 if name == 'use_frames':
                     self.use_frames = value
             else:
-                raise AttributeError('unknown iconview set_property %s' % property.name)
+                raise AttributeError('unknown notification set_property %s' % property.name)
         except:
             print('Attribute error', property, "and", type(value) , value)
             pass
@@ -271,8 +279,8 @@ class Notification(gtk.Window):
 def main():
 
     notification = Notification()
-    notification.add_message('Halo World out there', '/home/emcmesa/linuxcnc-dev/share/gscreen/images/std_info.gif')
-    notification.add_message('Hallo World ', '/home/emcmesa/linuxcnc-dev/share/gscreen/images/std_info.gif')
+    notification.add_message('Halo World out there', '/usr/share/gmoccapy/images/applet-critical.png')
+    notification.add_message('Hallo World ', '/usr/share/gmoccapy/images/std_info.gif')
     notification.show()
     def debug(self, text):
         print "debug", text

--- a/src/emc/usr_intf/gmoccapy/release_notes.txt
+++ b/src/emc/usr_intf/gmoccapy/release_notes.txt
@@ -1,3 +1,33 @@
+ver. 1.3.2
+- fixed a small bug PAUSE button did not get active on M01
+  Thanks to Rick (LAIR82) for pointing on it.
+
+ver. 1.3.1
+- fixed very serious bug PAUSE / RESUME / STOP issue
+  Program jumped to strange positions if STOP has been pressed 
+  while PAUSE was active.
+  Thanks to Mael (papaours) for finding it.
+
+ver. 1.3.0.1
+- corrected a bug, toolchange velocity hal pin have not been
+  preseted with values, if the user worked with the
+  default values, so a probing with vel = 0 was posible, 
+  resulting in an error
+- correctet an error in notifications.py, as the text to be
+  displayed has not been checked for correct pango format, a
+  message like "vel <= 0" resulted in an error. Now the necessary 
+  check is done
+
+ver. 1.3.0
+- added replace function to the edit page
+- added ignore case to allow case sensitive search
+- added reload button on edit page, so if you 
+  mixed up to much, you are able to reload the
+  original file
+- corrected an error at start up, giving a button
+  a label, conflicting with a button label
+- changed a wrong icon on the button go up one directory
+
 ver. 1.2.2
 - changed the way the window size and position is 
   handled, as bevore the default values did apear 


### PR DESCRIPTION
ver. 1.3.2
- fixed a small bug PAUSE button did not get active on M01
  Thanks to Rick (LAIR82) for pointing on it.

ver. 1.3.1
- fixed very serious bug PAUSE / RESUME / STOP issue
  Program jumped to strange positions if STOP has been pressed
  while PAUSE was active.
  Thanks to Mael (papaours) for finding it.

ver. 1.3.0.1
- corrected a bug, toolchange velocity hal pin have not been
  presetted with values, if the user worked with the
  default values, so a probing with vel = 0 was possible,
  resulting in an error
- corrected an error in notifications.py, as the text to be
  displayed has not been checked for correct pango format, a
  message like "vel <= 0" resulted in an error. Now the necessary
  check is done

ver. 1.3.0
- added replace function to the edit page
- added ignore case to allow case sensitive search
- added reload button on edit page, so if you
  mixed up to much, you are able to reload the
  original file
- corrected an error at start up, giving a button
  a label, conflicting with a button label
- changed a wrong icon on the button go up one directory
