### PR TITLE
debian: Use invoke-rc.d in machinekit.postinst

### DIFF
--- a/debian/machinekit.postinst
+++ b/debian/machinekit.postinst
@@ -19,4 +19,4 @@ touch /var/log/linuxcnc.log
 chmod ugo+r /var/log/linuxcnc.log
 
 # restart the rsyslogd to start logging to /var/log/linuxcnc.conf 
-service rsyslog restart
+invoke-rc.d rsyslog restart


### PR DESCRIPTION
Follow Debian policy and use invoke-rc.d to trigger rsyslogd restart
Resolves machinekit/machinekit#447

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>