### PR TITLE
TP fix missing typecasts for I/O mask registers

### DIFF
--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -255,7 +255,7 @@ extern int num_joints;
    but can be altered at motmod insmod time */
 extern int num_dio;
 
-/* userdefined number of analog IO. default is 4. (EMCMOT_MAX_AIO=16), 
+/* userdefined number of analog IO. default is 4. (EMCMOT_MAX_AIO=64), 
    but can be altered at motmod insmod time */
 extern int num_aio;
 

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -363,8 +363,8 @@ int tpClearDIOs(TP_STRUCT * const tp) {
     //XXX: All IO's will be flushed on next synced aio/dio! Is it ok?
     int i;
     tp->syncdio.anychanged = 0;
-    tp->syncdio.dio_mask = 0;
-    tp->syncdio.aio_mask = 0;
+    tp->syncdio.dio_mask = 0ull;
+    tp->syncdio.aio_mask = 0ull;
     for (i = 0; i < num_dio; i++) {
         tp->syncdio.dios[i] = 0;
     }
@@ -2124,12 +2124,12 @@ void tpToggleDIOs(TC_STRUCT * const tc) {
     int i=0;
     if (tc->syncdio.anychanged != 0) { // we have DIO's to turn on or off
         for (i=0; i < num_dio; i++) {
-            if (!(tc->syncdio.dio_mask & (1 << i))) continue;
+            if (!(tc->syncdio.dio_mask & (1ull << i))) continue;
             if (tc->syncdio.dios[i] > 0) emcmotDioWrite(i, 1); // turn DIO[i] on
             if (tc->syncdio.dios[i] < 0) emcmotDioWrite(i, 0); // turn DIO[i] off
         }
         for (i=0; i < num_aio; i++) {
-            if (!(tc->syncdio.aio_mask & (1 << i))) continue;
+            if (!(tc->syncdio.aio_mask & (1ull << i))) continue;
             emcmotAioWrite(i, tc->syncdio.aios[i]); // set AIO[i]
         }
         tc->syncdio.anychanged = 0; //we have turned them all on/off, nothing else to do for this TC the next time
@@ -3166,7 +3166,7 @@ int tpSetAout(TP_STRUCT * const tp, unsigned char index, double start, double en
         return TP_ERR_FAIL;
     }
     tp->syncdio.anychanged = 1; //something has changed
-    tp->syncdio.aio_mask |= (1 << index);
+    tp->syncdio.aio_mask |= (1ull << index);
     tp->syncdio.aios[index] = start;
     return TP_ERR_OK;
 }
@@ -3176,7 +3176,7 @@ int tpSetDout(TP_STRUCT * const tp, int index, unsigned char start, unsigned cha
         return TP_ERR_FAIL;
     }
     tp->syncdio.anychanged = 1; //something has changed
-    tp->syncdio.dio_mask |= (1 << index);
+    tp->syncdio.dio_mask |= (1ull << index);
     if (start > 0)
         tp->syncdio.dios[index] = 1; // the end value can't be set from canon currently, and has the same value as start
     else


### PR DESCRIPTION
fixes https://github.com/machinekit/machinekit/issues/467

On 32bit systems the default number data type is a 32bit integer. Therefore, shifting such a number more than 31 bits to the left does not work correctly. For such machines it is necessary to explicitely specify the data type of the number. In this case `ull` for unsigned long long which is a 64bit unsigned integer and matches the data type of the mask registers.