### PR TITLE
gladevcp: example configs were broken due to API change

### DIFF
--- a/configs/ARM/PRU-Debugger/ui.py
+++ b/configs/ARM/PRU-Debugger/ui.py
@@ -173,7 +173,7 @@ class HandlerClass:
             return
         self._set_line(line+1)
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
 
         self.halcomp = halcomp
         self.builder = builder
@@ -213,6 +213,6 @@ class HandlerClass:
             self.have_file = False
 
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/apps/gladevcp/README.changes
+++ b/configs/apps/gladevcp/README.changes
@@ -9,13 +9,13 @@ parameter any more as well:
 
 class HandlerClass:
     ...
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         self.halcomp = halcomp
         self.builder = builder
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]
 
 Widget access in handler classes:
 =================================

--- a/configs/apps/gladevcp/animated-backdrop/cairodraw.py
+++ b/configs/apps/gladevcp/animated-backdrop/cairodraw.py
@@ -31,7 +31,7 @@ class HandlerClass:
 
 
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
 
         self.builder = builder
         win = self.builder.get_object("window1")
@@ -56,6 +56,6 @@ class HandlerClass:
         # however the fixed widget does NOT do proportional scaling
         self.scale = 1
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/apps/gladevcp/by-widget/combobox.py
+++ b/configs/apps/gladevcp/by-widget/combobox.py
@@ -23,18 +23,18 @@ class HandlerClass:
     def on_changed(self, combobox, data=None):
         print "on_changed %f %d" % (combobox.hal_pin_f.get(),combobox.hal_pin_s.get())
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         self.halcomp = halcomp
         self.builder = builder
         self.useropts = useropts
 
         self.combo = self.builder.get_object('hal_combobox1')
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
     global debug
     for cmd in useropts:
         exec cmd in globals()
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]
 

--- a/configs/apps/gladevcp/by-widget/combobox_manual_list.py
+++ b/configs/apps/gladevcp/by-widget/combobox_manual_list.py
@@ -28,7 +28,7 @@ class HandlerClass:
         return
 
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         self.halcomp = halcomp
         self.builder = builder
         self.useropts = useropts
@@ -49,11 +49,11 @@ class HandlerClass:
         self.combo.add_attribute(cell, "text", 0)
 
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
     global debug
     for cmd in useropts:
         exec cmd in globals()
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]
 

--- a/configs/apps/gladevcp/by-widget/radio.py
+++ b/configs/apps/gladevcp/by-widget/radio.py
@@ -57,7 +57,7 @@ class HandlerClass:
         self.halcomp.exit() # avoid lingering HAL component
         gtk.main_quit()
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         self.halcomp = halcomp
         self.builder = builder
         self.useropts = useropts
@@ -76,11 +76,11 @@ class HandlerClass:
                                 }
         self.on_showoutput_btn_toggled(self.builder.get_object('showoutput_btn'))
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
     global debug
     for cmd in useropts:
         exec cmd in globals()
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]
 

--- a/configs/apps/gladevcp/by-widget/sourceview.py
+++ b/configs/apps/gladevcp/by-widget/sourceview.py
@@ -34,7 +34,7 @@ class HandlerClass:
         self.line -= 1
         self._set_line(self.line)
    
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         self.halcomp = halcomp
         self.builder = builder
 
@@ -51,6 +51,6 @@ class HandlerClass:
         self.mark = None
 
         
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/apps/gladevcp/by-widget/spinbutton.py
+++ b/configs/apps/gladevcp/by-widget/spinbutton.py
@@ -10,7 +10,7 @@ class HandlerClass:
         widget.set_value(3.14)
 
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
     return [HandlerClass()]
 

--- a/configs/apps/gladevcp/class-callback/class_callback.py
+++ b/configs/apps/gladevcp/class-callback/class_callback.py
@@ -42,7 +42,7 @@ class HandlerClass:
         return True
 
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         '''
         Handler classes are instantiated in the following state:
         - the widget tree is created, but not yet realized (no toplevel window.show() executed yet)
@@ -74,7 +74,7 @@ class HandlerClass:
 other = OtherClass()  # executed at import time
 
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
     '''
     this function is called by gladevcp at import time (when this module is passed with '-u <modname>.py')
 
@@ -83,4 +83,4 @@ def get_handlers(halcomp,builder,useropts):
 
     the 'get_handlers' name is reserved - gladevcp expects it, so do not change
     '''
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/apps/gladevcp/colored-label/coloredlabel.py
+++ b/configs/apps/gladevcp/colored-label/coloredlabel.py
@@ -75,10 +75,10 @@ class HandlerClass:
         hal_widget.set_label(text)
         self.colorize(hal_widget, gtk.STATE_NORMAL, color)
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
 
         self.hal_button1 = builder.get_object('hal_button1')
  
 
-def get_handlers(halcomp,builder,useropts):
-    return [HandlerClass(halcomp,builder,useropts)]
+def get_handlers(halcomp,builder,useropts,compname):
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/apps/gladevcp/complex/complex.py
+++ b/configs/apps/gladevcp/complex/complex.py
@@ -129,7 +129,7 @@ class HandlerClass:
         self.example_trigger = hal_glib.GPin(halcomp.newpin('example-trigger',  hal.HAL_BIT, hal.HAL_IN))
         self.example_trigger.connect('value-changed', self._on_example_trigger_change)
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         '''
         Handler classes are instantiated in the following state:
         - the widget tree is created, but not yet realized (no toplevel window.show() executed yet)
@@ -190,7 +190,7 @@ class HandlerClass:
         glib.timeout_add_seconds(1, self._on_timer_tick)
 
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
     '''
     this function is called by gladevcp at import time (when this module is passed with '-u <modname>.py')
 
@@ -210,4 +210,4 @@ def get_handlers(halcomp,builder,useropts):
 
     if debug: print "%s.get_handlers() called" % (__name__)
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/apps/gladevcp/templates/classhandler.py
+++ b/configs/apps/gladevcp/templates/classhandler.py
@@ -40,7 +40,7 @@ class HandlerClass:
         return True
 
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         self.halcomp = halcomp
         self.builder = builder
         self.useropts = useropts
@@ -51,9 +51,9 @@ class HandlerClass:
         glib.timeout_add_seconds(1, self._on_timer_tick)
 
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
     for cmd in useropts:
         exec cmd in globals()
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/apps/gladevcp/templates/classhandler_persistent.py
+++ b/configs/apps/gladevcp/templates/classhandler_persistent.py
@@ -51,7 +51,7 @@ class HandlerClass:
         self.ini.restore_state(self)
 
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         self.halcomp = halcomp
         self.builder = builder
         self.useropts = useropts
@@ -81,7 +81,7 @@ class HandlerClass:
         self.ini.restore_state(self)
 
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
     global debug
     for cmd in useropts:
@@ -90,4 +90,4 @@ def get_handlers(halcomp,builder,useropts):
     # get some detail what save/restore etc are doing
     set_debug(debug)
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/sim/axis/gladevcp-jwp.py
+++ b/configs/sim/axis/gladevcp-jwp.py
@@ -66,5 +66,5 @@ class HandlerClass:
         self.motion_type  = hal_glib.GPin(halcomp.newpin('motion_type', hal.HAL_S32, hal.HAL_IN))
         self.motion_type.connect('value-changed', self._on_motion_type_changed)
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts, compname):
     return [HandlerClass(halcomp,builder,useropts)]

--- a/configs/sim/axis/gladevcp/meter_scale.py
+++ b/configs/sim/axis/gladevcp/meter_scale.py
@@ -9,7 +9,7 @@ class HandlerClass:
         self.meter.max = float(hal_pin.get())
         self.meter.queue_draw() # force a widget redraw
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         self.builder = builder
 
         # hal pin with change callback.
@@ -23,5 +23,5 @@ class HandlerClass:
         self.meter.min = mmin
 
 
-def get_handlers(halcomp,builder,useropts):
-    return [HandlerClass(halcomp,builder,useropts)]
+def get_handlers(halcomp,builder,useropts,compname):
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/sim/axis/gladevcp/probe.py
+++ b/configs/sim/axis/gladevcp/probe.py
@@ -178,7 +178,7 @@ class HandlerClass:
         self.ini.restore_state(self)
 
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         self.halcomp = halcomp
         self.builder = builder
 
@@ -193,7 +193,7 @@ class HandlerClass:
 
         glib.timeout_add_seconds(1, self._query_emc_status)
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
 
     global debug
     for cmd in useropts:
@@ -201,4 +201,4 @@ def get_handlers(halcomp,builder,useropts):
 
     set_debug(debug)
 
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/sim/axis/remap/manual-toolchange-with-tool-length-switch/python/gladevcp-handler.py
+++ b/configs/sim/axis/remap/manual-toolchange-with-tool-length-switch/python/gladevcp-handler.py
@@ -16,10 +16,10 @@ class HandlerClass:
         else:
             self.change_text.set_label("")         
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         self.halcomp = halcomp
         self.change_text = builder.get_object("change-text")
         self.halcomp.newpin("number", hal.HAL_FLOAT, hal.HAL_IN)
 
-def get_handlers(halcomp,builder,useropts):
-    return [HandlerClass(halcomp,builder,useropts)]
+def get_handlers(halcomp,builder,useropts,compname):
+    return [HandlerClass(halcomp,builder,useropts,compname)]

--- a/configs/sim/gmoccapy/gmoccapy_plasma/plasma.py
+++ b/configs/sim/gmoccapy/gmoccapy_plasma/plasma.py
@@ -36,7 +36,7 @@ from gmoccapy import getiniinfo
 
 class PlasmaClass:
 
-    def __init__(self, halcomp, builder, useropts):
+    def __init__(self, halcomp, builder, useropts,compname):
         self.builder = builder
         self.halcomp = halcomp
         self.defaults = { IniFile.vars : { "thcspeedval"       : 15.0 ,
@@ -309,5 +309,5 @@ class PlasmaClass:
     def on_enable_HeightLock_toggled(self, widget, data = None):
         self.enableheightlock = widget.get_active()
 
-def get_handlers(halcomp, builder, useropts):
-    return[PlasmaClass(halcomp, builder, useropts)]
+def get_handlers(halcomp, builder, useropts,compname):
+    return[PlasmaClass(halcomp, builder, useropts,compname)]

--- a/configs/sim/gmoccapy/gmoccapy_plasma/signals.py
+++ b/configs/sim/gmoccapy/gmoccapy_plasma/signals.py
@@ -34,7 +34,7 @@ from gmoccapy import getiniinfo
 
 class SignalsClass:
 
-    def __init__(self, halcomp, builder, useropts):
+    def __init__(self, halcomp, builder, useropts,compname):
 
         get_ini_info = getiniinfo.GetIniInfo()
         prefs = preferences.preferences(get_ini_info.get_preference_file_path())
@@ -43,5 +43,5 @@ class SignalsClass:
             theme_name = gtk.settings_get_default().get_property("gtk-theme-name")
         gtk.settings_get_default().set_string_property("gtk-theme-name", theme_name, "")
 
-def get_handlers(halcomp, builder, useropts):
-    return[SignalsClass(halcomp, builder, useropts)]
+def get_handlers(halcomp, builder, useropts,compname):
+    return[SignalsClass(halcomp, builder, useropts,compname)]

--- a/configs/sim/hitcounter.py
+++ b/configs/sim/hitcounter.py
@@ -19,7 +19,7 @@ class HandlerClass:
         self.nhits += 1
         self.builder.get_object('hits').set_label("Hits: %d" % (self.nhits))
 
-    def __init__(self, halcomp,builder,useropts):
+    def __init__(self, halcomp,builder,useropts,compname):
         '''
         Handler classes are instantiated in the following state:
         - the widget tree is created, but not yet realized (no toplevel window.show() executed yet)
@@ -39,7 +39,7 @@ class HandlerClass:
 
 
 
-def get_handlers(halcomp,builder,useropts):
+def get_handlers(halcomp,builder,useropts,compname):
     '''
     this function is called by gladevcp at import time (when this module is passed with '-u <modname>.py')
 
@@ -48,4 +48,4 @@ def get_handlers(halcomp,builder,useropts):
 
     the 'get_handlers' name is reserved - gladevcp expects it, so do not change
     '''
-    return [HandlerClass(halcomp,builder,useropts)]
+    return [HandlerClass(halcomp,builder,useropts,compname)]


### PR DESCRIPTION
Making gladevcp remote-capable forced a fourth parameter to the get_handlers()
API. This caused all gladevcp example configs to break.

Sorry about this. Strange this wasnt reported..
