### PR TITLE
machinetalk/configserver: fixed utf-8 encoding in examples

### DIFF
--- a/src/machinetalk/config-service/ledctrl/LedctrlDemo.qml
+++ b/src/machinetalk/config-service/ledctrl/LedctrlDemo.qml
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2014 Alexander Rössler
+** Copyright (C) 2014 Alexander Roessler
 ** License: LGPL version 2.1
 **
 ** This file is part of QtQuickVcp.
@@ -16,7 +16,7 @@
 ** Lesser General Public License for more details.
 **
 ** Contributors:
-** Alexander Rössler @ The Cool Tool GmbH <mail DOT aroessler AT gmail DOT com>
+** Alexander Roessler @ The Cool Tool GmbH <mail DOT aroessler AT gmail DOT com>
 **
 ****************************************************************************/
 import QtQuick 2.0

--- a/src/machinetalk/config-service/video/VideoDemo.qml
+++ b/src/machinetalk/config-service/video/VideoDemo.qml
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2014 Alexander Rössler
+** Copyright (C) 2014 Alexander Roessler
 ** License: LGPL version 2.1
 **
 ** This file is part of QtQuickVcp.
@@ -16,7 +16,7 @@
 ** Lesser General Public License for more details.
 **
 ** Contributors:
-** Alexander Rössler @ The Cool Tool GmbH <mail DOT aroessler AT gmail DOT com>
+** Alexander Roessler @ The Cool Tool GmbH <mail DOT aroessler AT gmail DOT com>
 **
 ****************************************************************************/
 import QtQuick 2.0


### PR DESCRIPTION
I updated the examples in PR 261 (or earlier) with files from QtQuickVcp. These files where utf-8 encoded and contained my name. This caused the build-bot to failed and I hope this patch fixed the problem.
