### PR TITLE
halcmd: add replacement option to source command

### DIFF
--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -214,7 +214,7 @@ struct halcmd_command halcmd_commands[] = {
     {"show",    FUNCT(do_show_cmd),    A_ONE | A_OPTIONAL | A_PLUS},
     {"shutdown",FUNCT(do_shutdown_cmd), A_ZERO },
     {"sleep",   FUNCT(do_sleep_cmd),  A_ONE },
-    {"source",  FUNCT(do_source_cmd),  A_ONE | A_TILDE },
+    {"source",  FUNCT(do_source_cmd),  A_ONE | A_TILDE | A_PLUS},
     {"start",   FUNCT(do_start_cmd),   A_ZERO},
     {"status",  FUNCT(do_status_cmd),  A_ONE | A_OPTIONAL },
     {"stop",    FUNCT(do_stop_cmd),    A_ZERO},

--- a/src/hal/utils/halcmd.h
+++ b/src/hal/utils/halcmd.h
@@ -94,6 +94,7 @@ extern FILE *halcmd_inifile;
 #define MAX_TOK 20
 #define MAX_CMD_LEN 1024
 #define MAX_EXPECTED_SIGS 999
+#define MAX_REPLACEMENTS 32
 
 extern flavor_ptr current_flavor; // reference to current flavor descriptor
 

--- a/src/hal/utils/halcmd_commands.h
+++ b/src/hal/utils/halcmd_commands.h
@@ -71,7 +71,7 @@ extern int do_ptype_cmd(char *name);
 extern int do_stype_cmd(char *name);
 extern int do_show_cmd(char *type, char **patterns);
 extern int do_list_cmd(char *type, char **patterns);
-extern int do_source_cmd(char *type);
+extern int do_source_cmd(char* type, char* opt[]);
 extern int do_status_cmd(char *type);
 extern int do_delsig_cmd(char *mod_name);
 extern int do_loadrt_cmd(char *mod_name, char *args[]);


### PR DESCRIPTION
This patch adds additional replacement parameters to the source command. It makes reuse of HAL code easier. 

For example: `test2.hal`

    newsig {test}.signal1 float
    newsig {test}.signal2 float

sourced with 

    source test2.hal test=e0
    source test2.hal test=hbp

creates following signals

    Signals:
    Type          Value  Name     (linked to)
    float             0  e0.signal1
    float             0  e0.signal2
    float             0  hbp.signal1
    float             0  hbp.signal2