### PR TITLE
Bug fix - pyvcp_widgets

### DIFF
--- a/lib/python/pyvcp_widgets.py
+++ b/lib/python/pyvcp_widgets.py
@@ -614,6 +614,7 @@ class pyvcp_radiobutton(Frame):
             n+=1
 
         self.selected = initval
+        pycomp[self.halpins[initval]]=1 
 
 
 ## ArcEye - FIXED - only update the pins if changed  ##


### PR DESCRIPTION
Bug in radio button widgets

initval field setting the correct widget to active at initialisation, but changes to prevent
unnecessary updates supressing initial setting of associated pin to match.

Explicitly setting pin associated with active button selection via initval at initialisation corrects this.