### PR TITLE
interp/remap: make M100-M199 remappable

### DIFF
--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -623,8 +623,10 @@ int Interp::init_remap_sets()
 	_setup.g_remappable[i] = 0;
     }
 
-    // all unallocated M-codes > 199 are freely remappable
-    for (i = 200; i < 1000; i++) _setup.m_remappable[i] = 1;
+    // all unallocated M-codes > 100 are freely remappable
+    // range 100-199: a remap takes precedence over an external executable
+    // named M100-M199
+    for (i = 100; i < 1000; i++) _setup.m_remappable[i] = 1;
 
     // in the range 1..99 unused M-codes are remappable
     for (i = 1; i < 100; i++) {


### PR DESCRIPTION
a REMAP=M1xx ... now takes precedence over an external executable
with the same name.

bbot tickle for now - please do not merge yet
