### PR TITLE
Fix metric arc tolerence to same value as imperial

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -561,7 +561,7 @@ int Interp::convert_arc2(int move,       //!< either G_2 (cw arc) or G_3 (ccw ar
   int plane = settings->plane;
 
   tolerance = (settings->length_units == CANON_UNITS_INCHES) ?
-    TOLERANCE_INCH : TOLERANCE_MM;
+    settings->tolerance_inch : settings->tolerance_mm;
 
   if (block->r_flag) {
       CHP(arc_data_r(move, plane, *current1, *current2, end1, end2,
@@ -641,7 +641,7 @@ int Interp::convert_arc_comp1(int move,  //!< either G_2 (cw arc) or G_3 (ccw ar
 
     side = settings->cutter_comp_side;
     tool_radius = settings->cutter_comp_radius;   /* always is positive */
-    tolerance = (settings->length_units == CANON_UNITS_INCHES) ? TOLERANCE_INCH : TOLERANCE_MM;
+    tolerance = (settings->length_units == CANON_UNITS_INCHES) ? settings->tolerance_inch : settings->tolerance_mm;
 
     comp_get_current(settings, &cx, &cy, &cz);
 
@@ -803,7 +803,7 @@ int Interp::convert_arc_comp2(int move,  //!< either G_2 (cw arc) or G_3 (ccw ar
     comp_get_current(settings, &cx, &cy, &cz);
 
     tolerance = (settings->length_units == CANON_UNITS_INCHES) ?
-        TOLERANCE_INCH : TOLERANCE_MM;
+        settings->tolerance_inch : settings->tolerance_mm;
 
     if (block->r_flag) {
         CHP(arc_data_r(move, plane, opx, opy, end_x, end_y,

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -60,7 +60,11 @@
 
 /* numerical constants */
 #define TOLERANCE_INCH 0.0005
-#define TOLERANCE_MM 0.005
+#define TOLERANCE_MM 0.0127
+
+#define MAX_TOLERANCE_INCH 0.005
+#define MAX_TOLERANCE_MM 0.127
+
 /* angle threshold for concavity for cutter compensation, in radians */
 #define TOLERANCE_CONCAVE_CORNER 0.05  
 #define TOLERANCE_EQUAL 0.0001 /* two numbers compare EQ if the
@@ -663,6 +667,8 @@ typedef struct setup_struct
   FILE *file_pointer;           // file pointer for open NC code file
   bool flood;                 // whether flood coolant is on
   CANON_UNITS length_units;     // millimeters or inches
+  double tolerance_inch;        // modify with ini setting
+  double tolerance_mm;          // modify with ini setting
   int line_length;              // length of line last read
   char linetext[LINELEN];       // text of most recent line read
   bool mist;                  // whether mist coolant is on

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -967,8 +967,25 @@ int Interp::init()
 	      n++;
 	  }
 
-          // close it
-          inifile.Close();
+    	// if exist and within parameters, apply ini file arc tolerances
+    	// limiting figures are defined in interp_internal.hh
+    	
+      _setup.tolerance_inch = TOLERANCE_INCH;
+      inifile.Find(&_setup.tolerance_inch, "TOLERANCE_INCH", "RS274NGC");
+	  if( (_setup.tolerance_inch > MAX_TOLERANCE_INCH) )
+	      _setup.tolerance_inch = MAX_TOLERANCE_INCH;
+	  else if(_setup.tolerance_inch < TOLERANCE_INCH) 
+	      _setup.tolerance_inch = TOLERANCE_INCH;
+	   
+      _setup.tolerance_mm = TOLERANCE_MM;
+	  inifile.Find(&_setup.tolerance_mm, "TOLERANCE_MM", "RS274NGC");
+	  if( (_setup.tolerance_mm > MAX_TOLERANCE_MM) )
+	      _setup.tolerance_mm = MAX_TOLERANCE_MM;
+	  else if(_setup.tolerance_mm < TOLERANCE_MM) 
+	      _setup.tolerance_mm = TOLERANCE_MM;
+	  
+      // close it
+      inifile.Close();
       }
   }
 


### PR DESCRIPTION
Also add an ini file field and allow user variance of arc tolerances
within preset limits.

New PR following from #402 , original closed

Limits are currently set MAX_TOLERANCE_INCH / MM at 10x defaults.
This allows all the testing CAM code I have to run happily

If usage suggests other limits should be used, it is a very simple matter to change the define
in interp_internal.hh
