### PR TITLE
machinekit/launcher: fixed unchecked exit when started process fails

### DIFF
--- a/lib/python/machinekit/launcher.py
+++ b/lib/python/machinekit/launcher.py
@@ -56,15 +56,16 @@ def cleanup_session():
 
 
 # starts and registers a process
-def start_process(command):
+def start_process(command, check=True, wait=1.0):
     sys.stdout.write("starting " + command.split(None, 1)[0] + "... ")
     sys.stdout.flush()
     process = subprocess.Popen(command, shell=True)
-    sleep(1)
-    process.poll()
-    if (process.returncode is not None):
-        sys.exit(1)
     process.command = command
+    if check:
+        sleep(wait)
+        process.poll()
+        if (process.returncode is not None):
+            raise subprocess.CalledProcessError(process.returncode, command, None)
     _processes.append(process)
     sys.stdout.write('done\n')
 


### PR DESCRIPTION
This bug prevented correct cleanup in case linuxcnc or other started processes fail on start-up. A error is now raised to make handling possible,