### PR TITLE
build: fix webtalk clean target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -678,7 +678,7 @@ modclean:
 depclean:
 	-rm -rf depends
 
-clean: depclean modclean
+clean: depclean modclean webtalk-clean
 	find . -name '*.o' |xargs rm -f
 	-rm -rf objects
 	-rm -f $(TARGETS)

--- a/src/machinetalk/webtalk/Submakefile
+++ b/src/machinetalk/webtalk/Submakefile
@@ -138,7 +138,7 @@ TARGETS += ../lib/webtalk/plugins/pbzws.o
 
 endif
 
-clean:
+webtalk-clean:
 	-rm -f \
 	machinetalk/webtalk/zws.pb.cc \
 	machinetalk/webtalk/zws.pb.h \


### PR DESCRIPTION
cant have multiple identically named targets - newer overrides older.
