### PR TITLE
Add IO to motion output  pins

### DIFF
--- a/man/man9/motion.9
+++ b/man/man9/motion.9
@@ -105,6 +105,10 @@ These pins are used by M66 Enn wait-for-input mode.
 These pins are used by M67-68.
 
 .TP
+\fBmotion.analog-out-io-\fINN\fR OUT FLOAT 
+Same as \fBmotion.analog-out-\fINN\fR, compatible with I/O signals.
+
+.TP
 \fBmotion.coord-error\fR OUT BIT 
 TRUE when motion has encountered an error, such as exceeding a soft limit
 
@@ -123,6 +127,10 @@ These pins are used by M66 Pnn wait-for-input mode.
 .TP
 \fBmotion.digital-out-\fINN\fR OUT BIT 
 These pins are controlled by the M62 through M65 words.
+
+.TP
+\fBmotion.digital-out-io-\fINN\fR OUT BIT 
+Same as \fBmotion.digital-out-\fINN\fR, compatible with I/O signals.
 
 .TP
 \fBmotion.distance-to-go\fR OUT FLOAT

--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -309,8 +309,10 @@ void emcmotDioWrite(int index, char value)
     } else {
 	if (value != 0) {
 	    *(emcmot_hal_data->synch_do[index])=1;
+        *(emcmot_hal_data->synch_dio[index])=1;
 	} else {
 	    *(emcmot_hal_data->synch_do[index])=0;
+        *(emcmot_hal_data->synch_dio[index])=0;
 	}
     }
 }
@@ -330,6 +332,7 @@ void emcmotAioWrite(int index, double value)
 	rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: index out of range, %d not in [0..%d] (increase num_aio/EMCMOT_MAX_AIO=%d)\n", index, num_aio, EMCMOT_MAX_AIO);
     } else {
         *(emcmot_hal_data->analog_output[index]) = value;
+        *(emcmot_hal_data->analog_io[index]) = value;
     }
 }
 

--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -309,10 +309,10 @@ void emcmotDioWrite(int index, char value)
     } else {
 	if (value != 0) {
 	    *(emcmot_hal_data->synch_do[index])=1;
-        *(emcmot_hal_data->synch_dio[index])=1;
+        *(emcmot_hal_data->synch_do_io[index])=1;
 	} else {
 	    *(emcmot_hal_data->synch_do[index])=0;
-        *(emcmot_hal_data->synch_dio[index])=0;
+        *(emcmot_hal_data->synch_do_io[index])=0;
 	}
     }
 }
@@ -332,7 +332,7 @@ void emcmotAioWrite(int index, double value)
 	rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: index out of range, %d not in [0..%d] (increase num_aio/EMCMOT_MAX_AIO=%d)\n", index, num_aio, EMCMOT_MAX_AIO);
     } else {
         *(emcmot_hal_data->analog_output[index]) = value;
-        *(emcmot_hal_data->analog_io[index]) = value;
+        *(emcmot_hal_data->analog_output_io[index]) = value;
     }
 }
 

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -119,10 +119,10 @@ typedef struct {
     
     hal_bit_t *synch_do[EMCMOT_MAX_DIO]; /* WPI array: output pins for motion synched IO */
     hal_bit_t *synch_di[EMCMOT_MAX_DIO]; /* RPI array: input pins for motion synched IO */
-    hal_bit_t *synch_dio[EMCMOT_MAX_DIO]; /* RPI array: IO pins for motion synched IO */
+    hal_bit_t *synch_do_io[EMCMOT_MAX_DIO]; /* RPI array: output io pins for motion synched IO */
     hal_float_t *analog_input[EMCMOT_MAX_AIO]; /* RPI array: input pins for analog Inputs */
     hal_float_t *analog_output[EMCMOT_MAX_AIO]; /* RPI array: output pins for analog Inputs */
-    hal_float_t *analog_io[EMCMOT_MAX_AIO]; /* RPI array: IO pins for analog Inputs */
+    hal_float_t *analog_output_io[EMCMOT_MAX_AIO]; /* RPI array: output io pins for analog Inputs */
 
 
     // creating a lot of pins for spindle control to be very flexible

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -119,8 +119,10 @@ typedef struct {
     
     hal_bit_t *synch_do[EMCMOT_MAX_DIO]; /* WPI array: output pins for motion synched IO */
     hal_bit_t *synch_di[EMCMOT_MAX_DIO]; /* RPI array: input pins for motion synched IO */
+    hal_bit_t *synch_dio[EMCMOT_MAX_DIO]; /* RPI array: IO pins for motion synched IO */
     hal_float_t *analog_input[EMCMOT_MAX_AIO]; /* RPI array: input pins for analog Inputs */
     hal_float_t *analog_output[EMCMOT_MAX_AIO]; /* RPI array: output pins for analog Inputs */
+    hal_float_t *analog_io[EMCMOT_MAX_AIO]; /* RPI array: IO pins for analog Inputs */
 
 
     // creating a lot of pins for spindle control to be very flexible

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -356,18 +356,21 @@ static int init_hal_io(void)
     if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->enable), mot_comp_id, "motion.enable")) < 0) goto error;
 
     /* export motion-synched digital output pins */
+    /* export motion-synched digital output io pins for compatibility with io signals */
     /* export motion digital input pins */
     for (n = 0; n < num_dio; n++) {
 	if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.digital-out-%02d", n)) < 0) goto error;
 	if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_di[n]), mot_comp_id, "motion.digital-in-%02d", n)) < 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_IO, &(emcmot_hal_data->synch_dio[n]), mot_comp_id, "motion.digital-io-%02d", n)) < 0) goto error;
+    if ((retval = hal_pin_bit_newf(HAL_IO, &(emcmot_hal_data->synch_do_io[n]), mot_comp_id, "motion.digital-out-io-%02d", n)) < 0) goto error;
     }
 
+    /* export motion-synched analog output pins */
+    /* export motion-synched analog output io pins for compatibility with io signals */
     /* export motion analog input pins */
     for (n = 0; n < num_aio; n++) {
 	if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->analog_output[n]), mot_comp_id, "motion.analog-out-%02d", n)) < 0) goto error;
 	if ((retval = hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->analog_input[n]), mot_comp_id, "motion.analog-in-%02d", n)) < 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_IO, &(emcmot_hal_data->analog_io[n]), mot_comp_id, "motion.analog-io-%02d", n)) < 0) goto error;
+    if ((retval = hal_pin_float_newf(HAL_IO, &(emcmot_hal_data->analog_output_io[n]), mot_comp_id, "motion.analog-out-io-%02d", n)) < 0) goto error;
     }
 
     /* export machine wide hal parameters */
@@ -630,13 +633,13 @@ static int init_hal_io(void)
     for (n = 0; n < num_dio; n++) {
 	 *(emcmot_hal_data->synch_do[n]) = 0;
 	 *(emcmot_hal_data->synch_di[n]) = 0;
-     *(emcmot_hal_data->synch_dio[n]) = 0;
+     *(emcmot_hal_data->synch_do_io[n]) = 0;
     }
 
     for (n = 0; n < num_aio; n++) {
 	 *(emcmot_hal_data->analog_output[n]) = 0.0;
 	 *(emcmot_hal_data->analog_input[n]) = 0.0;
-     *(emcmot_hal_data->analog_io[n]) = 0.0;
+     *(emcmot_hal_data->analog_output_io[n]) = 0.0;
     }
     
     /*! \todo FIXME - these don't really need initialized, since they are written

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -360,12 +360,14 @@ static int init_hal_io(void)
     for (n = 0; n < num_dio; n++) {
 	if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.digital-out-%02d", n)) < 0) goto error;
 	if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_di[n]), mot_comp_id, "motion.digital-in-%02d", n)) < 0) goto error;
+    if ((retval = hal_pin_bit_newf(HAL_IO, &(emcmot_hal_data->synch_dio[n]), mot_comp_id, "motion.digital-io-%02d", n)) < 0) goto error;
     }
 
     /* export motion analog input pins */
     for (n = 0; n < num_aio; n++) {
 	if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->analog_output[n]), mot_comp_id, "motion.analog-out-%02d", n)) < 0) goto error;
 	if ((retval = hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->analog_input[n]), mot_comp_id, "motion.analog-in-%02d", n)) < 0) goto error;
+    if ((retval = hal_pin_float_newf(HAL_IO, &(emcmot_hal_data->analog_io[n]), mot_comp_id, "motion.analog-io-%02d", n)) < 0) goto error;
     }
 
     /* export machine wide hal parameters */
@@ -628,11 +630,13 @@ static int init_hal_io(void)
     for (n = 0; n < num_dio; n++) {
 	 *(emcmot_hal_data->synch_do[n]) = 0;
 	 *(emcmot_hal_data->synch_di[n]) = 0;
+     *(emcmot_hal_data->synch_dio[n]) = 0;
     }
 
     for (n = 0; n < num_aio; n++) {
 	 *(emcmot_hal_data->analog_output[n]) = 0.0;
 	 *(emcmot_hal_data->analog_input[n]) = 0.0;
+     *(emcmot_hal_data->analog_io[n]) = 0.0;
     }
     
     /*! \todo FIXME - these don't really need initialized, since they are written


### PR DESCRIPTION
Fix for the motion IO pin issue: https://github.com/machinekit/machinekit/issues/451

Uses a similar approach to fix the problem that outputs are driving a signal as the out-io pin of the lincurve component: https://github.com/machinekit/machinekit-man/blob/master/man9comp/lincurve.9comp.asciidoc#pins