### PR TITLE
Fix metric arc tolerence to same value as imperial

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -561,7 +561,7 @@ int Interp::convert_arc2(int move,       //!< either G_2 (cw arc) or G_3 (ccw ar
   int plane = settings->plane;
 
   tolerance = (settings->length_units == CANON_UNITS_INCHES) ?
-    TOLERANCE_INCH : TOLERANCE_MM;
+	settings->tolerance_inch : settings->tolerance_mm;
 
   if (block->r_flag) {
       CHP(arc_data_r(move, plane, *current1, *current2, end1, end2,
@@ -641,7 +641,8 @@ int Interp::convert_arc_comp1(int move,  //!< either G_2 (cw arc) or G_3 (ccw ar
 
     side = settings->cutter_comp_side;
     tool_radius = settings->cutter_comp_radius;   /* always is positive */
-    tolerance = (settings->length_units == CANON_UNITS_INCHES) ? TOLERANCE_INCH : TOLERANCE_MM;
+    tolerance = (settings->length_units == CANON_UNITS_INCHES) ? 
+	  settings->tolerance_inch : settings->tolerance_mm;  
 
     comp_get_current(settings, &cx, &cy, &cz);
 
@@ -803,7 +804,7 @@ int Interp::convert_arc_comp2(int move,  //!< either G_2 (cw arc) or G_3 (ccw ar
     comp_get_current(settings, &cx, &cy, &cz);
 
     tolerance = (settings->length_units == CANON_UNITS_INCHES) ?
-        TOLERANCE_INCH : TOLERANCE_MM;
+        settings->tolerance_inch : settings->tolerance_mm;
 
     if (block->r_flag) {
         CHP(arc_data_r(move, plane, opx, opy, end_x, end_y,

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -59,8 +59,22 @@
 #define MAX_NESTED_REMAPS 10
 
 /* numerical constants */
-#define TOLERANCE_INCH 0.0005
-#define TOLERANCE_MM 0.005
+
+/*****************************************************************************
+The default tolerance (if none tighter is specified in the ini file) should be 
+2 * 0.001 * sqrt(2) for inch, and 2 * 0.01 * sqrt(2) for mm. 
+This would mean that any valid arc where the endpoints and/or centerpoint 
+got rounded or truncated to 0.001 inch or 0.01 mm precision would be accepted.
+
+Tighter tolerance down to a minimum of 1 micron +- also accepted 
+******************************************************************************/
+
+#define TOLERANCE_INCH 0.0028
+#define TOLERANCE_MM 0.0282
+
+#define MIN_TOLERANCE_INCH 0.00004
+#define MIN_TOLERANCE_MM 0.001
+
 /* angle threshold for concavity for cutter compensation, in radians */
 #define TOLERANCE_CONCAVE_CORNER 0.05  
 #define TOLERANCE_EQUAL 0.0001 /* two numbers compare EQ if the
@@ -663,6 +677,8 @@ typedef struct setup_struct
   FILE *file_pointer;           // file pointer for open NC code file
   bool flood;                 // whether flood coolant is on
   CANON_UNITS length_units;     // millimeters or inches
+  double tolerance_inch;        // modify with ini setting
+  double tolerance_mm;          // modify with ini setting
   int line_length;              // length of line last read
   char linetext[LINELEN];       // text of most recent line read
   bool mist;                  // whether mist coolant is on

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -966,12 +966,50 @@ int Interp::init()
 	      CHP(parse_remap( inistring,  lineno));
 	      n++;
 	  }
+	
+	// if exist and within parameters, apply ini file arc tolerances
+	// limiting figures are defined in interp_internal.hh
+	
+	_setup.tolerance_inch = TOLERANCE_INCH;
+        inifile.Find(&_setup.tolerance_inch, "TOLERANCE_INCH", "RS274NGC");
 
+	if( (_setup.tolerance_inch > TOLERANCE_INCH) || _setup.tolerance_inch < MIN_TOLERANCE_INCH )
+	    {
+	    logDebug("setup.tolerance_inch outside bounds at %f, set to default\n", 
+		_setup.tolerance_inch );
+	    _setup.tolerance_inch = TOLERANCE_INCH;
+	    }
+	logDebug("setup.tolerance_inch set to %f\n", _setup.tolerance_inch ); 
+
+        _setup.tolerance_mm = TOLERANCE_MM;
+	inifile.Find(&_setup.tolerance_mm, "TOLERANCE_MM", "RS274NGC");
+	
+	if( (_setup.tolerance_mm > TOLERANCE_MM) || _setup.tolerance_mm < MIN_TOLERANCE_MM )
+	    {
+	    logDebug("setup.tolerance_mm outside bounds at %f, set to default\n", 
+		_setup.tolerance_mm );
+	    _setup.tolerance_mm = TOLERANCE_MM;
+	    }
+	logDebug("setup.tolerance_mm set to %f\n", _setup.tolerance_mm );         
           // close it
-          inifile.Close();
+        inifile.Close();
       }
   }
-
+    /**************************************************
+    If no ini file is used, as when runtests is called
+    always fail on arcs because tolerance is not set.
+    Ensure tests and any other instance of external 
+    launch of interpreter without ini file pass
+    **************************************************/
+  else
+    {
+    _setup.tolerance_inch = TOLERANCE_INCH;    
+    logDebug("setup.tolerance_inch set to %f\n", _setup.tolerance_inch ); 
+    
+    _setup.tolerance_mm = TOLERANCE_MM;    
+    logDebug("setup.tolerance_mm set to %f\n", _setup.tolerance_mm );             
+    }  
+      
   _setup.length_units = GET_EXTERNAL_LENGTH_UNIT_TYPE();
   USE_LENGTH_UNITS(_setup.length_units);
   GET_EXTERNAL_PARAMETER_FILE_NAME(filename, LINELEN);


### PR DESCRIPTION
Also add an ini file field and allow user variance of arc tolerances
within preset limits
Default tolerance set to figure 2 * 0.001 * sqrt(2) for inch,
and 2 * 0.01 * sqrt(2) for mm.

This would mean that any valid arc where the endpoints and/or
centerpoint got rounded or truncated to 0.001 inch or 0.01 mm
precision would be accepted.

This behavior is the root of the problem with some CAM generated code.

Minimum tolerance capped at 1 micron and equivalent imperial.

Now passes all tests ( 139 of 139 )
Previous problem was solely related to the tests themselves.
Because they invoke the interpreter via bin/rs274 without an ini file, a valid tolerance figure
was not being set - now fixed with default value irrespective of how invoked.

Signed-off-by: Mick Grant<arceye@mgware.co.uk>