### PR TITLE
hal/drviers/7i90: unbreak loading of the driver

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_7i90.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i90.h
@@ -41,7 +41,7 @@
 
 #define HM2_7I90_ADDR_AUTOINCREMENT (0x8000)
 
-#define HM2_7I90_MAX_BOARDS (4)
+#define HM2_7I90_MAX_BOARDS 4
 
 
 


### PR DESCRIPTION
cpp stringification created an invalid descriptor when using
parentheses