### PR TITLE
Revert "linuxcnc: added environment variable replacement for ini files"

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -332,26 +332,6 @@ if [ "$PREVINIFILE" != "$INIFILE" ]; then
     trap "rm -f $INIFILE" 0 1 2 3 15; # Clean up the temporary file
 fi
 
-function handle_env () {
-    inifile=$1
-    outfile=`mktemp`; # Let the shell create a temporary file
-    echo -e "$(eval "echo -e \"`<$inifile`\"")" >> $outfile
-    cmp --silent $inifile $outfile
-    if [ $? -ne 0 ] ; then
-        echo $outfile ;# use the expanded file
-    else
-        rm -f $outfile 
-        echo $inifile ;# use the original file
-    fi
-    return 0 ;# ok
-}
-
-PREVINIFILE=$INIFILE
-INIFILE=$(handle_env $INIFILE)
-if [ "$PREVINIFILE" != "$INIFILE" ]; then
-    trap "rm -f $INIFILE" 0 1 2 3 15; # Clean up the temporary file
-fi
-
 export PATH=$CONFIG_DIR/bin:$PATH
 
 [ -z $RUNTESTS ] && echo "Machine configuration directory is '$INI_DIR'"


### PR DESCRIPTION
This reverts commit d337feba8e2a2d2f8143fa0b6f7fefa92634c2c4.

This patch partially reverts https://github.com/machinekit/machinekit/pull/424. Environment variable replacement should not be done in the linuxcnc script. In fact the patch affected all linuxcnc instances as eval does not only replace environment variables but also local variables and quote marks.