### PR TITLE
Fix metric arc tolerence to same value as imperial

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -561,7 +561,7 @@ int Interp::convert_arc2(int move,       //!< either G_2 (cw arc) or G_3 (ccw ar
   int plane = settings->plane;
 
   tolerance = (settings->length_units == CANON_UNITS_INCHES) ?
-    TOLERANCE_INCH : TOLERANCE_MM;
+    settings->tolerance_inch : settings->tolerance_mm;
 
   if (block->r_flag) {
       CHP(arc_data_r(move, plane, *current1, *current2, end1, end2,
@@ -641,7 +641,7 @@ int Interp::convert_arc_comp1(int move,  //!< either G_2 (cw arc) or G_3 (ccw ar
 
     side = settings->cutter_comp_side;
     tool_radius = settings->cutter_comp_radius;   /* always is positive */
-    tolerance = (settings->length_units == CANON_UNITS_INCHES) ? TOLERANCE_INCH : TOLERANCE_MM;
+    tolerance = (settings->length_units == CANON_UNITS_INCHES) ? settings->tolerance_inch : settings->tolerance_mm;
 
     comp_get_current(settings, &cx, &cy, &cz);
 
@@ -803,7 +803,7 @@ int Interp::convert_arc_comp2(int move,  //!< either G_2 (cw arc) or G_3 (ccw ar
     comp_get_current(settings, &cx, &cy, &cz);
 
     tolerance = (settings->length_units == CANON_UNITS_INCHES) ?
-        TOLERANCE_INCH : TOLERANCE_MM;
+        settings->tolerance_inch : settings->tolerance_mm;
 
     if (block->r_flag) {
         CHP(arc_data_r(move, plane, opx, opy, end_x, end_y,

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -60,7 +60,11 @@
 
 /* numerical constants */
 #define TOLERANCE_INCH 0.0005
-#define TOLERANCE_MM 0.005
+#define TOLERANCE_MM 0.0127
+
+#define MAX_TOLERANCE_INCH 0.005
+#define MAX_TOLERANCE_MM 0.05
+
 /* angle threshold for concavity for cutter compensation, in radians */
 #define TOLERANCE_CONCAVE_CORNER 0.05  
 #define TOLERANCE_EQUAL 0.0001 /* two numbers compare EQ if the
@@ -663,6 +667,8 @@ typedef struct setup_struct
   FILE *file_pointer;           // file pointer for open NC code file
   bool flood;                 // whether flood coolant is on
   CANON_UNITS length_units;     // millimeters or inches
+  double tolerance_inch;        // modify with ini setting
+  double tolerance_mm;          // modify with ini setting
   int line_length;              // length of line last read
   char linetext[LINELEN];       // text of most recent line read
   bool mist;                  // whether mist coolant is on

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -82,6 +82,7 @@ include an option for suppressing superfluous commands.
 #include <set>
 #include <stdexcept>
 
+#include "rtapi.h"
 #include "inifile.hh"		// INIFILE
 #include "rs274ngc.hh"
 #include "rs274ngc_return.hh"
@@ -967,8 +968,39 @@ int Interp::init()
 	      n++;
 	  }
 
-          // close it
-          inifile.Close();
+    	// if exist and within parameters, apply ini file arc tolerances
+    	// limiting figures are defined in interp_internal.hh
+    	
+      _setup.tolerance_inch = TOLERANCE_INCH;
+      inifile.Find(&_setup.tolerance_inch, "TOLERANCE_INCH", "RS274NGC");
+	  if( (_setup.tolerance_inch > MAX_TOLERANCE_INCH) )
+	      {
+	      _setup.tolerance_inch = MAX_TOLERANCE_INCH;
+	      rtapi_print_msg(RTAPI_MSG_DBG, "setup.tolerance_inch GT MAX_TOLERANCE_INCH\n");	    
+	      }
+	  else if(_setup.tolerance_inch < TOLERANCE_INCH) 
+	      {
+	      _setup.tolerance_inch = TOLERANCE_INCH;
+	      rtapi_print_msg(RTAPI_MSG_DBG, "setup.tolerance_inch LT TOLERANCE_INCH\n");	    	  
+	      }
+	  rtapi_print_msg(RTAPI_MSG_DBG, "setup.tolerance_inch set to %f\n", _setup.tolerance_inch);
+ 
+      _setup.tolerance_mm = TOLERANCE_MM;
+	  inifile.Find(&_setup.tolerance_mm, "TOLERANCE_MM", "RS274NGC");
+	  if( (_setup.tolerance_mm > MAX_TOLERANCE_MM) )
+	      {
+	      _setup.tolerance_mm = MAX_TOLERANCE_MM;
+	      rtapi_print_msg(RTAPI_MSG_DBG, "setup.tolerance_mm GT MAX_TOLERANCE_MM\n");	    
+	      }
+	  else if(_setup.tolerance_mm < TOLERANCE_MM) 
+	      {
+	      _setup.tolerance_mm = TOLERANCE_MM;
+	      rtapi_print_msg(RTAPI_MSG_DBG, "setup.tolerance_mm LT TOLERANCE_MM\n");	    	  
+	      }
+	  rtapi_print_msg(RTAPI_MSG_DBG, "setup.tolerance_mm set to %f\n", _setup.tolerance_mm);
+
+      // close it
+      inifile.Close();
       }
   }
 


### PR DESCRIPTION
Also add an ini file field and allow user variance of arc tolerances
within preset limits

This arose from Linuxcnc forum, with user who could not get CAM generated code for cutting signs to load because of the arc tolerance test.

I found that TOLERANCE_MM had been wrongly set for years to 1x10 of imperial setting instead of
1x25.4
The fixed metric tolerances have already been pushed into 2.7

Additionally built upon a patch by Dewey Garret to allow setting of arc tolerance in the ini file. 

Contains limits checking against those set in interp_internal.hh, to allow CAM code which contains imprecise or rounded up I, J and K figures in G2 and G3 to run, within sensible bounds.
