### PR TITLE
linuxcnc: fixed temporary file creation of include statement and environ...

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -297,7 +297,8 @@ function handle_includes () {
        if [ "X$b" = "X" ] ; then
           msg="$hdr <$line> found #INCLUDE with no filename" >>$outfile
           echo "$msg" >&2
-          echo "$msg" >>$outfile
+          rm -f $outfile
+          return 1 ;# error
        else
           # expand file name
           breal=$(eval echo "$b")
@@ -310,7 +311,8 @@ function handle_includes () {
           else
             msg="$hdr <$line> CANNOT READ $breal"
             echo "$msg" >&2
-            echo "$msg" >>$outfile
+            rm -f $outfile
+            return 1 ;# error
           fi
        fi
     else
@@ -323,6 +325,9 @@ function handle_includes () {
 
 PREVINIFILE=$INIFILE
 INIFILE=$(handle_includes $INIFILE)
+if [ $? -ne 0 ] ; then
+    exit 1 ; # error
+fi
 if [ "$PREVINIFILE" != "$INIFILE" ]; then
     trap "rm -f $INIFILE" 0 1 2 3 15; # Clean up the temporary file
 fi

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -327,6 +327,26 @@ if [ "$PREVINIFILE" != "$INIFILE" ]; then
     trap "rm -f $INIFILE" 0 1 2 3 15; # Clean up the temporary file
 fi
 
+function handle_env () {
+    inifile=$1
+    outfile=`mktemp`; # Let the shell create a temporary file
+    echo -e "$(eval "echo -e \"`<$inifile`\"")" >> $outfile
+    cmp --silent $inifile $outfile
+    if [ $? -ne 0 ] ; then
+        echo $outfile ;# use the expanded file
+    else
+        rm -f $outfile 
+        echo $inifile ;# use the original file
+    fi
+    return 0 ;# ok
+}
+
+PREVINIFILE=$INIFILE
+INIFILE=$(handle_env $INIFILE)
+if [ "$PREVINIFILE" != "$INIFILE" ]; then
+    trap "rm -f $INIFILE" 0 1 2 3 15; # Clean up the temporary file
+fi
+
 export PATH=$CONFIG_DIR/bin:$PATH
 
 [ -z $RUNTESTS ] && echo "Machine configuration directory is '$INI_DIR'"

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -268,6 +268,12 @@ if [ ! -n "$INIFILE" ] ; then
     exit 0
 fi
 
+# delete directories from path, save name only
+INI_NAME="${INIFILE##*/}"
+INI_DIR="${INIFILE%/*}"
+CONFIG_DIR="${INIFILE%/*}"
+export CONFIG_DIR
+
 function handle_includes () {
   hdr="# handle_includes():"
   inifile=$1 
@@ -278,7 +284,7 @@ function handle_includes () {
     echo "$inifile" ;# just use the input
     return 0 ;# ok
   fi
-  outfile=$(dirname $inifile)/$(basename $inifile).expanded
+  outfile=`mktemp`; # Let the shell create a temporary file
   >|$outfile
   echo "#*** $outfile" >>$outfile
   echo "#*** Created: $(date)" >>$outfile
@@ -315,13 +321,11 @@ function handle_includes () {
   return 0 ;# ok
 }
 
+PREVINIFILE=$INIFILE
 INIFILE=$(handle_includes $INIFILE)
-
-# delete directories from path, save name only
-INI_NAME="${INIFILE##*/}"
-INI_DIR="${INIFILE%/*}"
-CONFIG_DIR="${INIFILE%/*}"
-export CONFIG_DIR
+if [ "$PREVINIFILE" != "$INIFILE" ]; then
+    trap "rm -f $INIFILE" 0 1 2 3 15; # Clean up the temporary file
+fi
 
 export PATH=$CONFIG_DIR/bin:$PATH
 


### PR DESCRIPTION
...ment variable replacement

The handle_includes function created a temporary file named <inifilename>.expanded in the ini file path. This does not work if the ini file is located in a place the user has no write access (e.g. using packages). Therefore using this patch a temporary file is created for this purpose. The file also trapped and will be correctly deleted when the linuxcnc script is exit.

Furthermore, the patch adds replacement of environment variables when reading the ini file. This makes possible to use e.g. EMC2_HOME to point to directories independent of the system. Cleanup is done in the same way as with the handle_includes function.