### PR TITLE
machinetalk/webtalk: fix for latest versions of libwebsockets

### DIFF
--- a/src/machinetalk/webtalk/webtalk_wsproxy.cc
+++ b/src/machinetalk/webtalk/webtalk_wsproxy.cc
@@ -175,7 +175,7 @@ static int serve_http(struct libwebsocket_context *context,
 	return -1;
     }
     lwsl_debug("serving '%s' mime type='%s'\n", buf, mt);
-    if (libwebsockets_serve_http_file(context, wsi, buf, mt, NULL))
+    if (libwebsockets_serve_http_file(context, wsi, buf, mt, NULL, 0))
 	return -1;
     return 0;
 }


### PR DESCRIPTION
Fixes building with the latest version of libwebsockets

See https://github.com/machinekit/machinekit/issues/339
