### PR TITLE
Fix hal/drivers/*.comp build

### DIFF
--- a/src/hal/components/Submakefile
+++ b/src/hal/components/Submakefile
@@ -3,8 +3,10 @@ HALCOMP_SUBMAKEFILE= hal/components/Submakefile
 # everything under the sun with every small change
 #HALCOMP_SUBMAKEFILE=
 
-ifneq ($(KERNELRELEASE),)
-COMPS := $(patsubst $(BASEPWD)/%,%,$(wildcard $(BASEPWD)/hal/components/*.comp $(BASEPWD)/hal/drivers/*.comp $(BASEPWD)/machinetalk/msgcomponents/*.comp))
+ifeq ($(BUILD_KBUILD),yes)
+COMPS := $(patsubst $(BASEPWD)/%,%,$(wildcard \
+	$(BASEPWD)/hal/components/*.comp $(BASEPWD)/hal/drivers/*.comp \
+	$(BASEPWD)/machinetalk/msgcomponents/*.comp))
 include $(patsubst %.comp, $(BASEPWD)/halcomp-srcs/%.mak, $(COMPS))
 else
 CONVERTERS :=  \
@@ -12,17 +14,25 @@ CONVERTERS :=  \
     conv_bit_s32.comp conv_bit_u32.comp \
     conv_s32_float.comp conv_s32_bit.comp conv_s32_u32.comp \
     conv_u32_float.comp conv_u32_bit.comp conv_u32_s32.comp
-COMPS := $(sort $(wildcard hal/components/*.comp) $(addprefix hal/components/, $(CONVERTERS)))
-COMP_MANPAGES := $(patsubst hal/components/%.comp, ../docs/man/man9/%.9, $(COMPS))
-COMP_DRIVERS := $(wildcard hal/drivers/*.comp)
-COMPS += $(wildcard machinetalk/msgcomponents/*.comp)
-COMP_DRIVER_MANPAGES := $(patsubst hal/drivers/%.comp, ../docs/man/man9/%.9, $(COMP_DRIVERS))
-manpages: $(COMP_MANPAGES) $(COMP_DRIVER_MANPAGES)
+COMPS := $(sort $(wildcard hal/components/*.comp) \
+	$(addprefix hal/components/, $(CONVERTERS)))
+COMP_MANPAGES := $(patsubst hal/components/%.comp, ../docs/man/man9/%.9, \
+	$(COMPS))
+
+MSG_COMPS := $(wildcard machinetalk/msgcomponents/*.comp)
+MSG_COMP_MANPAGES := $(patsubst machinetalk/msgcomponents/%.comp, \
+	../docs/man/man9/%.9, $(MSG_COMPS))
+
+DRIVER_COMPS := $(wildcard hal/drivers/*.comp)
+DRIVER_COMP_MANPAGES := $(patsubst hal/drivers/%.comp, ../docs/man/man9/%.9, \
+	$(COMP_DRIVERS))
+
+manpages: $(COMP_MANPAGES) $(DRIVER_COMP_MANPAGES) $(MSG_COMP_MANPAGES)
 TARGETS += manpages
 .PHONY: manpages
 ifeq ($(TRIVIAL_BUILD)+$(BUILD_THREAD_MODULES),no+yes)
 -include $(patsubst %.comp, $(BASEPWD)/halcomp-srcs/%.mak,\
-	$(COMPS) $(COMP_DRIVERS) $(MSGCOMPS))
+	$(COMPS) $(DRIVER_COMPS) $(MSG_COMPS))
 endif # TRIVIAL_BUILD == no
 endif # KERNELRELEASE != ''
 
@@ -30,7 +40,7 @@ ifeq ($(BUILD_THREAD_MODULES),yes)
 obj-m += $(patsubst hal/drivers/%.comp, %.o, \
 	$(patsubst hal/components/%.comp, %.o, \
 	$(patsubst machinetalk/msgcomponents/%.comp, %.o, \
-	$(COMPS))))
+	$(COMPS) $(DRIVER_COMPS) $(MSG_COMPS))))
 endif
 
 $(COMP_MANPAGES): ../docs/man/man9/%.9: hal/components/%.comp ../bin/comp
@@ -38,7 +48,13 @@ $(COMP_MANPAGES): ../docs/man/man9/%.9: hal/components/%.comp ../bin/comp
 	@mkdir -p $(dir $@)
 	$(Q)../bin/comp --document -o $@ $<
 
-$(COMP_DRIVER_MANPAGES): ../docs/man/man9/%.9: hal/drivers/%.comp ../bin/comp
+$(DRIVER_COMP_MANPAGES): ../docs/man/man9/%.9: hal/drivers/%.comp ../bin/comp
+	$(ECHO) Making comp manpage $(notdir $@)
+	@mkdir -p $(dir $@)
+	$(Q)../bin/comp --document -o $@ $<
+
+$(MSG_COMP_MANPAGES): ../docs/man/man9/%.9: \
+		machinetalk/msgcomponents/%.comp ../bin/comp
 	$(ECHO) Making comp manpage $(notdir $@)
 	@mkdir -p $(dir $@)
 	$(Q)../bin/comp --document -o $@ $<
@@ -62,8 +78,10 @@ halcomp-srcs/%.mak: %.comp $(HALCOMP_SUBMAKEFILE)
 	$(Q)mv -f $@.tmp $@
 
 # Generate .c and .mak files before the modules target
-modules: $(patsubst %.comp, halcomp-srcs/%.c, $(COMPS) $(COMP_DRIVERS) $(MSGCOMPS))
-modules: $(patsubst %.comp, halcomp-srcs/%.mak, $(COMPS) $(COMP_DRIVERS) $(MSGCOMPS))
+modules: $(patsubst %.comp, halcomp-srcs/%.c, \
+	$(COMPS) $(DRIVER_COMPS) $(MSG_COMPS))
+modules: $(patsubst %.comp, halcomp-srcs/%.mak, \
+	$(COMPS) $(DRIVER_COMPS) $(MSG_COMPS))
 endif # BUILD_ALL_FLAVORS == yes
 
 # ifeq ($(BUILD_THREAD_MODULES),yes)
@@ -90,7 +108,7 @@ endif # BUILD_ALL_FLAVORS == yes
 
 clean: clean-comp-manpages
 clean-comp-manpages:
-	-rm -f $(COMP_MANPAGES) $(COMP_DRIVER_MANPAGES)
+	-rm -f $(COMP_MANPAGES) $(DRIVER_COMP_MANPAGES) $(MSG_COMP_MANPAGES)
 
 HALSTREAMERSRCS := hal/components/streamer_usr.c
 USERSRCS += $(HALSTREAMERSRCS)

--- a/src/hal/drivers/Submakefile
+++ b/src/hal/drivers/Submakefile
@@ -33,11 +33,9 @@ pluto_clean:
 
 # The kernel's build system won't know how to rebuild generated files
 # so modules must depend on them explicitly
-ifneq ($(BUILD_SYS),user-dso)
 modules:                                                         \
     hal/drivers/pluto_servo_rbf.h                                \
     hal/drivers/pluto_step_rbf.h
-endif
 
 INCLUDES += hal/drivers
 

--- a/src/hal/drivers/pcl720.comp
+++ b/src/hal/drivers/pcl720.comp
@@ -45,7 +45,7 @@ license "GPL";
 author "Andy Pugh";
 ;;
 
-#include <asm/io.h>
+#include <rtapi_io.h>
 #define MAX_CHAN 8
 
 static int ioaddr[MAX_CHAN] = {-1, -1, -1, -1, -1, -1, -1, -1};

--- a/src/hal/drivers/pluto_common.h
+++ b/src/hal/drivers/pluto_common.h
@@ -39,8 +39,10 @@ RTAPI_MP_INT(epp_wide, "Use 16- and 32-bit EPP transfers with hardware EPP");
 RTAPI_MP_INT(watchdog,
 	"Enable hardware watchdog to tristate outputs if EMC crashes");
 
+#ifdef BUILD_SYS_KBUILD
 #ifndef llabs // linux/kernel.h may provide labs for realtime systems
 static int64_t llabs(int64_t l) { if(l < 0) return -l; return l; }
+#endif
 #endif
 
 static inline int64_t extend(int64_t old, int newlow, int nbits) {

--- a/src/hal/drivers/pluto_servo.comp
+++ b/src/hal/drivers/pluto_servo.comp
@@ -159,8 +159,8 @@ option extra_cleanup;
 
 option data internal;
 
-function read "Read all the inputs from the pluto-servo board";
-function write "Write all the outputs on the pluto-servo board";
+function ppread "Read all the inputs from the pluto-servo board";
+function ppwrite "Write all the outputs on the pluto-servo board";
 
 see_also """The \\fIpluto_servo\\fR section in the HAL User Manual, which shows the location of each physical pin on the pluto board.""";
 
@@ -173,7 +173,7 @@ mode.""";
 
 modparam dummy epp_wide = 1
     """Set to zero to disable the "wide EPP mode".  "Wide" mode allows a 16-
-and 32-bit EPP transfers, which can reduce the time spent in the read and write
+and 32-bit EPP transfers, which can reduce the time spent in the ppread and ppwrite
 functions.  However, this may not work on all EPP parallel ports.""";
 
 modparam dummy watchdog = 1
@@ -228,7 +228,7 @@ int PWM(int enable, double value, double offset, double scale, double min_dc, do
     return result;
 }
 
-FUNCTION(write) {
+FUNCTION(ppwrite) {
     int r = 0;
     int i;
     if(communication_error) return;
@@ -257,7 +257,7 @@ FUNCTION(write) {
     write16(r);
 }
 
-FUNCTION(read) {
+FUNCTION(ppread) {
     int i;
     __u32 ppdata;
 

--- a/src/hal/drivers/pluto_step.comp
+++ b/src/hal/drivers/pluto_step.comp
@@ -32,7 +32,7 @@ secondary address.
 .TP
 \\fBepp_wide\\fR [default: 1]
 Set to zero to disable "wide EPP mode".  "Wide" mode allows 16- and 32-bit EPP
-transfers, which can reduce the time spent in the read and write functions.
+transfers, which can reduce the time spent in the ppread and ppwrite functions.
 However, this mode may not work on all EPP parallel ports.
 
 .TP
@@ -136,8 +136,8 @@ option extra_cleanup;
 
 option data internal;
 
-function read "Read all the inputs from the pluto-step board";
-function write "Write all the outputs on the pluto-step board";
+function ppread "Read all the inputs from the pluto-step board";
+function ppwrite "Write all the outputs on the pluto-step board";
 
 see_also """The \\fIpluto_step\\fR section in the HAL User Manual, which shows the location of each physical pin on the pluto board.""";
 
@@ -168,7 +168,7 @@ typedef struct {
 
 #define ONE (1<<F)
 #define MAX_STEP_RATE (1<<(F-1))
-FUNCTION(write) {
+FUNCTION(ppwrite) {
     int r = 0;
     int i;
     int stepspace_ticks = stepgen_stepspace/PLUTO_SPEED_NS;
@@ -266,7 +266,7 @@ FUNCTION(write) {
 }
 
 
-FUNCTION(read) {
+FUNCTION(ppread) {
     int i;
     __u32 ppdata;
 

--- a/src/hal/drivers/serport.comp
+++ b/src/hal/drivers/serport.comp
@@ -46,7 +46,7 @@ function write nofp;
 license "GPL";
 ;;
 
-#include <asm/io.h>
+#include <rtapi_io.h>
 #include <rtapi_errno.h>
 
 #define MAX 8


### PR DESCRIPTION
The `$(COMP_DRIVERS)` variable was left out of `obj-m`, so these comps
have not been built for a long time.  Re-enabling revealed a number of
build problems:
- The pluto driver build was only partially disabled for userland threads
  - legacy project completely disables for userland
  - enabling userland threads build reveals more problems:
    - `read()`/`write()` name conflict with functions in `unistd.h`
    - `llabs` type definition conflict
- The `pcl720` and `serport` comps needed header updates for `USER_PCI`
- Broken `msgcomponents` comp build recipes
  - `hal/components` and `machinetalk/msgcomponents` don't fit into
    one pattern
  - man pages not built

This patch straightens the basic build problems out, but these fixes
are untested.  Fixes #384
