### PR TITLE
emc/rs274ngc/previewmodule: added missing UPDATE_TAG

### DIFF
--- a/src/emc/rs274ngc/previewmodule.cc
+++ b/src/emc/rs274ngc/previewmodule.cc
@@ -687,6 +687,7 @@ void PROGRAM_END() {}
 void FINISH() {}
 void PALLET_SHUTTLE() {}
 void SELECT_POCKET(int pocket, int tool) {}
+void UPDATE_TAG(StateTag tag) {}
 void OPTIONAL_PROGRAM_STOP() {}
 void START_CHANGE() {}
 int  GET_EXTERNAL_TC_FAULT() {return 0;}


### PR DESCRIPTION
fixes a problem in the previemodule introduced by https://github.com/machinekit/machinekit/pull/472