### PR TITLE
Vtable tp and kins try3

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper.hal
@@ -18,7 +18,9 @@ loadusr -w ./setup.bridge.sh
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,224,226 input_pins=108,109,110,114,117,118

--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/lineardelta.hal
@@ -22,7 +22,9 @@ setp lineardeltakins.L [MACHINE]CF_ROD
 setp lineardeltakins.R [MACHINE]DELTA_R
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=lineardeltakins
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,224,226 input_pins=108,109,110,114,117,118

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/BeBoPr++.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/BeBoPr++.hal
@@ -18,7 +18,9 @@ loadusr -w ./setup.bridge.sh
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 
 # load low-level drivers

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.hal
@@ -22,7 +22,9 @@ setp lineardeltakins.L [MACHINE]CF_ROD
 setp lineardeltakins.R [MACHINE]DELTA_R
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=lineardeltakins
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
@@ -18,7 +18,9 @@ loadusr -w ./setup.bridge.sh
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 
 # load low-level drivers
@@ -47,7 +49,7 @@ addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
 addf [PRUCONF](DRIVER).update             servo-thread
 addf bb_gpio.write                        servo-thread
-       
+
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -62,7 +64,7 @@ addf bb_gpio.write                        servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
 
 
@@ -101,7 +103,7 @@ setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
 
 
@@ -140,7 +142,7 @@ setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x4F
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
 
 
@@ -179,7 +181,7 @@ setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x51
 newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
-net emcmot.03.enable <= axis.3.amp-enable-out 
+net emcmot.03.enable <= axis.3.amp-enable-out
 net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
 
 
@@ -300,23 +302,23 @@ setp limit1.1.min 0
 
 # PID Parameters for adjusting temperature control
 # Extruder
-#setp pid.0.FF0      0  
-#setp pid.0.FF1      0  
-#setp pid.0.FF2      0  
+#setp pid.0.FF0      0
+#setp pid.0.FF1      0
+#setp pid.0.FF2      0
 setp pid.0.Pgain  0.30
 setp pid.0.Igain  0.00001
 setp pid.0.Dgain  0.9375
 setp pid.0.maxerrorI 1.0
-setp pid.0.bias    0.5  
+setp pid.0.bias    0.5
 setp pid.0.enable   1
 
 # Bed
-#setp pid.1.FF0      0  
-#setp pid.1.FF1      0  
-#setp pid.1.FF2      0  
+#setp pid.1.FF0      0
+#setp pid.1.FF1      0
+#setp pid.1.FF2      0
 setp pid.1.Pgain  1
 setp pid.1.Igain  0.0
 setp pid.1.Dgain  0.0
 setp pid.1.maxerrorI 1.0
-setp pid.1.bias    0.5  
+setp pid.1.bias    0.5
 setp pid.1.enable   1

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
@@ -16,14 +16,16 @@ loadusr -w ./setup.bridge.sh
 
 # kinematics
 #loadrt trivkins
-loadrt lineardeltakins 
+loadrt lineardeltakins
 
 # settings for delta printer
 setp lineardeltakins.L [MACHINE]CF_ROD
 setp lineardeltakins.R [MACHINE]DELTA_R
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=lineardeltakins
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
@@ -60,7 +62,7 @@ addf bb_gpio.write                        servo-thread
 addf wcomp.0                              servo-thread
 addf sum2.0                               servo-thread
 addf sum2.1                               servo-thread
-       
+
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -75,7 +77,7 @@ addf sum2.1                               servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
 
 
@@ -108,7 +110,7 @@ setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
 # because column C is connected to the X-axis output
 # the bebopr-bridge signal needs to be X-max means P8.9
 net home-x bb_gpio.p8.in-09 => axis.0.home-sw-in
-setp bb_gpio.p8.in-09.invert 1 
+setp bb_gpio.p8.in-09.invert 1
 
 # ################
 # Y [1] Axis = column A
@@ -118,7 +120,7 @@ setp bb_gpio.p8.in-09.invert 1
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
 
 
@@ -162,7 +164,7 @@ setp bb_gpio.p8.in-14.invert 1
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
 
 
@@ -205,7 +207,7 @@ setp bb_gpio.p8.in-18.invert 1
 newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
-net emcmot.03.enable <= axis.3.amp-enable-out 
+net emcmot.03.enable <= axis.3.amp-enable-out
 net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
 
 
@@ -361,23 +363,23 @@ setp limit1.1.min 0
 
 # PID Parameters for adjusting temperature control
 # Extruder
-#setp pid.0.FF0      0  
-#setp pid.0.FF1      0  
-#setp pid.0.FF2      0  
+#setp pid.0.FF0      0
+#setp pid.0.FF1      0
+#setp pid.0.FF2      0
 setp pid.0.Pgain  0.30
 setp pid.0.Igain  0.00001
 setp pid.0.Dgain  0.9375
 setp pid.0.maxerrorI 1.0
-setp pid.0.bias    0.5  
+setp pid.0.bias    0.5
 setp pid.0.enable   1
 
 # Bed
-#setp pid.1.FF0      0  
-#setp pid.1.FF1      0  
-#setp pid.1.FF2      0  
+#setp pid.1.FF0      0
+#setp pid.1.FF1      0
+#setp pid.1.FF2      0
 setp pid.1.Pgain  1
 setp pid.1.Igain  0.0
 setp pid.1.Dgain  0.0
 setp pid.1.maxerrorI 1.0
-setp pid.1.bias    0.5  
+setp pid.1.bias    0.5
 setp pid.1.enable   1

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.hal
@@ -17,14 +17,16 @@ loadusr -w ../setup.bridge.sh
 
 # kinematics
 #loadrt trivkins
-loadrt lineardeltakins 
+loadrt lineardeltakins
 
 # settings for delta printer
 setp lineardeltakins.L [MACHINE]CF_ROD
 setp lineardeltakins.R [MACHINE]DELTA_R
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES num_aio=5
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES num_aio=5 tp=tp kins=lineardeltakins
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
@@ -72,7 +74,7 @@ addf wcomp.0                              servo-thread
 addf sum2.0                               servo-thread
 addf sum2.1                               servo-thread
 addf sum2.2				  servo-thread
-addf sum2.3				  servo-thread					  
+addf sum2.3				  servo-thread
 addf mult2.0                              servo-thread
 addf mult2.1				  servo-thread
 addf mult2.2				  servo-thread
@@ -108,7 +110,7 @@ addf lineardeltajointscartesian.0	  servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
 
 
@@ -141,7 +143,7 @@ setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
 # because column C is connected to the X-axis output
 # the bebopr-bridge signal needs to be X-max means P8.9
 net home-x bb_gpio.p8.in-09 => axis.0.home-sw-in
-setp bb_gpio.p8.in-09.invert 1 
+setp bb_gpio.p8.in-09.invert 1
 
 # ################
 # Y [1] Axis = column A
@@ -151,7 +153,7 @@ setp bb_gpio.p8.in-09.invert 1
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
 
 
@@ -195,7 +197,7 @@ setp bb_gpio.p8.in-14.invert 1
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
 
 
@@ -492,23 +494,23 @@ setp limit1.1.min 0
 
 # PID Parameters for adjusting temperature control
 # Extruder
-#setp pid.0.FF0      0  
-#setp pid.0.FF1      0  
-#setp pid.0.FF2      0  
+#setp pid.0.FF0      0
+#setp pid.0.FF1      0
+#setp pid.0.FF2      0
 setp pid.0.Pgain  0.30
 setp pid.0.Igain  0.00001
 setp pid.0.Dgain  0.9375
 setp pid.0.maxerrorI 1.0
-setp pid.0.bias    0.5  
+setp pid.0.bias    0.5
 setp pid.0.enable   1
 
 # Bed
-#setp pid.1.FF0      0  
-#setp pid.1.FF1      0  
-#setp pid.1.FF2      0  
+#setp pid.1.FF0      0
+#setp pid.1.FF1      0
+#setp pid.1.FF2      0
 setp pid.1.Pgain  1
 setp pid.1.Igain  0.0
 setp pid.1.Dgain  0.0
 setp pid.1.maxerrorI 1.0
-setp pid.1.bias    0.5  
+setp pid.1.bias    0.5
 setp pid.1.enable   1

--- a/configs/ARM/BeagleBone/BeBoPr/BeBoPr.hal
+++ b/configs/ARM/BeagleBone/BeBoPr/BeBoPr.hal
@@ -18,7 +18,9 @@ loadusr -w ./setup.sh
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 
 # load low-level drivers
@@ -47,7 +49,7 @@ addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
 addf [PRUCONF](DRIVER).update             servo-thread
 addf bb_gpio.write                        servo-thread
-       
+
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -62,7 +64,7 @@ addf bb_gpio.write                        servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
 
 
@@ -101,7 +103,7 @@ setp [PRUCONF](DRIVER).stepgen.00.dirpin          0xA3
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
 
 
@@ -140,7 +142,7 @@ setp [PRUCONF](DRIVER).stepgen.01.dirpin          0xA6
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
 
 
@@ -179,7 +181,7 @@ setp [PRUCONF](DRIVER).stepgen.02.dirpin          0xA9
 newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
-net emcmot.03.enable <= axis.3.amp-enable-out 
+net emcmot.03.enable <= axis.3.amp-enable-out
 net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
 
 
@@ -231,7 +233,7 @@ setp bb_gpio.p8.out-28.invert 1
 net emcmot.03.enable => bb_gpio.p8.out-20
 setp bb_gpio.p8.out-20.invert 1
 
-# Machine power (BeBoPr Enable) 
+# Machine power (BeBoPr Enable)
 net estop-loop => bb_gpio.p8.out-03
 net estop-loop => bb_gpio.p8.out-05
 setp bb_gpio.p8.out-05.invert 1
@@ -305,23 +307,23 @@ setp limit1.1.min 0
 
 # PID Parameters for adjusting temperature control
 # Extruder
-#setp pid.0.FF0      0  
-#setp pid.0.FF1      0  
-#setp pid.0.FF2      0  
+#setp pid.0.FF0      0
+#setp pid.0.FF1      0
+#setp pid.0.FF2      0
 setp pid.0.Pgain  0.30
 setp pid.0.Igain  0.00001
 setp pid.0.Dgain  0.9375
 setp pid.0.maxerrorI 1.0
-setp pid.0.bias    0.5  
+setp pid.0.bias    0.5
 setp pid.0.enable   1
 
 # Bed
-#setp pid.1.FF0      0  
-#setp pid.1.FF1      0  
-#setp pid.1.FF2      0  
+#setp pid.1.FF0      0
+#setp pid.1.FF1      0
+#setp pid.1.FF2      0
 setp pid.1.Pgain  1
 setp pid.1.Igain  0.0
 setp pid.1.Dgain  0.0
 setp pid.1.maxerrorI 1.0
-setp pid.1.bias    0.5  
+setp pid.1.bias    0.5
 setp pid.1.enable   1

--- a/configs/ARM/BeagleBone/CRAMPS/CRAMPS.hal
+++ b/configs/ARM/BeagleBone/CRAMPS/CRAMPS.hal
@@ -18,7 +18,9 @@ loadusr -w ./setup.sh
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 
 # load low-level drivers
@@ -46,7 +48,7 @@ addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
 addf hpg.update             servo-thread
 addf bb_gpio.write                        servo-thread
-       
+
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -61,7 +63,7 @@ addf bb_gpio.write                        servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => hpg.stepgen.00.enable
 
 
@@ -100,7 +102,7 @@ setp hpg.stepgen.00.dirpin         812
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => hpg.stepgen.01.enable
 
 
@@ -139,7 +141,7 @@ setp hpg.stepgen.01.dirpin         814
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => hpg.stepgen.02.enable
 
 
@@ -178,7 +180,7 @@ setp hpg.stepgen.02.dirpin         818
 newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
-net emcmot.03.enable <= axis.3.amp-enable-out 
+net emcmot.03.enable <= axis.3.amp-enable-out
 net emcmot.03.enable => hpg.stepgen.03.enable
 
 
@@ -280,7 +282,7 @@ setp bb_gpio.p9.in-13.invert 1
 # ################
 
 # There is currently no driver to generate pulses for actual
-# radio-control style servos, but the buffered 5V output 
+# radio-control style servos, but the buffered 5V output
 # signals can be used as GPIO
 
 # !!! WARNING !!!
@@ -393,23 +395,23 @@ setp limit1.1.min 0
 
 # PID Parameters for adjusting temperature control
 # Extruder
-#setp pid.0.FF0      0  
-#setp pid.0.FF1      0  
-#setp pid.0.FF2      0  
+#setp pid.0.FF0      0
+#setp pid.0.FF1      0
+#setp pid.0.FF2      0
 setp pid.0.Pgain  0.30
 setp pid.0.Igain  0.00001
 setp pid.0.Dgain  0.9375
 setp pid.0.maxerrorI 1.0
-setp pid.0.bias    0.5  
+setp pid.0.bias    0.5
 setp pid.0.enable   1
 
 # Bed
-#setp pid.1.FF0      0  
-#setp pid.1.FF1      0  
-#setp pid.1.FF2      0  
+#setp pid.1.FF0      0
+#setp pid.1.FF1      0
+#setp pid.1.FF2      0
 setp pid.1.Pgain  1
 setp pid.1.Igain  0.0
 setp pid.1.Dgain  0.0
 setp pid.1.maxerrorI 1.0
-setp pid.1.bias    0.5  
+setp pid.1.bias    0.5
 setp pid.1.enable   1

--- a/configs/ARM/BeagleBone/PMDX-432/Shapeoko/Shapeoko.hal
+++ b/configs/ARM/BeagleBone/PMDX-432/Shapeoko/Shapeoko.hal
@@ -35,7 +35,9 @@ loadusr -w ./setup.Shapeoko.sh
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 
 # load low-level drivers
@@ -55,10 +57,10 @@ addf [PRUCONF](DRIVER).capture-position   servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
-# revel in the free time here from not having to run PID 
+# revel in the free time here from not having to run PID
 addf [PRUCONF](DRIVER).update             servo-thread
 addf bb_gpio.write                        servo-thread
-       
+
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -73,7 +75,7 @@ addf bb_gpio.write                        servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
 
 
@@ -112,7 +114,7 @@ setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x8F
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
 
 
@@ -151,7 +153,7 @@ setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x91
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
 
 # position command and feedback
@@ -189,7 +191,7 @@ setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x93
 newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
-net emcmot.03.enable <= axis.3.amp-enable-out 
+net emcmot.03.enable <= axis.3.amp-enable-out
 net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
 
 

--- a/configs/ARM/BeagleBone/PMDX-432/Standard-Configs/K9-Generic.hal
+++ b/configs/ARM/BeagleBone/PMDX-432/Standard-Configs/K9-Generic.hal
@@ -35,7 +35,9 @@ loadusr -w ./setup.K9-DTO.sh
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 
 # load low-level drivers
@@ -55,10 +57,10 @@ addf [PRUCONF](DRIVER).capture-position   servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
-# revel in the free time here from not having to run PID 
+# revel in the free time here from not having to run PID
 addf [PRUCONF](DRIVER).update             servo-thread
 addf bb_gpio.write                        servo-thread
-       
+
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -73,7 +75,7 @@ addf bb_gpio.write                        servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
 
 
@@ -112,7 +114,7 @@ setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x8F
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
 
 
@@ -151,7 +153,7 @@ setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x91
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
 
 # position command and feedback
@@ -189,7 +191,7 @@ setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x93
 newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
-net emcmot.03.enable <= axis.3.amp-enable-out 
+net emcmot.03.enable <= axis.3.amp-enable-out
 net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
 
 

--- a/configs/ARM/BeagleBone/PocketNC/PocketNC.hal
+++ b/configs/ARM/BeagleBone/PocketNC/PocketNC.hal
@@ -18,7 +18,9 @@ loadusr -w /home/machinekit/machinekit-dev/configs/ARM/BeagleBone/PocketNC/setup
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 
 # load low-level drivers
@@ -92,7 +94,7 @@ addf not.7							servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
 
 
@@ -131,7 +133,7 @@ setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
 
 
@@ -170,7 +172,7 @@ setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x4F
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
 
 
@@ -209,7 +211,7 @@ setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x51
 newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
-net emcmot.03.enable <= axis.3.amp-enable-out 
+net emcmot.03.enable <= axis.3.amp-enable-out
 net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
 
 
@@ -256,7 +258,7 @@ setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x91
 newsig emcmot.04.enable bit
 sets emcmot.04.enable FALSE
 
-net emcmot.04.enable <= axis.4.amp-enable-out 
+net emcmot.04.enable <= axis.4.amp-enable-out
 net emcmot.04.enable => [PRUCONF](DRIVER).stepgen.04.enable
 
 
@@ -302,9 +304,9 @@ net tool-prep-loop iocontrol.0.tool-prepare => iocontrol.0.tool-prepared
 net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
 
 # Axis enable signals
-#net emcmot.00.enable => bb_gpio.p9.out-18 
+#net emcmot.00.enable => bb_gpio.p9.out-18
 #setp bb_gpio.p9.out-18.invert 1
-#net emcmot.01.enable => bb_gpio.p9.out-17 
+#net emcmot.01.enable => bb_gpio.p9.out-17
 #setp bb_gpio.p9.out-17.invert 1
 #net emcmot.02.enable => bb_gpio.p9.out-26 #A-min
 #setp bb_gpio.p9.out-26.invert 1
@@ -407,7 +409,7 @@ net spindleEnable => bb_gpio.p9.out-24
 net spindleDirection <= motion.spindle-forward
 net spindleDirection => bb_gpio.p9.out-11
 net displaySpindleReverseButton <= motion.spindle-reverse
- 
+
 # spindleSpeed is on p8.13
 setp spindleScale.gain 0.005
 setp spindleScale.offset 0.035
@@ -483,23 +485,23 @@ setp limit1.1.min 0
 
 # PID Parameters for adjusting temperature control
 # Extruder
-#setp pid.0.FF0      0  
-#setp pid.0.FF1      0  
-#setp pid.0.FF2      0  
+#setp pid.0.FF0      0
+#setp pid.0.FF1      0
+#setp pid.0.FF2      0
 setp pid.0.Pgain  0.30
 setp pid.0.Igain  0.00001
 setp pid.0.Dgain  0.9375
 setp pid.0.maxerrorI 1.0
-setp pid.0.bias    0.5  
+setp pid.0.bias    0.5
 setp pid.0.enable   1
 
 # Bed
-#setp pid.1.FF0      0  
-#setp pid.1.FF1      0  
-#setp pid.1.FF2      0  
+#setp pid.1.FF0      0
+#setp pid.1.FF1      0
+#setp pid.1.FF2      0
 setp pid.1.Pgain  1
 setp pid.1.Igain  0.0
 setp pid.1.Dgain  0.0
 setp pid.1.maxerrorI 1.0
-setp pid.1.bias    0.5  
+setp pid.1.bias    0.5
 setp pid.1.enable   1

--- a/configs/ARM/BeagleBone/Probotix/Comet.hal
+++ b/configs/ARM/BeagleBone/Probotix/Comet.hal
@@ -5,7 +5,9 @@
 loadusr -w ./setup.sh
 
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 #loadrt probe_parport
 #loadrt hal_parport cfg=0x378
 #setp parport.0.reset-time 5000

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.hal
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.hal
@@ -31,7 +31,9 @@ loadusr -w ./setup.sh
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 
 # load low-level drivers
@@ -199,7 +201,7 @@ setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
 setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
 setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-setp [PRUCONF](DRIVER).stepgen.02.control-type    1 
+setp [PRUCONF](DRIVER).stepgen.02.control-type    1
 setp [PRUCONF](DRIVER).stepgen.02.stepinvert      [AXIS_2]STEP_INVERT
 #setp [PRUCONF](DRIVER).stepgen.02.step_type       0
 setp [PRUCONF](DRIVER).stepgen.02.steppin         0x50

--- a/configs/apps/axis-alterations/core_sim.hal
+++ b/configs/apps/axis-alterations/core_sim.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD  num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD  num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt threads name3=real_servo_thread period3=1000000 fp3=1
 
 # load 6 differentiators (for velocity and accel signals
@@ -37,11 +39,11 @@ net Zpos axis.2.motor-pos-cmd => axis.2.motor-pos-fb ddt.4.in
 # send the position commands thru differentiators to
 # generate velocity and accel signals
 net Xvel ddt.0.out => ddt.1.in hypot.0.in0
-net Xacc <= ddt.1.out 
+net Xacc <= ddt.1.out
 net Yvel ddt.2.out => ddt.3.in hypot.0.in1
-net Yacc <= ddt.3.out 
+net Yacc <= ddt.3.out
 net Zvel ddt.4.out => ddt.5.in hypot.1.in0
-net Zacc <= ddt.5.out 
+net Zacc <= ddt.5.out
 
 # Cartesian 2- and 3-axis velocities
 net XYvel hypot.0.out => hypot.1.in1

--- a/configs/attic/dallur-thc/dallur-core_stepper.hal
+++ b/configs/attic/dallur-thc/dallur-core_stepper.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # stepper module, three step generators, all three using step/dir
 loadrt stepgen step_type=0,0,0
 

--- a/configs/attic/demo_mazak/demo_mazak.hal
+++ b/configs/attic/demo_mazak/demo_mazak.hal
@@ -3,7 +3,9 @@
 # kinematics
 loadrt trivkins
 # first load the motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD tp=tp kins=trivkins
 
 # next load I/O drivers.  This retrofit uses three different I/O devices
 #
@@ -405,7 +407,7 @@ net arm-retracted ax5214h.0.in-29
 net arm-extended ax5214h.0.in-30
 # FIXME!!  This sensor is broken, so we are using a delay
 # instead - 2 seconds after the cylinder is actuated, we
-# assume that we have reached the desired position and 
+# assume that we have reached the desired position and
 # set the signal true.  The commented out line below is
 # the proper source for the signal.  But for now, it is
 # driven by classicladder output number 27 (see ladder

--- a/configs/by_interface/general_mechatronics/GM6-PCI/3-axis-servo.hal
+++ b/configs/by_interface/general_mechatronics/GM6-PCI/3-axis-servo.hal
@@ -5,7 +5,9 @@
 
 loadrt trivkins
 loadrt hal_gm
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt pid num_chan=3
 loadrt not
 

--- a/configs/by_interface/general_mechatronics/GM6-PCI/3-axis-stepper.hal
+++ b/configs/by_interface/general_mechatronics/GM6-PCI/3-axis-stepper.hal
@@ -5,7 +5,9 @@
 
 loadrt trivkins
 loadrt hal_gm
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt not
 loadusr halmeter
 #loadusr halscope -f

--- a/configs/by_interface/mesa/hm2-servo/hm2-servo.hal
+++ b/configs/by_interface/mesa/hm2-servo/hm2-servo.hal
@@ -29,10 +29,12 @@
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # standard components
-loadrt pid num_chan=3 
+loadrt pid num_chan=3
 
 # only the 7i43 needs this, but it doesnt hurt the others
 loadrt probe_parport
@@ -63,7 +65,7 @@ addf pid.2.do-pid-calcs                    servo-thread
 
 addf hm2_[HOSTMOT2](BOARD).0.write         servo-thread
 addf hm2_[HOSTMOT2](BOARD).0.pet_watchdog  servo-thread
-       
+
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -79,7 +81,7 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 net emcmot.00.enable => pid.0.enable
 net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.pwmgen.00.enable
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 
 # encoder feedback
 setp hm2_[HOSTMOT2](BOARD).0.encoder.00.counter-mode 0
@@ -120,7 +122,7 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 net emcmot.01.enable => pid.1.enable
 net emcmot.01.enable => hm2_[HOSTMOT2](BOARD).0.pwmgen.01.enable
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 
 # encoder feedback
 setp hm2_[HOSTMOT2](BOARD).0.encoder.01.counter-mode 0
@@ -161,7 +163,7 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 net emcmot.02.enable => pid.2.enable
 net emcmot.02.enable => hm2_[HOSTMOT2](BOARD).0.pwmgen.02.enable
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 
 # encoder feedback
 setp hm2_[HOSTMOT2](BOARD).0.encoder.02.counter-mode 0

--- a/configs/by_interface/mesa/hm2-stepper/hm2-stepper.hal
+++ b/configs/by_interface/mesa/hm2-stepper/hm2-stepper.hal
@@ -29,7 +29,9 @@
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # only the 7i43 needs this, but it doesnt hurt the others
 loadrt probe_parport
@@ -48,10 +50,10 @@ loadrt [HOSTMOT2](DRIVER) config=[HOSTMOT2](CONFIG)
 addf hm2_[HOSTMOT2](BOARD).0.read         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
-# revel in the free time here from not having to run PID 
+# revel in the free time here from not having to run PID
 addf hm2_[HOSTMOT2](BOARD).0.write        servo-thread
 addf hm2_[HOSTMOT2](BOARD).0.pet_watchdog servo-thread
-       
+
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -66,7 +68,7 @@ addf hm2_[HOSTMOT2](BOARD).0.pet_watchdog servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.00.enable
 
 
@@ -101,7 +103,7 @@ setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.step_type       0
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.01.enable
 
 
@@ -136,7 +138,7 @@ setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.step_type       0
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.02.enable
 
 
@@ -165,7 +167,7 @@ setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.step_type       0
 
 
 
-# 
+#
 # The Mesa AnyIO output pins can be in open-drain mode (drive low, float
 # high) or push/pull mode (drive low, drive high).
 #

--- a/configs/by_interface/mesa/plasma-5i20/plasma-5i20.hal
+++ b/configs/by_interface/mesa/plasma-5i20/plasma-5i20.hal
@@ -17,7 +17,9 @@
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # only the 7i43 needs this, but it doesnt hurt the others
 # loadrt probe_parport
@@ -54,7 +56,7 @@ addf parport.0.write servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.00.enable
 
 
@@ -93,7 +95,7 @@ net both-home-x => axis.0.pos-lim-sw-in
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.01.enable
 
 
@@ -132,7 +134,7 @@ net both-home-y => axis.1.pos-lim-sw-in
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.02.enable
 
 
@@ -167,7 +169,7 @@ net both-home-z => axis.2.pos-lim-sw-in
 
 #######################
 # Standard I/O Block - EStop, Etc
-# ############################### 
+# ###############################
 
 # create a signal for the estop loopback
 net estop-loop iocontrol.0.user-enable-out => iocontrol.0.emc-enable-in

--- a/configs/by_interface/mesa/plasma-5i20/plasma-demo.hal
+++ b/configs/by_interface/mesa/plasma-5i20/plasma-demo.hal
@@ -2,7 +2,9 @@
 # If you make changes to this file, they will be
 # overwritten when you run stepconf again
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt probe_parport
 loadrt hal_parport cfg="0x378 out  "
 setp parport.0.reset-time 1000

--- a/configs/by_interface/parport/classicladder/cl-estop/cl-estop.hal
+++ b/configs/by_interface/parport/classicladder/cl-estop/cl-estop.hal
@@ -2,7 +2,9 @@
 # If you make changes to this file, they will be
 # overwritten when you run stepconf again
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt probe_parport
 loadrt hal_parport cfg=0x378
 setp parport.0.reset-time 5000

--- a/configs/by_interface/parport/etch-servo/etch.hal
+++ b/configs/by_interface/parport/etch-servo/etch.hal
@@ -1,7 +1,9 @@
 # load realtime modules
 # kinematics
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt hal_parport cfg="0x378"
 loadrt encoder num_chan=2
 loadrt pid num_chan=2

--- a/configs/by_interface/parport/gantry/gantry.hal
+++ b/configs/by_interface/parport/gantry/gantry.hal
@@ -7,7 +7,9 @@ setp gantrykins.joint-1 1
 setp gantrykins.joint-2 2
 setp gantrykins.joint-3 1
 
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=gantrykins
 loadrt probe_parport
 loadrt hal_parport cfg="0x378 out  "
 setp parport.0.reset-time 5000

--- a/configs/by_interface/parport/gecko/Gecko_540B3/Gecko_540B3.hal
+++ b/configs/by_interface/parport/gecko/Gecko_540B3/Gecko_540B3.hal
@@ -2,7 +2,9 @@
 # If you make changes to this file, they will be
 # overwritten when you run stepconf again
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt probe_parport
 loadrt hal_parport cfg="0x378 out  "
 setp parport.0.reset-time 1000

--- a/configs/by_interface/parport/gecko/Gecko_540B4/Gecko_540B4.hal
+++ b/configs/by_interface/parport/gecko/Gecko_540B4/Gecko_540B4.hal
@@ -2,7 +2,9 @@
 # If you make changes to this file, they will be
 # overwritten when you run stepconf again
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt probe_parport
 loadrt hal_parport cfg="0x378 out  "
 setp parport.0.reset-time 1000

--- a/configs/by_interface/parport/nist-lathe/nist-lathe.hal
+++ b/configs/by_interface/parport/nist-lathe/nist-lathe.hal
@@ -5,7 +5,9 @@
 # kinematics
 loadrt trivkins
 # main motion controller module
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # using steppers....
 loadrt stepgen step_type=0,0,0
 # I/O thru the parport

--- a/configs/by_interface/parport/plasma-thc-sim/kinematics.hal
+++ b/configs/by_interface/parport/plasma-thc-sim/kinematics.hal
@@ -9,4 +9,6 @@ setp gantrykins.joint-2 2
 setp gantrykins.joint-3 1
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD tp=tp kins=gantrykins

--- a/configs/by_interface/parport/stepper-gantry/kinematics.hal
+++ b/configs/by_interface/parport/stepper-gantry/kinematics.hal
@@ -9,4 +9,6 @@ setp gantrykins.joint-2 2
 setp gantrykins.joint-3 1
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD tp=tp kins=gantrykins

--- a/configs/by_interface/parport/stepper-xyza/stepper_xyza.hal
+++ b/configs/by_interface/parport/stepper-xyza/stepper_xyza.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # stepper module
 loadrt stepgen step_type=0,0,0,0
 

--- a/configs/by_interface/pico/USC_encod/univstep_load.hal
+++ b/configs/by_interface/pico/USC_encod/univstep_load.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
 loadrt pid num_chan=4

--- a/configs/by_interface/pico/ppmc/ppmc_load.hal
+++ b/configs/by_interface/pico/ppmc/ppmc_load.hal
@@ -5,7 +5,9 @@
 loadrt trivkins
 
 #motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
 loadrt pid num_chan=4

--- a/configs/by_interface/pico/ppmc_vel/ppmc_load.hal
+++ b/configs/by_interface/pico/ppmc_vel/ppmc_load.hal
@@ -16,7 +16,9 @@
 loadrt trivkins
 
 #motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
 loadrt pid num_chan=4

--- a/configs/by_interface/pico/univpwm/univpwm_load.hal
+++ b/configs/by_interface/pico/univpwm/univpwm_load.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
 loadrt pid num_chan=4

--- a/configs/by_interface/pico/univpwmv/univpwm_load.hal
+++ b/configs/by_interface/pico/univpwmv/univpwm_load.hal
@@ -6,7 +6,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
 loadrt pid num_chan=4

--- a/configs/by_interface/pico/univstep/univstep_load.hal
+++ b/configs/by_interface/pico/univstep/univstep_load.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
 loadrt pid num_chan=4

--- a/configs/by_interface/pluto/lathe-pluto/lathe-pluto.hal
+++ b/configs/by_interface/pluto/lathe-pluto/lathe-pluto.hal
@@ -1,8 +1,10 @@
 # load realtime modules
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt at_pid num_chan=2 debug=1
-loadrt ddt count=4 
+loadrt ddt count=4
 loadrt pluto_servo
 loadrt scale
 loadrt mux2

--- a/configs/by_interface/pluto/pluto_inch/pluto_pinout.hal
+++ b/configs/by_interface/pluto/pluto_inch/pluto_pinout.hal
@@ -2,7 +2,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 loadrt pluto_step
 addf pluto-step.read servo-thread

--- a/configs/by_machine/boss/boss.hal
+++ b/configs/by_machine/boss/boss.hal
@@ -6,7 +6,9 @@
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # PID module, for four PID loops
 loadrt pid num_chan=4
@@ -126,10 +128,10 @@ net aOutput pid.3.output => motenc.0.dac-00-value
 # Encoders.
 #
 # Set feedback scaling from ini file.
-setp motenc.0.enc-01-scale [AXIS_0]INPUT_SCALE 
-setp motenc.0.enc-03-scale [AXIS_1]INPUT_SCALE 
-setp motenc.0.enc-02-scale [AXIS_2]INPUT_SCALE 
-setp motenc.0.enc-00-scale [AXIS_3]INPUT_SCALE 
+setp motenc.0.enc-01-scale [AXIS_0]INPUT_SCALE
+setp motenc.0.enc-03-scale [AXIS_1]INPUT_SCALE
+setp motenc.0.enc-02-scale [AXIS_2]INPUT_SCALE
+setp motenc.0.enc-00-scale [AXIS_3]INPUT_SCALE
 
 # Connect position feedback to PID loop.
 net xPosFb motenc.0.enc-01-position => pid.0.feedback

--- a/configs/by_machine/boss/pid_test.hal
+++ b/configs/by_machine/boss/pid_test.hal
@@ -6,7 +6,9 @@
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # PID module, for four PID loops
 loadrt at_pid num_chan=4
@@ -198,10 +200,10 @@ net zPidAccCmd ddt.2.out
 # Encoders.
 #
 # Set feedback scaling from ini file.
-setp motenc.0.enc-01-scale [AXIS_0]INPUT_SCALE 
-setp motenc.0.enc-03-scale [AXIS_1]INPUT_SCALE 
-setp motenc.0.enc-02-scale [AXIS_2]INPUT_SCALE 
-setp motenc.0.enc-00-scale [AXIS_3]INPUT_SCALE 
+setp motenc.0.enc-01-scale [AXIS_0]INPUT_SCALE
+setp motenc.0.enc-03-scale [AXIS_1]INPUT_SCALE
+setp motenc.0.enc-02-scale [AXIS_2]INPUT_SCALE
+setp motenc.0.enc-00-scale [AXIS_3]INPUT_SCALE
 
 # Connect position feedback to PID loop.
 net xMotorPosFb motenc.0.enc-01-position => pid.0.feedback

--- a/configs/by_machine/cooltool/core_stepper4.hal
+++ b/configs/by_machine/cooltool/core_stepper4.hal
@@ -3,14 +3,16 @@ loadrt trivkins
 # core HAL config file for steppers
 
 # first load the stepper module
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD tp=tp kins=trivkins
 
 loadrt stepgen step_type=0,0,0,0
 
 # hook its functions to realtime threads
 addf stepgen.capture-position servo-thread
 addf stepgen.update-freq servo-thread
-addf stepgen.make-pulses base-thread 
+addf stepgen.make-pulses base-thread
 
 #add motion controller to the threads
 addf motion-command-handler servo-thread

--- a/configs/by_machine/cooltool/uni-dreh-g_stepper.hal
+++ b/configs/by_machine/cooltool/uni-dreh-g_stepper.hal
@@ -3,14 +3,16 @@ loadrt trivkins
 # core HAL config file for steppers
 
 # first load the stepper module
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD tp=tp kins=trivkins
 
 loadrt stepgen step_type=0,0,0,0,0,0
 
 # hook its functions to realtime threads
 addf stepgen.capture-position servo-thread
 addf stepgen.update-freq servo-thread
-addf stepgen.make-pulses base-thread 
+addf stepgen.make-pulses base-thread
 
 #add motion controller to the threads
 addf motion-command-handler servo-thread

--- a/configs/by_machine/sherline/Sherline4Axis/stepper_xyza.hal
+++ b/configs/by_machine/sherline/Sherline4Axis/stepper_xyza.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD tp=tp kins=trivkins
 # stepper module
 loadrt stepgen step_type=0,0,0,0
 

--- a/configs/by_machine/smithy/1240.hal
+++ b/configs/by_machine/smithy/1240.hal
@@ -23,7 +23,9 @@ setp hm2_5i20.0.raw.write_strobe 1
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load charge pump
 loadrt charge_pump

--- a/configs/by_machine/smithy/1240_4axis.hal
+++ b/configs/by_machine/smithy/1240_4axis.hal
@@ -23,7 +23,9 @@ setp hm2_5i20.0.raw.write_strobe 1
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load charge pump
 loadrt charge_pump

--- a/configs/by_machine/smithy/1240combined.hal
+++ b/configs/by_machine/smithy/1240combined.hal
@@ -24,7 +24,9 @@ setp hm2_5i20.0.raw.write_strobe 1
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load charge pump
 loadrt charge_pump
@@ -52,7 +54,7 @@ loadrt comp count=2
 setp comp.0.in0 1.0
 setp comp.1.in0 0.0
 loadrt and2 count=2
-# Filter srps 
+# Filter srps
 loadrt lowpass
 setp lowpass.0.gain 0.07
 # Spindle at-speed detection

--- a/configs/by_machine/smithy/1240combined_4axis.hal
+++ b/configs/by_machine/smithy/1240combined_4axis.hal
@@ -24,7 +24,9 @@ setp hm2_5i20.0.raw.write_strobe 1
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load charge pump
 loadrt charge_pump
@@ -52,7 +54,7 @@ loadrt comp count=2
 setp comp.0.in0 1.0
 setp comp.1.in0 0.0
 loadrt and2 count=2
-# Filter srps 
+# Filter srps
 loadrt lowpass
 setp lowpass.0.gain 0.07
 # Spindle at-speed detection

--- a/configs/by_machine/smithy/1240gecko.hal
+++ b/configs/by_machine/smithy/1240gecko.hal
@@ -1,5 +1,7 @@
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt hal_parport cfg=0x378
 setp parport.0.reset-time 4000
 loadrt stepgen step_type=0,0,0,0

--- a/configs/by_machine/smithy/1240rutex.hal
+++ b/configs/by_machine/smithy/1240rutex.hal
@@ -1,5 +1,7 @@
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt stepgen step_type=0,0,0
 loadrt match8 count=1
 # Used to filter out spurious limit switch signals

--- a/configs/by_machine/smithy/1240rutex_4axis.hal
+++ b/configs/by_machine/smithy/1240rutex_4axis.hal
@@ -1,5 +1,7 @@
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt stepgen step_type=0,0,0,0
 loadrt match8 count=1
 # Used to filter out spurious limit switch signals

--- a/configs/by_machine/smithy/1315.hal
+++ b/configs/by_machine/smithy/1315.hal
@@ -23,7 +23,9 @@ setp hm2_5i20.0.raw.write_strobe 1
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # classicladder for machine logic
 # (load the realtime portion)

--- a/configs/by_machine/smithy/516gecko.hal
+++ b/configs/by_machine/smithy/516gecko.hal
@@ -1,5 +1,7 @@
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt hal_parport cfg=0x378
 setp parport.0.reset-time 4000
 loadrt stepgen step_type=0,0,0,0

--- a/configs/by_machine/smithy/622.hal
+++ b/configs/by_machine/smithy/622.hal
@@ -15,7 +15,9 @@ loadrt hm2_pci config="firmware=hm2/5i20/SVST2_4_7I47.BIT num_encoders=1 num_pwm
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load charge pump
 loadrt charge_pump

--- a/configs/by_machine/smithy/622_4axis.hal
+++ b/configs/by_machine/smithy/622_4axis.hal
@@ -15,7 +15,9 @@ loadrt hm2_pci config="firmware=hm2/5i20/SVST2_4_7I47.BIT num_encoders=1 num_pwm
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load charge pump
 loadrt charge_pump

--- a/configs/by_machine/smithy/622gecko.hal
+++ b/configs/by_machine/smithy/622gecko.hal
@@ -1,5 +1,7 @@
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt hal_parport cfg=0x378
 setp parport.0.reset-time 4000
 loadrt stepgen step_type=0,0,0,0

--- a/configs/by_machine/smithy/622keyence.hal
+++ b/configs/by_machine/smithy/622keyence.hal
@@ -1,6 +1,6 @@
 # 5i20 config file for Smithy 622 Mill with Leadshine Drives
 
-# load the hostmot2 driver, this doesnt do anything by itself, 
+# load the hostmot2 driver, this doesnt do anything by itself,
 # it just waits for low-level drivers to register boards
 loadrt hostmot2 debug_idrom=1 debug_module_descriptors=1 debug_pin_descriptors=1 debug_modules=1
 
@@ -15,7 +15,9 @@ loadrt hm2_pci config="firmware=hm2/5i20/SVST2_4_7I47.BIT num_encoders=1 num_pwm
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load charge pump
 loadrt charge_pump
@@ -161,7 +163,7 @@ setp hm2_5i20.0.gpio.043.is_output TRUE
 setp hm2_5i20.0.gpio.043.invert_output TRUE
 net M8 hm2_5i20.0.gpio.043.out => iocontrol.0.coolant-flood
 
-# Mist 
+# Mist
 setp hm2_5i20.0.gpio.045.is_output TRUE
 setp hm2_5i20.0.gpio.045.invert_output TRUE
 net M7 hm2_5i20.0.gpio.045.out => iocontrol.0.coolant-mist

--- a/configs/by_machine/smithy/622leadshine.hal
+++ b/configs/by_machine/smithy/622leadshine.hal
@@ -15,7 +15,9 @@ loadrt hm2_pci config="firmware=hm2/5i20/SVST2_4_7I47.BIT num_encoders=1 num_pwm
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load charge pump
 loadrt charge_pump

--- a/configs/by_machine/smithy/622leadshine_4axis.hal
+++ b/configs/by_machine/smithy/622leadshine_4axis.hal
@@ -15,7 +15,9 @@ loadrt hm2_pci config="firmware=hm2/5i20/SVST2_4_7I47.BIT num_encoders=1 num_pwm
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load charge pump
 loadrt charge_pump

--- a/configs/by_machine/smithy/924.hal
+++ b/configs/by_machine/smithy/924.hal
@@ -15,7 +15,9 @@ loadrt hm2_pci config="firmware=hm2/5i20/SVST2_4_7I47.BIT num_encoders=3 num_pwm
 loadrt trivkins
 
 # load motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD key=[EMCMOT]SHMEM_KEY num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # classicladder for machine logic
 # (load the realtime portion)

--- a/configs/by_machine/tormach/pcnc-1100.hal
+++ b/configs/by_machine/tormach/pcnc-1100.hal
@@ -1,6 +1,8 @@
 
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt probe_parport
 loadrt hal_parport cfg=0x378
 setp parport.0.reset-time 4000

--- a/configs/by_machine/tormach/pcnc-770.hal
+++ b/configs/by_machine/tormach/pcnc-770.hal
@@ -1,6 +1,8 @@
 
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt probe_parport
 loadrt hal_parport cfg=0x378
 setp parport.0.reset-time 4000

--- a/configs/common/core_servo.hal
+++ b/configs/common/core_servo.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # PID module, for three PID loops
 loadrt pid num_chan=3
 

--- a/configs/common/core_sim.hal
+++ b/configs/common/core_sim.hal
@@ -3,8 +3,10 @@
 # first load all the RT modules that will be needed
 # kinematics
 loadrt trivkins
+# trajectory planner
+loadrt tp
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES kins=trivkins tp=tp
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt names=ddt_x,ddt_xv,ddt_y,ddt_yv,ddt_z,ddt_zv
 # load additional blocks

--- a/configs/common/core_sim9.hal
+++ b/configs/common/core_sim9.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt names=ddt_x,ddt_xv,ddt_y,ddt_yv,ddt_z,ddt_zv
 # load additional blocks

--- a/configs/common/core_stepper.hal
+++ b/configs/common/core_stepper.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # stepper module, three step generators, all three using step/dir
 loadrt stepgen step_type=0,0,0
 

--- a/configs/hm2-stepper/hm2-stepper-5i25.hal
+++ b/configs/hm2-stepper/hm2-stepper-5i25.hal
@@ -29,7 +29,9 @@
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # only the 7i43 needs this, but it doesnt hurt the others
 loadrt probe_parport
@@ -38,7 +40,7 @@ loadrt probe_parport
 loadrt hostmot2
 
 # load low-level driver
-loadrt [HOSTMOT2](DRIVER) 
+loadrt [HOSTMOT2](DRIVER)
 #config=[HOSTMOT2](CONFIG)
 
 
@@ -49,10 +51,10 @@ loadrt [HOSTMOT2](DRIVER)
 addf hm2_[HOSTMOT2](BOARD).0.read         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
-# revel in the free time here from not having to run PID 
+# revel in the free time here from not having to run PID
 addf hm2_[HOSTMOT2](BOARD).0.write        servo-thread
 addf hm2_[HOSTMOT2](BOARD).0.pet_watchdog servo-thread
-       
+
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -67,7 +69,7 @@ addf hm2_[HOSTMOT2](BOARD).0.pet_watchdog servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.00.enable
 
 
@@ -102,7 +104,7 @@ setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.step_type       0
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.01.enable
 
 
@@ -137,7 +139,7 @@ setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.step_type       0
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.02.enable
 
 
@@ -166,7 +168,7 @@ setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.step_type       0
 
 
 
-# 
+#
 # The Mesa AnyIO output pins can be in open-drain mode (drive low, float
 # high) or push/pull mode (drive low, drive high).
 #

--- a/configs/pru-examples/pru-stepper.hal
+++ b/configs/pru-examples/pru-stepper.hal
@@ -29,7 +29,9 @@
 loadrt trivkins
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load low-level driver
 loadrt [PRUCONF](DRIVER) [PRUCONF](CONFIG)
@@ -42,9 +44,9 @@ loadrt [PRUCONF](DRIVER) [PRUCONF](CONFIG)
 addf [PRUCONF](DRIVER).capture-position   servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
-# revel in the free time here from not having to run PID 
+# revel in the free time here from not having to run PID
 addf [PRUCONF](DRIVER).update             servo-thread
-       
+
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -59,7 +61,7 @@ addf [PRUCONF](DRIVER).update             servo-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out 
+net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
 
 
@@ -96,7 +98,7 @@ setp [PRUCONF](DRIVER).stepgen.00.dirpin          0xA3
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out 
+net emcmot.01.enable <= axis.1.amp-enable-out
 net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
 
 
@@ -133,7 +135,7 @@ setp [PRUCONF](DRIVER).stepgen.01.dirpin          0xA5
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out 
+net emcmot.02.enable <= axis.2.amp-enable-out
 net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
 
 
@@ -164,7 +166,7 @@ setp [PRUCONF](DRIVER).stepgen.02.dirpin          0xA7
 
 
 
-# 
+#
 # The Mesa AnyIO output pins can be in open-drain mode (drive low, float
 # high) or push/pull mode (drive low, drive high).
 #

--- a/configs/sim/axis/orphans/core_sim_noio.hal
+++ b/configs/sim/axis/orphans/core_sim_noio.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt names=ddt_x,ddt_xv,ddt_y,ddt_yv,ddt_z,ddt_zv
 # load additional blocks

--- a/configs/sim/axis/orphans/core_sim_noiocontrol.hal
+++ b/configs/sim/axis/orphans/core_sim_noiocontrol.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt names=ddt_x,ddt_xv,ddt_y,ddt_yv,ddt_z,ddt_zv
 # load additional blocks

--- a/configs/sim/axis/orphans/core_sim_test.hal
+++ b/configs/sim/axis/orphans/core_sim_test.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt names=ddt_x,ddt_xv,ddt_y,ddt_yv,ddt_z,ddt_zv
 # load additional blocks

--- a/configs/sim/axis/remap/iocontrol-removed/core_sim_test.hal
+++ b/configs/sim/axis/remap/iocontrol-removed/core_sim_test.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt names=ddt_x,ddt_xv,ddt_y,ddt_yv,ddt_z,ddt_zv
 # load additional blocks

--- a/configs/sim/axis/sim_rostock.hal
+++ b/configs/sim/axis/sim_rostock.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt lineardeltakins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=lineardeltakins
 
 #loadusr -W rostock
 
@@ -14,12 +16,12 @@ addf motion-controller servo-thread
 
 # create HAL signals for position commands from motion module
 # loop position commands back to motion module feedback
-net J0pos axis.0.motor-pos-cmd => axis.0.motor-pos-fb 
-net J1pos axis.1.motor-pos-cmd => axis.1.motor-pos-fb 
-net J2pos axis.2.motor-pos-cmd => axis.2.motor-pos-fb 
+net J0pos axis.0.motor-pos-cmd => axis.0.motor-pos-fb
+net J1pos axis.1.motor-pos-cmd => axis.1.motor-pos-fb
+net J2pos axis.2.motor-pos-cmd => axis.2.motor-pos-fb
 net Apos axis.3.motor-pos-cmd => axis.3.motor-pos-fb
 
-#setp lineardeltakins.L 190.00 
+#setp lineardeltakins.L 190.00
 #setp lineardeltakins.R  100.00
 setp lineardeltakins.J0off 0.00
 setp lineardeltakins.J1off 0.00

--- a/configs/sim/axis/vismach/5axis/5axis_sim.hal
+++ b/configs/sim/axis/vismach/5axis/5axis_sim.hal
@@ -2,7 +2,9 @@
 
 # load RT modules
 loadrt 5axiskins
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=5axiskins
 loadrt ddt count=12
 
 # add motion controller functions to servo thread

--- a/configs/sim/axis/vismach/hbm/hbm.hal
+++ b/configs/sim/axis/vismach/hbm/hbm.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # load four limit3 blocks to simulate the accel and vel limits of the motors
 loadrt limit3 count=4
 # load window comparators for home/limit switches

--- a/configs/sim/axis/vismach/hexapod-sim/core_sim_6.hal
+++ b/configs/sim/axis/vismach/hexapod-sim/core_sim_6.hal
@@ -2,7 +2,9 @@
 
 # load RT modules
 loadrt genhexkins
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD num_joints=[TRAJ]AXES tp=tp kins=genhexkins
 loadrt ddt count=9
 
 # add motion controller functions to servo thread

--- a/configs/sim/axis/vismach/max5kins/max5kins.hal
+++ b/configs/sim/axis/vismach/max5kins/max5kins.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt maxkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=maxkins
 # load five limit3 blocks to simulate the accel and vel limits of the motors
 loadrt limit3 count=5
 # load window comparators for home/limit switches

--- a/configs/sim/axis/vismach/max5triv/max5triv.hal
+++ b/configs/sim/axis/vismach/max5triv/max5triv.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # load five limit3 blocks to simulate the accel and vel limits of the motors
 loadrt limit3 count=5
 # load window comparators for home/limit switches

--- a/configs/sim/axis/vismach/puma/puma560_sim_6.hal
+++ b/configs/sim/axis/vismach/puma/puma560_sim_6.hal
@@ -2,7 +2,9 @@
 
 # load RT modules
 loadrt genserkins
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD num_joints=[TRAJ]AXES tp=tp kins=genserkins
 
 # add motion controller functions to servo thread
 addf motion-command-handler servo-thread
@@ -41,18 +43,18 @@ setp genserkins.A-3 0
 setp genserkins.A-4 0
 setp genserkins.A-5 0
 
-setp genserkins.ALPHA-0 0 
-setp genserkins.ALPHA-1 1.570796326 
-setp genserkins.ALPHA-2 0 
-setp genserkins.ALPHA-3 1.570796326 
-setp genserkins.ALPHA-4 -1.570796326 
-setp genserkins.ALPHA-5 1.570796326 
+setp genserkins.ALPHA-0 0
+setp genserkins.ALPHA-1 1.570796326
+setp genserkins.ALPHA-2 0
+setp genserkins.ALPHA-3 1.570796326
+setp genserkins.ALPHA-4 -1.570796326
+setp genserkins.ALPHA-5 1.570796326
 
 setp genserkins.D-0 26.45
 setp genserkins.D-1 -5.5
 setp genserkins.D-2 0
 setp genserkins.D-3 17.05
-setp genserkins.D-4 0 
+setp genserkins.D-4 0
 setp genserkins.D-5 2.2
 
 

--- a/configs/sim/axis/vismach/puma/puma_sim_6.hal
+++ b/configs/sim/axis/vismach/puma/puma_sim_6.hal
@@ -2,7 +2,9 @@
 
 # load RT modules
 loadrt pumakins
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD num_joints=[TRAJ]AXES tp=tp kins=pumakins
 loadrt ddt count=12
 
 # add motion controller functions to servo thread

--- a/configs/sim/axis/vismach/scara/scara_sim_4.hal
+++ b/configs/sim/axis/vismach/scara/scara_sim_4.hal
@@ -2,7 +2,9 @@
 
 # load RT modules
 loadrt scarakins
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]TRAJ_PERIOD num_joints=[TRAJ]AXES tp=tp kins=scarakins
 loadrt ddt count=12
 
 # add motion controller functions to servo thread

--- a/configs/sim/emcweb.hal
+++ b/configs/sim/emcweb.hal
@@ -1,5 +1,7 @@
 loadrt trivkins
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt ddt count=6
 loadrt hypot count=2
 loadrt comp count=3
@@ -22,11 +24,11 @@ net Ypos axis.1.motor-pos-cmd => axis.1.motor-pos-fb ddt.2.in
 net Zpos axis.2.motor-pos-cmd => axis.2.motor-pos-fb ddt.4.in
 
 net Xvel ddt.0.out => ddt.1.in hypot.0.in0
-net Xacc <= ddt.1.out 
+net Xacc <= ddt.1.out
 net Yvel ddt.2.out => ddt.3.in hypot.0.in1
-net Yacc <= ddt.3.out 
+net Yacc <= ddt.3.out
 net Zvel ddt.4.out => ddt.5.in hypot.1.in0
-net Zacc <= ddt.5.out 
+net Zacc <= ddt.5.out
 
 net XYvel hypot.0.out => hypot.1.in1
 net XYZvel <= hypot.1.out

--- a/configs/sim/gantrysim.hal
+++ b/configs/sim/gantrysim.hal
@@ -2,7 +2,9 @@
 loadrt gantrykins coordinates=XYZY
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=gantrykins
 
 # add motion controller functions to servo thread
 addf motion-command-handler servo-thread

--- a/configs/sim/gmoccapy/core_sim4.hal
+++ b/configs/sim/gmoccapy/core_sim4.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt names=ddt_x,ddt_xv,ddt_y,ddt_yv,ddt_z,ddt_zv
 # load additional blocks

--- a/configs/sim/servo_sim.hal
+++ b/configs/sim/servo_sim.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # PID module, for three PID loops
 loadrt pid names=pid_x,pid_y,pid_z
 # 6 differentiators (for velocity and accel sigs),
@@ -138,12 +140,12 @@ setp pid_z.maxoutput [AXIS_2]MAX_VELOCITY
 # NOTE: eventually these will be non-zero values as
 # needed to tune the performance of each axis.  The
 # initial values shown here are extremely conservative
-# to prevent unexpected behavior.  After this file 
+# to prevent unexpected behavior.  After this file
 # has been "executed" by halcmd, the gains can be
 # interactively adjusted using commands like
 # "halcmd setp pid.<channel>.Pgain <value>"
-# Once the axis has been tuned to your satisfaction, 
-# do "halcmd show param | grep pid" to get a listing 
+# Once the axis has been tuned to your satisfaction,
+# do "halcmd show param | grep pid" to get a listing
 # of the tuning parameters, and enter those values here.
 
 # the values below come from the ini

--- a/configs/sim/tripodsim.hal
+++ b/configs/sim/tripodsim.hal
@@ -8,7 +8,9 @@ setp tripodkins.Cx 5
 setp tripodkins.Cy 7.071
 
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD tp=tp kins=tripodkins
 # 6 differentiators (for velocity and accel sigs)
 loadrt ddt names=ddt_j0,ddt_j1,ddt_j2,ddt_j0v,ddt_j1v,ddt_j2v
 

--- a/configs/stepper/mah_stepper.hal
+++ b/configs/stepper/mah_stepper.hal
@@ -4,7 +4,9 @@
 # kinematics
 loadrt trivkins
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD base_cpu=1 servo_period_nsec=[EMCMOT]SERVO_PERIOD servo_cpu=0 num_joints=[TRAJ]AXES
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD base_cpu=1 servo_period_nsec=[EMCMOT]SERVO_PERIOD servo_cpu=0 num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # stepper module, three step generators, all three using step/dir
 loadrt stepgen step_type=0,0,0
 

--- a/scripts/fix-tp-loading
+++ b/scripts/fix-tp-loading
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+import sys,os
+import fileinput
+inplace = 1
+mot = ['[EMCMOT]EMCMOT','motmod']
+tps = ['tp']
+
+# find configs/ -name '*.hal' -print|xargs grep EMCMOT|grep -v tp=tp|cut -d ':' -f1
+for f in sys.argv[1:]:
+    fn = os.path.realpath(f)
+    kins = None
+    fixed = False
+    for l in fileinput.input(fn, inplace=inplace):
+        line = l.rstrip()
+        words = line.split()
+        if fixed or len(words) < 2:
+            print line
+            continue
+        if not line.startswith('loadrt') or line.startswith('#') :
+            print line
+            continue
+        if words[1] in tps: # already has tp
+            print line
+            fixed = True
+            continue
+        if words[1].endswith('kins'):
+            kins = words[1]
+            print line
+            continue
+        else:
+            if words[1] in mot and line.find("tp=tp") == -1:
+                if not kins:
+                    raise RuntimeError, "kins not found in " + f + " , " + line
+
+                print '# trajectory planner'
+                print 'loadrt tp'
+                print line + " tp=tp kins=" + kins
+            else:
+                print line

--- a/src/Makefile
+++ b/src/Makefile
@@ -467,6 +467,8 @@ HEADERS := \
     emc/tp/tp_types.h \
     emc/tp/spherical_arc.h \
     emc/tp/blendmath.h \
+    emc/tp/tp_shared.h \
+    emc/tp/tp_private.h \
     emc/motion/emcmotcfg.h \
     emc/motion/emcmotglb.h \
     emc/motion/motion.h \
@@ -480,6 +482,7 @@ HEADERS := \
     emc/nml_intf/emccfg.h \
     emc/nml_intf/emcglb.h \
     emc/nml_intf/emcpos.h \
+    emc/nml_intf/emcpose.h \
     emc/nml_intf/interp_return.hh \
     emc/nml_intf/interpl.hh \
     emc/nml_intf/motion_types.h \

--- a/src/Makefile
+++ b/src/Makefile
@@ -472,6 +472,7 @@ HEADERS := \
     emc/motion/emcmotcfg.h \
     emc/motion/emcmotglb.h \
     emc/motion/motion.h \
+    emc/motion/motion_id.h \
     emc/motion/usrmotintf.h \
     emc/motion/state_tag.h \
     emc/nml_intf/canon.hh \

--- a/src/Makefile
+++ b/src/Makefile
@@ -1434,11 +1434,6 @@ scarakins-objs += libnml/posemath/sincos.o $(MATHSTUB)
 
 obj-$(CONFIG_MOTMOD) += motmod.o
 motmod-objs := emc/kinematics/cubic.o
-motmod-objs += emc/tp/tc.o
-motmod-objs += emc/tp/tcq.o
-motmod-objs += emc/tp/tp.o
-motmod-objs += emc/tp/spherical_arc.o
-motmod-objs += emc/tp/blendmath.o
 motmod-objs += emc/motion/motion.o
 motmod-objs += emc/motion/command.o
 motmod-objs += emc/motion/control.o
@@ -1447,7 +1442,6 @@ motmod-objs += emc/motion/emcmotglb.o
 motmod-objs += emc/motion/emcmotutil.o
 motmod-objs += emc/motion/stashf.o
 motmod-objs += emc/motion/dbuf.o
-motmod-objs += emc/nml_intf/emcpose.o
 motmod-objs += libnml/posemath/_posemath.o
 motmod-objs += libnml/posemath/sincos.o $(MATHSTUB)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -495,6 +495,7 @@ HEADERS := \
     hal/lib/hal_ring.h \
     hal/lib/hal_rcomp.h \
     hal/lib/hal_iter.h \
+    hal/lib/vtable.h \
     hal/lib/config_module.h \
     hal/drivers/hal_gpiomap.h \
     hal/drivers/hal_spi.h \

--- a/src/Makefile
+++ b/src/Makefile
@@ -202,6 +202,7 @@ SUBDIRS := \
 	\
 	hal/lib \
 	hal/components \
+	hal/vtable-example \
 	hal/drivers \
 	hal/user_comps/devices \
 	hal/user_comps/mb2hal \
@@ -1075,6 +1076,7 @@ ifneq ($(KERNELRELEASE),)
 include $(BASEPWD)/hal/lib/Submakefile
 include $(BASEPWD)/machinetalk/Submakefile
 include $(BASEPWD)/hal/components/Submakefile
+include $(BASEPWD)/hal/vtable-example/Submakefile
 include $(BASEPWD)/machinetalk/msgcomponents/Submakefile
 include $(BASEPWD)/rtapi/Submakefile
 include $(BASEPWD)/rtapi/shmdrv/Submakefile
@@ -1386,6 +1388,7 @@ endif
 
 obj-m += scope_rt.o
 scope_rt-objs := hal/utils/scope_rt.o $(MATHSTUB)
+
 
 obj-m += trivkins.o
 trivkins-objs := emc/kinematics/trivkins.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -1449,6 +1449,19 @@ motmod-objs += emc/motion/dbuf.o
 motmod-objs += libnml/posemath/_posemath.o
 motmod-objs += libnml/posemath/sincos.o $(MATHSTUB)
 
+obj-m += tp.o
+tp-objs := $(addprefix emc/tp/, \
+	tc.o 		\
+	tcq.o 		\
+	tp.o 		\
+	tpmain.o 	\
+	blendmath.o 	\
+	spherical_arc.o 	\
+	) 		\
+	emc/nml_intf/emcpose.o \
+	libnml/posemath/_posemath.o \
+	libnml/posemath/sincos.o $(MATHSTUB)
+
 TORTOBJS = $(foreach file,$($(patsubst %.o,%,$(1))-objs), $(OBJDIR)/$(file))
 
 # USER_DSO module building
@@ -1606,6 +1619,8 @@ $(RTLIBDIR)/genserkins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(genserkins-objs))
 $(RTLIBDIR)/pumakins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(pumakins-objs))
 $(RTLIBDIR)/scarakins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(scarakins-objs))
 $(RTLIBDIR)/hal_gm$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hal_gm-objs))
+
+$(RTLIBDIR)/tp$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(tp-objs))
 
 ifeq ($(TRIVIAL_BUILD),no)
 READ_RTDEPS = $(wildcard $(RTDEPS))

--- a/src/emc/ini/initraj.cc
+++ b/src/emc/ini/initraj.cc
@@ -166,7 +166,7 @@ static int loadTraj(EmcIniFile *trajInifile)
         int arcBlendEnable = 1;
         int arcBlendFallbackEnable = 0;
         int arcBlendOptDepth = 50;
-        double arcBlendGapCycles = 4;
+        int arcBlendGapCycles = 4;
         double arcBlendRampFreq = 100.0;
 
         trajInifile->Find(&arcBlendEnable, "ARC_BLEND_ENABLE", "TRAJ");

--- a/src/emc/kinematics/5axiskins.c
+++ b/src/emc/kinematics/5axiskins.c
@@ -13,10 +13,13 @@
 * Last change:
 ********************************************************************/
 
-#include "kinematics.h"		/* these decls */
+#include "rtapi.h"		/* RTAPI realtime OS API */
+#include "rtapi_app.h"		/* RTAPI realtime module decls */
+#include "rtapi_math.h"
+
+#include "kinematics.h"
 #include "posemath.h"
 #include "hal.h"
-#include "rtapi_math.h"
 
 #define d2r(d) ((d)*PM_PI/180.0)
 #define r2d(r) ((r)*180.0/PM_PI)
@@ -89,25 +92,36 @@ int kinematicsHome(EmcPose * world,
     return kinematicsForward(joint, world, fflags, iflags);
 }
 
-KINEMATICS_TYPE kinematicsType()
+KINEMATICS_TYPE kinematicsType(void)
 {
     return KINEMATICS_BOTH;
 }
 
-#include "rtapi.h"		/* RTAPI realtime OS API */
-#include "rtapi_app.h"		/* RTAPI realtime module decls */
-#include "hal.h"
-
-EXPORT_SYMBOL(kinematicsType);
-EXPORT_SYMBOL(kinematicsForward);
-EXPORT_SYMBOL(kinematicsInverse);
 MODULE_LICENSE("GPL");
+#define VTVERSION VTKINEMATICS_VERSION1
 
-int comp_id;
+static vtkins_t vtk = {
+    .kinematicsForward = kinematicsForward,
+    .kinematicsInverse  = kinematicsInverse,
+    // .kinematicsHome = kinematicsHome,
+    .kinematicsType = kinematicsType
+};
+
+static int comp_id, vtable_id;
+static const char *name = "5axiskins";
+
 int rtapi_app_main(void) {
     int result;
-    comp_id = hal_init("5axiskins");
+    comp_id = hal_init(name);
     if(comp_id < 0) return comp_id;
+
+    vtable_id = hal_export_vtable(name, VTVERSION, &vtk, comp_id);
+    if (vtable_id < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: ERROR: hal_export_vtable(%s,%d,%p) failed: %d\n",
+			name, name, VTVERSION, &vtk, vtable_id );
+	return -ENOENT;
+    }
 
     haldata = hal_malloc(sizeof(struct haldata));
 
@@ -124,4 +138,8 @@ error:
     return result;
 }
 
-void rtapi_app_exit(void) { hal_exit(comp_id); }
+void rtapi_app_exit(void)
+{
+    hal_remove_vtable(vtable_id);
+    hal_exit(comp_id);
+}

--- a/src/emc/kinematics/genserkins.c
+++ b/src/emc/kinematics/genserkins.c
@@ -554,7 +554,7 @@ int kinematicsHome(EmcPose * world,
     return kinematicsForward(joint, world, fflags, iflags);
 }
 
-KINEMATICS_TYPE kinematicsType()
+KINEMATICS_TYPE kinematicsType(void)
 {
     return KINEMATICS_BOTH;
 }

--- a/src/emc/kinematics/kinematics.h
+++ b/src/emc/kinematics/kinematics.h
@@ -16,6 +16,7 @@
 #define KINEMATICS_H
 
 #include "emcpos.h"		/* EmcPose */
+#include "vtable.h"		// vtable signatures
 
 /*
   The type of kinematics used.
@@ -70,6 +71,11 @@ typedef unsigned long int KINEMATICS_FORWARD_FLAGS;
    indicate this. */
 typedef unsigned long int KINEMATICS_INVERSE_FLAGS;
 
+
+// these methods used to be exported through symbol resolution, and now
+// go through function pointers in the kins vtable:
+#ifdef LEGACY_KINS_API
+
 /* the forward kinematics take joint values and determine world coordinates,
    given forward kinematics flags to resolve any ambiguities. The inverse
    flags are set to indicate their value appropriate to the joint values
@@ -100,5 +106,31 @@ extern int kinematicsHome(struct EmcPose * world,
 			  KINEMATICS_INVERSE_FLAGS * iflags);
 
 extern KINEMATICS_TYPE kinematicsType(void);
+
+#endif
+
+typedef int (*vtk_kinematicsForward_t)(const double *joint,
+				     struct EmcPose * world,
+				     const KINEMATICS_FORWARD_FLAGS * fflags,
+				     KINEMATICS_INVERSE_FLAGS * iflags);
+typedef int (*vtk_kinematicsInverse_t)(const struct EmcPose * world,
+				     double *joint,
+				     const KINEMATICS_INVERSE_FLAGS * iflags,
+				     KINEMATICS_FORWARD_FLAGS * fflags);
+
+typedef int (* vtk_kinematicsHome_t)(struct EmcPose * world,
+				   double *joint,
+				   KINEMATICS_FORWARD_FLAGS * fflags,
+				   KINEMATICS_INVERSE_FLAGS * iflags);
+
+
+typedef KINEMATICS_TYPE  (*vtk_kinematicsType_t)(void);
+
+typedef struct {
+    vtk_kinematicsForward_t kinematicsForward;
+    vtk_kinematicsInverse_t kinematicsInverse;
+    //    vtk_kinematicsHome_t    kinematicsHome; // unused
+    vtk_kinematicsType_t    kinematicsType;
+} vtkins_t;
 
 #endif

--- a/src/emc/kinematics/lineardeltakins.c
+++ b/src/emc/kinematics/lineardeltakins.c
@@ -20,13 +20,12 @@
 #include "rtapi_app.h"
 
 #include "lineardeltakins-common.h"
+#define VTVERSION VTKINEMATICS_VERSION1
 
 struct haldata
 {
     hal_float_t *r, *l, *j0off, *j1off, *j2off;
 } *haldata;
-
-int comp_id;
 
 int kinematicsForward(const double * joints,
                       EmcPose * pos,
@@ -43,17 +42,35 @@ int kinematicsInverse(const EmcPose *pos, double *joints,
     return kinematics_inverse(pos, joints);
 }
 
-KINEMATICS_TYPE kinematicsType()
+KINEMATICS_TYPE kinematicsType(void)
 {
     return KINEMATICS_BOTH;
 }
+
+static vtkins_t vtk = {
+    .kinematicsForward = kinematicsForward,
+    .kinematicsInverse  = kinematicsInverse,
+    // .kinematicsHome = kinematicsHome,
+    .kinematicsType = kinematicsType
+};
+
+static int comp_id, vtable_id;
+static const char *name = "lineardeltakins";
 
 int rtapi_app_main(void)
 {
     int retval = 0;
 
-    comp_id = hal_init("lineardeltakins");
+    comp_id = hal_init(name);
     if(comp_id < 0) retval = comp_id;
+
+    vtable_id = hal_export_vtable(name, VTVERSION, &vtk, comp_id);
+    if (vtable_id < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: ERROR: hal_export_vtable(%s,%d,%p) failed: %d\n",
+			name, name, VTVERSION, &vtk, vtable_id );
+	return -ENOENT;
+    }
 
     if(retval == 0)
     {
@@ -96,10 +113,6 @@ int rtapi_app_main(void)
 
 void rtapi_app_exit(void)
 {
+    hal_remove_vtable(vtable_id);
     hal_exit(comp_id);
 }
-
-EXPORT_SYMBOL(kinematicsType);
-EXPORT_SYMBOL(kinematicsForward);
-EXPORT_SYMBOL(kinematicsInverse);
-MODULE_LICENSE("GPL");

--- a/src/emc/kinematics/trivkins.c
+++ b/src/emc/kinematics/trivkins.c
@@ -15,6 +15,12 @@
 
 #include "kinematics.h"		/* these decls */
 
+#include "rtapi.h"		/* RTAPI realtime OS API */
+#include "rtapi_app.h"		/* RTAPI realtime module decls */
+#include "hal.h"
+
+#define VTVERSION VTKINEMATICS_VERSION1
+
 
 int kinematicsForward(const double *joints,
 		      EmcPose * pos,
@@ -64,28 +70,43 @@ int kinematicsHome(EmcPose * world,
     return kinematicsForward(joint, world, fflags, iflags);
 }
 
-KINEMATICS_TYPE kinematicsType()
+KINEMATICS_TYPE kinematicsType(void)
 {
     return KINEMATICS_IDENTITY;
 }
 
-#include "rtapi.h"		/* RTAPI realtime OS API */
-#include "rtapi_app.h"		/* RTAPI realtime module decls */
-#include "hal.h"
-
-EXPORT_SYMBOL(kinematicsType);
-EXPORT_SYMBOL(kinematicsForward);
-EXPORT_SYMBOL(kinematicsInverse);
 MODULE_LICENSE("GPL");
 
-int comp_id;
-int rtapi_app_main(void) {
-    comp_id = hal_init("trivkins");
+static vtkins_t vtk = {
+    .kinematicsForward = kinematicsForward,
+    .kinematicsInverse  = kinematicsInverse,
+    // .kinematicsHome = kinematicsHome,
+    .kinematicsType = kinematicsType
+};
+
+static int comp_id, vtable_id;
+static const char *name = "trivkins";
+
+int rtapi_app_main(void)
+{
+    comp_id = hal_init(name);
     if(comp_id > 0) {
+	vtable_id = hal_export_vtable(name, VTVERSION, &vtk, comp_id);
+
+	if (vtable_id < 0) {
+	    rtapi_print_msg(RTAPI_MSG_ERR,
+			    "%s: ERROR: hal_export_vtable(%s,%d,%p) failed: %d\n",
+			    name, name, VTVERSION, &vtk, vtable_id );
+	    return -ENOENT;
+	}
 	hal_ready(comp_id);
 	return 0;
     }
     return comp_id;
 }
 
-void rtapi_app_exit(void) { hal_exit(comp_id); }
+void rtapi_app_exit(void)
+{
+    hal_remove_vtable(vtable_id);
+    hal_exit(comp_id);
+}

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -309,11 +309,11 @@ extern void emcmotController(void *arg, long period);
 extern void emcmotSetCycleTime(unsigned long nsec);
 
 /* these are related to synchronized I/O */
-extern void emcmotDioWrite(int index, char value);
-extern void emcmotAioWrite(int index, double value);
+extern void emcmotDioWrite(int index, hal_bit_t value);
+extern void emcmotAioWrite(int index, hal_float_t value);
 
-extern void emcmotSetRotaryUnlock(int axis, int unlock);
-extern int emcmotGetRotaryIsUnlocked(int axis);
+extern void emcmotSetRotaryUnlock(int axis,  hal_bit_t unlock);
+extern hal_bit_t emcmotGetRotaryIsUnlocked(int axis);
 
 /* homing is no longer in control.c, make functions public */
 extern void do_homing_sequence(void);

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -1393,7 +1393,7 @@ static int init_shared(tp_shared_t *tps,
     tps->num_aio = &num_aio;
 
     // from emcmotConfig
-    tps->arcBlendGapCycles = &cfg->arcBlendGapCycles; // XXX FIXME TYPE ERROR ?
+    tps->arcBlendGapCycles = &cfg->arcBlendGapCycles;
     tps->arcBlendOptDepth = &cfg->arcBlendOptDepth;
     tps->arcBlendEnable = &cfg->arcBlendEnable;
     tps->arcBlendRampFreq = &cfg->arcBlendRampFreq;

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -21,6 +21,10 @@
 #include "mot_priv.h"
 #include "rtapi_math.h"
 
+// vtable signatures
+#define VTKINS_VERSION VTKINEMATICS_VERSION1
+#define VTP_VERSION    VTTP_VERSION1
+
 // Mark strings for translation, but defer translation to userspace
 #define _(s) (s)
 
@@ -62,6 +66,10 @@ int num_dio = 4;			/* default number of motion synched DIO */
 RTAPI_MP_INT(num_dio, "number of digital inputs/outputs");
 int num_aio = 4;			/* default number of motion synched AIO */
 RTAPI_MP_INT(num_aio, "number of analog inputs/outputs");
+static char *kins = "trivkins";
+RTAPI_MP_STRING(kins, "kinematics vtable name");
+static char *tp = "tp";
+RTAPI_MP_STRING(tp, "tp vtable name");
 
 /***********************************************************************
 *                  GLOBAL VARIABLE DEFINITIONS                         *
@@ -147,6 +155,13 @@ static int init_threads(void);
 static int setTrajCycleTime(double secs);
 static int setServoCycleTime(double secs);
 
+// init the shared state handling between tp and motion
+static int init_shared(tp_shared_t *tps,
+		       struct emcmot_config_t *cfg,
+		       struct emcmot_status_t *status,
+		       emcmot_debug_t *dbg,
+		       emcmot_joint_t *joint,
+		       emcmot_hal_data_t *hal);
 /***********************************************************************
 *                     PUBLIC FUNCTION CODE                             *
 ************************************************************************/
@@ -265,6 +280,13 @@ void rtapi_app_exit(void)
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    _("MOTION: hal_stop_threads() failed, returned %d\n"), retval);
     }
+
+    // release the kinematics vtable
+    hal_unreference_vtable(emcmotConfig->kins_vid);
+
+    // release the tp vtable
+    hal_unreference_vtable(emcmotConfig->tp_vid);
+
     /* free shared memory */
     retval = rtapi_shmem_delete(emc_shmem_id, mot_comp_id);
     if (retval < 0) {
@@ -902,8 +924,6 @@ static int init_comm_buffers(void)
     emcmotCommand = 0;
     emcmotConfig = 0;
 
-    /* record the kinematics type of the machine */
-    kinType = kinematicsType();
 
     /* allocate and initialize the shared memory structure */
     emc_shmem_id = rtapi_shmem_new(key, mot_comp_id, sizeof(emcmot_struct_t));
@@ -926,6 +946,30 @@ static int init_comm_buffers(void)
     emcmotCommand = &emcmotStruct->command;
     emcmotStatus = &emcmotStruct->status;
     emcmotConfig = &emcmotStruct->config;
+
+    // bind kinematics vtable
+    emcmotConfig->kins_vid = hal_reference_vtable(kins, VTKINS_VERSION,
+						  (void **)&emcmotConfig->vtk);
+    if (emcmotConfig->kins_vid < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"MOTION: hal_reference_vtable(%s,%d) failed: %d\n",
+			kins, VTKINS_VERSION, emcmotConfig->kins_vid);
+	return -1;
+    }
+
+    /* record the kinematics type of the machine */
+    kinType = emcmotConfig->vtk->kinematicsType();
+
+    // bind the tp vtable
+    emcmotConfig->tp_vid = hal_reference_vtable(tp, VTP_VERSION,
+						(void **)&emcmotConfig->vtp);
+    if (emcmotConfig->tp_vid < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"MOTION: hal_reference_vtable(%s,%d) failed: %d\n",
+			tp, VTP_VERSION, emcmotConfig->tp_vid);
+	return -1;
+    }
+
 
     emcmotDebug = &emcmotStruct->debug;
 
@@ -1123,17 +1167,34 @@ static int init_comm_buffers(void)
     emcmotPrimQueue = &emcmotStruct->debug.tp;     // primary motion queue
     emcmotAltQueue = &emcmotStruct->debug.altqueue;   // alternate motion queue
 
+
+    // init the shared data between tp and using code
+    emcmotDebug->tps = hal_malloc(sizeof(tp_shared_t));
+    if (!emcmotDebug->tps) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"MOTION: failed to create tp_shared in HAL memory");
+	return -1;
+    }
+    init_shared(emcmotDebug->tps,
+		emcmotConfig,
+		emcmotStatus,
+		emcmotDebug,
+		joints, // internal joint data
+		emcmot_hal_data); // HAL exorted part of joint data
+
     /* init motion emcmotDebug->queue */
-    if (-1 == tpCreate(emcmotPrimQueue, DEFAULT_TC_QUEUE_SIZE,
-		       emcmotDebug->queueTcSpace)) {
+    if (-1 == emcmotConfig->vtp->tpCreate(emcmotPrimQueue, DEFAULT_TC_QUEUE_SIZE,
+					  emcmotDebug->queueTcSpace,
+					  emcmotDebug->tps)) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "MOTION: failed to create motion emcmotPrimQueue\n");
 	return -1;
     }
 
     // and the alternate queue
-    if (-1 == tpCreate(emcmotAltQueue, DEFAULT_ALT_TC_QUEUE_SIZE,
-	    emcmotDebug->altqueueTcSpace)) {
+    if (-1 == emcmotConfig->vtp->tpCreate(emcmotAltQueue, DEFAULT_ALT_TC_QUEUE_SIZE,
+					  emcmotDebug->altqueueTcSpace,
+					  emcmotDebug->tps)) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "MOTION: failed to create motion emcmotAltQueue\n");
 	return -1;
@@ -1141,10 +1202,10 @@ static int init_comm_buffers(void)
 
 
 //    tpInit(&emcmotDebug->queue); // tpInit called from tpCreate
-    tpSetCycleTime(emcmotQueue, emcmotConfig->trajCycleTime);
-    tpSetPos(emcmotQueue, &emcmotStatus->carte_pos_cmd);
-    tpSetVmax(emcmotQueue, emcmotStatus->vel, emcmotStatus->vel);
-    tpSetAmax(emcmotQueue, emcmotStatus->acc);
+    emcmotConfig->vtp->tpSetCycleTime(emcmotQueue, emcmotConfig->trajCycleTime);
+    emcmotConfig->vtp->tpSetPos(emcmotQueue, &emcmotStatus->carte_pos_cmd);
+    emcmotConfig->vtp->tpSetVmax(emcmotQueue, emcmotStatus->vel, emcmotStatus->vel);
+    emcmotConfig->vtp->tpSetAmax(emcmotQueue, emcmotStatus->acc);
 
     // the emcmotAltQueue parameters as per above are cloned
     // by tpSnapshot() during switching queues
@@ -1274,7 +1335,7 @@ static int setTrajCycleTime(double secs)
         emcmotConfig->interpolationRate = 1;
 
     /* set traj planner */
-    tpSetCycleTime(emcmotPrimQueue, secs);
+    emcmotConfig->vtp->tpSetCycleTime(emcmotPrimQueue, secs);
 
     /* set the free planners, cubic interpolation rate and segment time */
     for (t = 0; t < num_joints; t++) {
@@ -1317,5 +1378,72 @@ static int setServoCycleTime(double secs)
     /* copy into status out */
     emcmotConfig->servoCycleTime = secs;
 
+    return 0;
+}
+
+static int init_shared(tp_shared_t *tps,
+		       struct emcmot_config_t *cfg,
+		       struct emcmot_status_t *status,
+		       emcmot_debug_t *dbg,
+		       emcmot_joint_t *joint,
+		       emcmot_hal_data_t *hal) // hal not used yet
+{
+    // global module param
+    tps->num_dio = &num_dio;
+    tps->num_aio = &num_aio;
+
+    // from emcmotConfig
+    tps->arcBlendGapCycles = &cfg->arcBlendGapCycles; // XXX FIXME TYPE ERROR ?
+    tps->arcBlendOptDepth = &cfg->arcBlendOptDepth;
+    tps->arcBlendEnable = &cfg->arcBlendEnable;
+    tps->arcBlendRampFreq = &cfg->arcBlendRampFreq;
+    tps->arcBlendFallbackEnable = &cfg->arcBlendFallbackEnable;
+    tps->maxFeedScale = &cfg->maxFeedScale;
+
+    // from emcmotStatus
+    tps->net_feed_scale = &status->net_feed_scale;
+    tps->spindle_direction = &status->spindle.direction;
+    tps->spindle_speed = &status->spindle.speed;
+    tps->spindleRevs = &status->spindleRevs;
+    tps->spindleSpeedIn = &status->spindleSpeedIn;
+    tps->spindle_index_enable = &status->spindle_index_enable;
+    tps->spindle_is_atspeed = &status->spindle_is_atspeed; // or pin
+    tps->spindleSync = &status->spindleSync;
+    tps->current_vel = &status->current_vel;
+    tps->requested_vel = &status->requested_vel;
+    tps->distance_to_go = &status->distance_to_go;
+    tps->enables_new = &status->enables_new;
+    tps->enables_queued = &status->enables_queued;
+    tps->tcqlen = &status->tcqlen;
+
+    tps->dtg[0] = &status->dtg.tran.x;
+    tps->dtg[1] = &status->dtg.tran.y;
+    tps->dtg[2] = &status->dtg.tran.z;
+    tps->dtg[3] = &status->dtg.a;
+    tps->dtg[4] = &status->dtg.b;
+    tps->dtg[5] = &status->dtg.c;
+    tps->dtg[6] = &status->dtg.u;
+    tps->dtg[7] = &status->dtg.v;
+    tps->dtg[8] = &status->dtg.w;
+
+    // from joints array
+    tps->acc_limit[0] = &joint[0].acc_limit;
+    tps->acc_limit[1] = &joint[1].acc_limit;
+    tps->acc_limit[2] = &joint[2].acc_limit;
+
+    tps->vel_limit[0] = &joint[0].vel_limit;
+    tps->vel_limit[1] = &joint[1].vel_limit;
+    tps->vel_limit[2] = &joint[2].vel_limit;
+
+    // from  emcmot_debug_t
+    tps->stepping = &dbg->stepping;
+
+    // M6x pin setters
+    tps->dioWrite = emcmotDioWrite;
+    tps->aioWrite = emcmotAioWrite;
+
+    // rotary setter/getters
+    tps->SetRotaryUnlock = emcmotSetRotaryUnlock;
+    tps->GetRotaryIsUnlocked = emcmotGetRotaryIsUnlocked;
     return 0;
 }

--- a/src/emc/motion/motion_debug.h
+++ b/src/emc/motion/motion_debug.h
@@ -16,6 +16,7 @@
 
 /*! \todo needs mot_priv.h, but including here causes conflicts */
 #include "tp.h"			/* TP_STRUCT */
+#include "tp_shared.h"		// tp_shared_t
 #include "tc.h"			/* TC_STRUCT, TC_QUEUE_STRUCT */
 
 /*********************************
@@ -69,6 +70,7 @@ typedef struct emcmot_debug_t {
 	/* flag that all active axes are homed */
 	unsigned char allHomed;
 
+        tp_shared_t *tps;
 	TP_STRUCT tp;	/* coordinated mode planner */
 
 /* space for trajectory planner queues, plus 10 more for safety */
@@ -98,7 +100,7 @@ typedef struct emcmot_debug_t {
 	int overriding;		/* non-zero means we've initiated an joint
 				   move while overriding limits */
 
-	int stepping;
+	hal_bit_t stepping;
 	int idForStep;
 
 /* Joints moved to HAL shared memory */

--- a/src/emc/motion/motion_id.h
+++ b/src/emc/motion/motion_id.h
@@ -1,0 +1,18 @@
+// spin out MOTION_ID related #defines to limit coupling between tp and motion
+
+
+#ifndef MOTION_ID_H
+#define MOTION_ID_H
+
+#include "rtapi_limits.h"
+// define a special value to denote an invalid motion ID
+// NB: do not ever generate a motion id of  MOTION_INVALID_ID
+// this should be really be tested for in command.c
+
+#define MOTION_INVALID_ID INT_MIN
+#define MOTION_ID_VALID(x) ((x) != MOTION_INVALID_ID)
+
+#define MOTION_PAUSED_RETURN_MOVE (MOTION_INVALID_ID+10)
+#define MOTION_PAUSED_JOG_MOVE (MOTION_INVALID_ID+11)
+
+#endif	/* MOTION_ID_H */

--- a/src/emc/nml_intf/emc.hh
+++ b/src/emc/nml_intf/emc.hh
@@ -552,7 +552,7 @@ int emcSetMaxFeedOverride(double maxFeedScale);
 int emcSetupArcBlends(int arcBlendEnable,
         int arcBlendFallbackEnable,
         int arcBlendOptDepth,
-        double arcBlendGapCycles,
+        int arcBlendGapCycles,
         double arcBlendRampFreq);
 
 extern int emcUpdate(EMC_STAT * stat);

--- a/src/emc/task/taskintf.cc
+++ b/src/emc/task/taskintf.cc
@@ -1559,7 +1559,7 @@ int emcMotionUpdate(EMC_MOTION_STAT * stat)
 int emcSetupArcBlends(int arcBlendEnable,
         int arcBlendFallbackEnable,
         int arcBlendOptDepth,
-        double arcBlendGapCycles,
+        int arcBlendGapCycles,
         double arcBlendRampFreq) {
 
     emcmotCommand.command = EMCMOT_SETUP_ARC_BLENDS;

--- a/src/emc/tp/Submakefile
+++ b/src/emc/tp/Submakefile
@@ -8,20 +8,20 @@ INCLUDES += $(TP_DIR)
 	cp $^ $@
 
 
-obj-m += tp.o
-tp-objs := $(addprefix $(TP_DIR)/, \
-	tc.o 		\
-	tcq.o 		\
-	tp.o 		\
-	tpmain.o 	\
-	blendmath.o 	\
-	spherical_arc.o 	\
-	) 		\
-	emc/nml_intf/emcpose.o \
-	libnml/posemath/_posemath.o
+# obj-m += tp.o
+# tp-objs := $(addprefix emc/tp/, \
+# 	tc.o 		\
+# 	tcq.o 		\
+# 	tp.o 		\
+# 	tpmain.o 	\
+# 	blendmath.o 	\
+# 	spherical_arc.o 	\
+# 	) 		\
+# 	emc/nml_intf/emcpose.o \
+# 	libnml/posemath/_posemath.o \
+# 	libnml/posemath/sincos.o $(MATHSTUB)
 
 
-ifneq "$(filter normal user-dso,$(BUILD_SYS))" ""
-$(RTLIBDIR)/tp$(MODULE_EXT): \
-	$(addprefix $(OBJDIR)/,$(tp-objs))
-endif
+# ifneq "$(filter normal user-dso,$(BUILD_SYS))" ""
+# $(RTLIBDIR)/tp$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(tp-objs))
+# endif

--- a/src/emc/tp/Submakefile
+++ b/src/emc/tp/Submakefile
@@ -1,6 +1,27 @@
-INCLUDES += emc/tp
+TP_DIR := emc/tp
+INCLUDES += $(TP_DIR)
 
-../include/%.h: ./emc/tp/%.h
+
+../include/%.h: ./$(TP_DIR)/%.h
 	cp $^ $@
-../include/%.hh: ./emc/tp/%.hh
+../include/%.hh: ./$(TP_DIR)/%.hh
 	cp $^ $@
+
+
+obj-m += tp.o
+tp-objs := $(addprefix $(TP_DIR)/, \
+	tc.o 		\
+	tcq.o 		\
+	tp.o 		\
+	tpmain.o 	\
+	blendmath.o 	\
+	spherical_arc.o 	\
+	) 		\
+	emc/nml_intf/emcpose.o \
+	libnml/posemath/_posemath.o
+
+
+ifneq "$(filter normal user-dso,$(BUILD_SYS))" ""
+$(RTLIBDIR)/tp$(MODULE_EXT): \
+	$(addprefix $(OBJDIR)/,$(tp-objs))
+endif

--- a/src/emc/tp/tc.h
+++ b/src/emc/tp/tc.h
@@ -18,7 +18,6 @@
 #include "spherical_arc.h"
 #include "posemath.h"
 #include "emcpos.h"
-#include "emcmotcfg.h"
 #include "tc_types.h"
 #include "tp_types.h"
 

--- a/src/emc/tp/tc_types.h
+++ b/src/emc/tp/tc_types.h
@@ -18,7 +18,7 @@
 #include "spherical_arc.h"
 #include "posemath.h"
 #include "emcpos.h"
-#include "emcmotcfg.h"
+#include "emcmotcfg.h"  // EMCMOT_MAX_DIO, EMCMOT_MAX_AIO
 #include "state_tag.h"
 
 /* values for endFlag */

--- a/src/emc/tp/tp.h
+++ b/src/emc/tp/tp.h
@@ -7,7 +7,7 @@
 * Author:
 * License: GPL Version 2
 * System: Linux
-*    
+*
 * Copyright (c) 2004 All rights reserved.
 *
 ********************************************************************/
@@ -19,71 +19,116 @@
 #include "tp_types.h"
 #include "tcq.h"
 
-int tpCreate(TP_STRUCT * tp, int _queueSize, TC_STRUCT * tcSpace);
-int tpClear(TP_STRUCT * tp);
-int tpInit(TP_STRUCT * tp);
-int tpClearDIOs(TP_STRUCT * const tp);
-int tpSetCycleTime(TP_STRUCT * tp, double secs);
-int tpSetVmax(TP_STRUCT * tp, double vmax, double ini_maxvel);
-int tpSetVlimit(TP_STRUCT * tp, double limit);
-int tpSetAmax(TP_STRUCT * tp, double amax);
-int tpSetId(TP_STRUCT * tp, int id);
-int tpGetExecId(TP_STRUCT * tp);
-struct state_tag_t tpGetExecTag(TP_STRUCT * const tp);
-int tpSetTermCond(TP_STRUCT * tp, int cond, double tolerance);
-int tpSetPos(TP_STRUCT * tp, EmcPose const * const pos);
-int tpAddCurrentPos(TP_STRUCT * const tp, EmcPose const * const disp);
-int tpSetCurrentPos(TP_STRUCT * const tp, EmcPose const * const pos);
-int tpRunCycle(TP_STRUCT * tp, long period);
-int tpPause(TP_STRUCT * tp);
-int tpResume(TP_STRUCT * tp);
-int tpAbort(TP_STRUCT * tp);
-int tpAddRigidTap(TP_STRUCT * const tp,
-        EmcPose end,
-        double vel,
-        double ini_maxvel,
-        double acc,
-        unsigned char enables,
-        struct state_tag_t tag);
-int tpAddLine(TP_STRUCT * const tp,
-        EmcPose end,
-        int canon_motion_type,
-        double vel,
-        double ini_maxvel,
-        double acc,
-        unsigned char enables,
-        char atspeed,
-        int indexrotary,
-        struct state_tag_t tag);
-int tpAddCircle(TP_STRUCT * const tp,
-        EmcPose end,
-        PmCartesian center,
-        PmCartesian normal,
-        int turn,
-        int canon_motion_type,
-        double vel,
-        double ini_maxvel,
-        double acc,
-        unsigned char enables,
-        char atspeed,
-        struct state_tag_t tag);
-int tpGetPos(TP_STRUCT const  * const tp, EmcPose * const pos);
-int tpIsDone(TP_STRUCT * tp);
-int tpQueueDepth(TP_STRUCT * tp);
-int tpActiveDepth(TP_STRUCT * tp);
-int tpGetMotionType(TP_STRUCT * tp);
-int tpSetSpindleSync(TP_STRUCT * tp, double sync, int wait);
-void tpToggleDIOs(TC_STRUCT * tc); //gets called when a new tc is taken from the queue. it checks and toggles all needed DIO's
+typedef struct tp_shared_t tp_shared_t;
 
-int tpSetAout(TP_STRUCT * tp, unsigned char index, double start, double end);
-int tpSetDout(TP_STRUCT * tp, int index, unsigned char start, unsigned char end); //gets called to place DIO toggles on the TC queue
+// tp API method signatures
+typedef int (*tpCreate_t)(TP_STRUCT * tp, int _queueSize, TC_STRUCT * tcSpace,
+			  tp_shared_t *shared);
+typedef int (*tpClear_t)(TP_STRUCT * tp);
+typedef int (*tpInit_t)(TP_STRUCT * tp);
+typedef int (*tpClearDIOs_t)(TP_STRUCT * const tp);
+typedef int (*tpSetCycleTime_t)(TP_STRUCT * tp, double secs);
+typedef int (*tpSetVmax_t)(TP_STRUCT * tp, double vmax, double ini_maxvel);
+typedef int (*tpSetVlimit_t)(TP_STRUCT * tp, double limit);
+typedef int (*tpSetAmax_t)(TP_STRUCT * tp, double amax);
+typedef int (*tpSetId_t)(TP_STRUCT * tp, int id);
+typedef int (*tpGetExecId_t)(TP_STRUCT * tp);
+typedef struct state_tag_t (*tpGetExecTag_t)(TP_STRUCT * const tp);
+typedef int (*tpSetTermCond_t)(TP_STRUCT * tp, int cond, double tolerance);
+typedef int (*tpSetPos_t)(TP_STRUCT * tp, EmcPose const * const pos);
+typedef int (*tpAddCurrentPos_t)(TP_STRUCT * const tp, EmcPose const * const disp);
+typedef int (*tpSetCurrentPos_t)(TP_STRUCT * const tp, EmcPose const * const pos);
+typedef int (*tpAddRigidTap_t)(TP_STRUCT * tp,
+			       EmcPose end,
+			       double vel,
+			       double ini_maxvel,
+			       double acc,
+			       unsigned char enables,
+			       struct state_tag_t tag);
+typedef int (*tpAddLine_t)(TP_STRUCT * tp,
+			   EmcPose end,
+			   int type,
+			   double vel,
+			   double ini_maxvel,
+			   double acc,
+			   unsigned char enables,
+			   char atspeed,
+			   int indexrotary,
+			    struct state_tag_t tag);
+typedef int (*tpAddCircle_t)(TP_STRUCT * tp,
+			     EmcPose end,
+			     PmCartesian center,
+			     PmCartesian normal,
+			     int turn,
+			     int type,
+			     double vel,
+			     double ini_maxvel,
+			     double acc,
+			     unsigned char enables,
+			     char atspeed,
+			    struct state_tag_t tag);
+typedef int (*tpRunCycle_t)(TP_STRUCT * tp, long period);
+typedef int (*tpPause_t)(TP_STRUCT * tp);
+typedef int (*tpResume_t)(TP_STRUCT * tp);
+typedef int (*tpAbort_t)(TP_STRUCT * tp);
+typedef int (*tpGetPos_t)(TP_STRUCT const  * const tp, EmcPose * const pos);
+typedef int (*tpIsDone_t)(TP_STRUCT * tp);
+typedef int (*tpQueueDepth_t)(TP_STRUCT * tp);
+typedef int (*tpActiveDepth_t)(TP_STRUCT * tp);
+typedef int (*tpGetMotionType_t)(TP_STRUCT * tp);
+typedef int (*tpSetSpindleSync_t)(TP_STRUCT * tp, double sync, int wait);
+typedef int (*tcqFull_t)(TC_QUEUE_STRUCT const * const tcq);
 
-//Misc utlity functions for motion
-int tpFindIntersectionAngle(PmCartesian const * const u1,
-        PmCartesian const * const u2, double * const theta);
+//gets called when a new tc is taken from the queue. it checks and toggles all needed DIO's
+typedef void (*tpToggleDIOs_t)(TP_STRUCT const * const tp,TC_STRUCT * tc);
+
+typedef int (*tpSetAout_t)(TP_STRUCT * tp, unsigned char index, double start, double end);
+
+ //gets called to place DIO toggles on the TC queue
+typedef int (*tpSetDout_t)(TP_STRUCT * tp, int index, unsigned char start, unsigned char end);
 
 // for jog-while-paused:
-extern int tpIsPaused(TP_STRUCT * tp);
-extern int tpSnapshot(TP_STRUCT * from, TP_STRUCT * to);
+typedef int (*tpIsPaused_t)(TP_STRUCT * tp);
+typedef int (*tpSnapshot_t)(TP_STRUCT * from, TP_STRUCT * to);
+
+
+// the tp API vtable
+typedef struct {
+    tpCreate_t          tpCreate;
+    tpClear_t           tpClear;
+    tpInit_t            tpInit;
+    tpClearDIOs_t	tpClearDIOs;
+    tpSetCycleTime_t    tpSetCycleTime;
+    tpSetVmax_t	        tpSetVmax;
+    tpSetVlimit_t	tpSetVlimit;
+    tpSetAmax_t		tpSetAmax;
+    tpSetId_t	        tpSetId;
+    tpGetExecId_t	tpGetExecId;
+    tpGetExecTag_t      tpGetExecTag;
+    tpSetTermCond_t	tpSetTermCond;
+    tpSetPos_t          tpSetPos;
+    tpAddCurrentPos_t   tpAddCurrentPos;
+    tpSetCurrentPos_t   tpSetCurrentPos;
+    tpAddRigidTap_t	tpAddRigidTap;
+    tpAddLine_t	        tpAddLine;
+    tpAddCircle_t	tpAddCircle;
+    tpRunCycle_t	tpRunCycle;
+    tpPause_t	        tpPause;
+    tpResume_t	        tpResume;
+    tpAbort_t	        tpAbort;
+    tpGetPos_t          tpGetPos;
+    tpIsDone_t          tpIsDone;
+    tpQueueDepth_t	tpQueueDepth;
+    tpActiveDepth_t	tpActiveDepth;
+    tpGetMotionType_t   tpGetMotionType;
+    tpSetSpindleSync_t  tpSetSpindleSync;
+    tpToggleDIOs_t	tpToggleDIOs;
+    tpSetAout_t	        tpSetAout;
+    tpSetDout_t	        tpSetDout;
+    tpIsPaused_t	tpIsPaused;
+    tpSnapshot_t	tpSnapshot;
+    tcqFull_t           tcqFull;
+} vtp_t;
+
 
 #endif				/* TP_H */

--- a/src/emc/tp/tp_private.h
+++ b/src/emc/tp/tp_private.h
@@ -1,0 +1,86 @@
+// signatures of the - formerly exposed extern - methods of the tp
+// these are used internally only now, and to populate the tp vtable
+// in tpmain.c
+
+#ifndef TP_PRIVATE_H
+#define TP_PRIVATE_H
+
+#include "posemath.h"
+#include "tc_types.h"
+#include "tp_types.h"
+#include "tcq.h"
+
+int tpCreate(TP_STRUCT * tp, int _queueSize, TC_STRUCT * tcSpace,  tp_shared_t *shared);
+
+int tpClear(TP_STRUCT * tp);
+
+int tpInit(TP_STRUCT * tp);
+
+int tpClearDIOs(TP_STRUCT * const tp);
+
+int tpSetCycleTime(TP_STRUCT * tp, double secs);
+
+int tpSetVmax(TP_STRUCT * tp, double vmax, double ini_maxvel);
+
+int tpSetVlimit(TP_STRUCT * tp, double limit);
+
+int tpSetAmax(TP_STRUCT * tp, double amax);
+
+int tpSetId(TP_STRUCT * tp, int id);
+
+int tpGetExecId(TP_STRUCT * tp);
+
+struct state_tag_t tpGetExecTag(TP_STRUCT * const tp);
+
+int tpSetTermCond(TP_STRUCT * tp, int cond, double tolerance);
+
+int tpSetPos(TP_STRUCT * tp, EmcPose const * const pos);
+
+int tpAddCurrentPos(TP_STRUCT * const tp, EmcPose const * const disp);
+
+int tpSetCurrentPos(TP_STRUCT * const tp, EmcPose const * const pos);
+
+int tpAddRigidTap(TP_STRUCT * tp, EmcPose end, double vel, double
+		  ini_maxvel, double acc, unsigned char enables,
+		  struct state_tag_t tag);
+
+int tpAddLine(TP_STRUCT * tp, EmcPose end, int type, double vel, double
+	      ini_maxvel, double acc, unsigned char enables, char atspeed,
+	      int indexrotary,struct state_tag_t tag);
+
+int tpAddCircle(TP_STRUCT * tp, EmcPose end, PmCartesian center,
+		PmCartesian normal, int turn, int type, double vel, double ini_maxvel,
+		double acc, unsigned char enables, char atspeed,struct state_tag_t tag);
+
+int tpRunCycle(TP_STRUCT * tp, long period);
+
+int tpPause(TP_STRUCT * tp);
+
+int tpResume(TP_STRUCT * tp);
+
+int tpAbort(TP_STRUCT * tp);
+
+int tpGetPos(TP_STRUCT const  * const tp, EmcPose * const pos);
+
+int tpIsDone(TP_STRUCT * tp);
+
+int tpQueueDepth(TP_STRUCT * tp);
+
+int tpActiveDepth(TP_STRUCT * tp);
+
+int tpGetMotionType(TP_STRUCT * tp);
+
+int tpSetSpindleSync(TP_STRUCT * tp, double sync, int wait);
+
+void tpToggleDIOs(TP_STRUCT const * const tp,TC_STRUCT * tc); //gets called when a new tc is taken from the queue. it checks and toggles all needed DIO's
+
+int tpSetAout(TP_STRUCT * tp, unsigned char index, double start, double end);
+
+int tpSetDout(TP_STRUCT * tp, int index, unsigned char start, unsigned char end); //gets called to place DIO toggles on the TC queue
+
+// for jog-while-paused:
+int tpIsPaused(TP_STRUCT * tp);
+
+int tpSnapshot(TP_STRUCT * from, TP_STRUCT * to);
+
+#endif // TP_PRIVATE_H

--- a/src/emc/tp/tp_shared.h
+++ b/src/emc/tp/tp_shared.h
@@ -1,0 +1,228 @@
+#ifndef _TP_SHARED_H
+#define _TP_SHARED_H
+
+#include "hal.h"
+#include "emcpose.h"
+
+typedef void (*emcmotDioWrite_t)(int index, hal_bit_t   value);
+typedef void (*emcmotAioWrite_t)(int index, hal_float_t value);
+
+typedef void (*emcmotSetRotaryUnlock_t)(int axis, hal_bit_t unlock);
+typedef hal_bit_t  (*emcmotGetRotaryIsUnlocked_t)(int axis);
+
+
+// this holds all shared data between using code and the tp
+// data items can be pins if so desired,
+// in this case the tp_shared struct must live in HAL memory, and
+// be allocated by hal_malloc()
+
+typedef struct tp_shared_t {
+
+    // read-only by tp, config items
+    hal_s32_t   *num_dio;
+    hal_s32_t   *num_aio;
+
+    hal_s32_t   *arcBlendGapCycles;
+    hal_s32_t   *arcBlendOptDepth;
+    hal_bit_t   *arcBlendEnable;
+    hal_float_t *arcBlendRampFreq;
+    hal_bit_t   *arcBlendFallbackEnable;
+    hal_float_t *maxFeedScale;
+    hal_float_t *net_feed_scale;
+
+    hal_float_t *acc_limit[3];
+    hal_float_t *vel_limit[3];
+
+    hal_bit_t  *stepping;
+    hal_u32_t  *enables_new;
+
+    // read/write by tp:
+    // NB: this is the direction field in struct spindle_status
+    // (there's another direction field in emcmot_command_t)
+    hal_s32_t  *spindle_direction;	// 0 stopped, 1 forward, -1 reverse
+    hal_float_t *spindleRevs;
+    hal_float_t *spindleSpeedIn;
+    hal_float_t *spindle_speed;  // in struct spindle_status
+    hal_bit_t   *spindle_index_enable;
+    hal_bit_t   *spindle_is_atspeed; // emcmotStatus->spindle_is_atspeed
+
+    hal_bit_t   *spindleSync;
+    hal_float_t *current_vel;
+    hal_float_t *dtg[9]; // an EmcPose
+
+    // write-only by tp:
+    hal_float_t *requested_vel;
+    hal_float_t *distance_to_go;
+    hal_u32_t   *enables_queued;
+    hal_u32_t   *tcqlen;
+
+    // upcalls by the tp into using code to set pin values:
+    emcmotDioWrite_t dioWrite;
+    emcmotAioWrite_t aioWrite;
+
+    emcmotSetRotaryUnlock_t SetRotaryUnlock;
+    emcmotGetRotaryIsUnlocked_t GetRotaryIsUnlocked;
+
+} tp_shared_t;
+
+static inline int get_num_dio(tp_shared_t *ts)  { return *(ts->num_dio); }
+static inline void set_num_dio(tp_shared_t *ts, int n)  { *(ts->num_dio) = n; }
+
+static inline int get_num_aio(tp_shared_t *ts)  { return *(ts->num_aio); }
+static inline void set_num_aio(tp_shared_t *ts, int n)  { *(ts->num_aio) = n; }
+
+static inline hal_float_t get_acc_limit(tp_shared_t *ts, int n)
+{ return *(ts->acc_limit[n]); }
+static inline void set_acc_limit(tp_shared_t *ts, int n, hal_float_t val)
+{ *(ts->acc_limit[n]) = val; }
+
+static inline hal_float_t get_vel_limit(tp_shared_t *ts, int n)
+{ return *(ts->vel_limit[n]); }
+static inline void set_vel_limit(tp_shared_t *ts, int n, hal_float_t val)
+{ *(ts->vel_limit[n]) = val; }
+
+static inline hal_float_t get_net_feed_scale(tp_shared_t *ts)
+{ return *(ts->net_feed_scale); }
+static inline hal_float_t get_maxFeedScale(tp_shared_t *ts)
+{ return *(ts->maxFeedScale); }
+
+static inline hal_bit_t get_stepping(tp_shared_t *ts)
+{ return *(ts->stepping); }
+
+static inline hal_float_t get_current_vel(tp_shared_t *ts)
+{ return *(ts->current_vel); }
+static inline void set_current_vel(tp_shared_t *ts, hal_float_t n)
+{ *(ts->current_vel) = n; }
+
+static inline hal_float_t get_requested_vel(tp_shared_t *ts)
+{ return *(ts->requested_vel); }
+static inline void set_requested_vel(tp_shared_t *ts, hal_float_t n)
+{ *(ts->requested_vel) = n; }
+
+static inline hal_float_t get_distance_to_go(tp_shared_t *ts)
+{ return *(ts->distance_to_go); }
+static inline void set_distance_to_go(tp_shared_t *ts, hal_float_t n)
+{ *(ts->distance_to_go) = n; }
+
+static inline hal_bit_t get_spindleSync(tp_shared_t *ts)
+{ return *(ts->spindleSync); }
+static inline void set_spindleSync(tp_shared_t *ts, hal_bit_t n)
+{ *(ts->spindleSync) = n; }
+
+static inline void zero_dtg(tp_shared_t *ts)
+{
+    unsigned i;
+    for (i = 0; i < sizeof(ts->dtg)/sizeof(ts->dtg[0]); i++)
+	*(ts->dtg[i]) = 0.0;
+}
+
+static inline hal_s32_t get_arcBlendGapCycles(tp_shared_t *ts)
+{ return *(ts->arcBlendGapCycles); }
+static inline void set_arcBlendGapCycles(tp_shared_t *ts, hal_s32_t n)
+{ *(ts->arcBlendGapCycles) = n; }
+
+static inline hal_s32_t get_arcBlendOptDepth(tp_shared_t *ts)
+{ return *(ts->arcBlendOptDepth); }
+static inline void set_arcBlendOptDepth(tp_shared_t *ts, hal_s32_t n)
+{ *(ts->arcBlendOptDepth) = n; }
+
+static inline hal_bit_t get_arcBlendEnable(tp_shared_t *ts)
+{ return *(ts->arcBlendEnable); }
+static inline void set_arcBlendEnable(tp_shared_t *ts, hal_bit_t n)
+{ *(ts->arcBlendEnable) = n; }
+
+static inline hal_float_t get_arcBlendRampFreq(tp_shared_t *ts)
+{ return *(ts->arcBlendRampFreq); }
+static inline void set_arcBlendRampFreq(tp_shared_t *ts, hal_float_t n)
+{ *(ts->arcBlendRampFreq) = n; }
+
+static inline void dioWrite(tp_shared_t *ts, int index, char value)
+{ if (ts->dioWrite) ts->dioWrite(index, value); }
+static inline void aioWrite(tp_shared_t *ts, int index, double value)
+{ if (ts->aioWrite) ts->aioWrite(index, value); }
+
+static inline hal_float_t get_spindleRevs(tp_shared_t *ts)
+{ return *(ts->spindleRevs); }
+static inline void set_spindleRevs(tp_shared_t *ts, hal_float_t n)
+{ *(ts->spindleRevs) = n; }
+
+static inline hal_float_t get_spindleSpeedIn(tp_shared_t *ts)
+{ return *(ts->spindleSpeedIn); }
+static inline void set_spindleSpeedIn(tp_shared_t *ts, hal_float_t n)
+{ *(ts->spindleSpeedIn) = n; }
+
+static inline hal_s32_t get_spindle_direction(tp_shared_t *ts)
+{ return *(ts->spindle_direction); }
+static inline void set_spindle_direction(tp_shared_t *ts, hal_s32_t n)
+{ *(ts->spindle_direction) = n; }
+
+static inline hal_float_t get_spindle_speed(tp_shared_t *ts)
+{ return *(ts->spindle_speed); }
+static inline void set_spindle_speed(tp_shared_t *ts, hal_float_t n)
+{ *(ts->spindle_speed) = n; }
+
+static inline hal_bit_t get_spindle_is_atspeed(tp_shared_t *ts)
+{ return *(ts->spindle_is_atspeed); }
+static inline void set_spindle_is_atspeed(tp_shared_t *ts, hal_bit_t n)
+{ *(ts->spindle_is_atspeed) = n; }
+
+static inline hal_bit_t get_spindle_index_enable(tp_shared_t *ts)
+{ return *(ts->spindle_index_enable); }
+static inline void set_spindle_index_enable(tp_shared_t *ts, hal_bit_t n)
+{ *(ts->spindle_index_enable) = n; }
+
+static inline hal_u32_t get_enables_queued(tp_shared_t *ts)
+{ return *(ts->enables_queued); }
+static inline void set_enables_queued(tp_shared_t *ts, hal_u32_t n)
+{ *(ts->enables_queued) = n; }
+
+static inline hal_u32_t get_tcqlen(tp_shared_t *ts)
+{ return *(ts->tcqlen); }
+static inline void set_tcqlen(tp_shared_t *ts, hal_u32_t n)
+{ *(ts->tcqlen) = n; }
+
+static inline hal_u32_t get_enables_new(tp_shared_t *ts)
+{ return *(ts->enables_new); }
+static inline void set_enables_new(tp_shared_t *ts, hal_u32_t n)
+{ *(ts->enables_new) = n; }
+
+// subtract two emcPose values and deposit the result
+// in a hal_float_t * array
+static inline int emcPoseSub2fp(EmcPose const * const p1,
+				EmcPose const * const p2,
+				hal_float_t ** const out)
+{
+#ifdef EMCPOSE_PEDANTIC
+    if (!p1 || !p2) {
+        return EMCPOSE_ERR_INPUT_MISSING;
+    }
+#endif
+    *(out[0]) = p1->tran.x - p2->tran.x;
+    *(out[1]) = p1->tran.y - p2->tran.y;
+    *(out[2]) = p1->tran.z - p2->tran.z;
+    *(out[3]) = p1->a - p2->a;
+    *(out[4]) = p1->b - p2->b;
+    *(out[5]) = p1->c - p2->c;
+    *(out[6]) = p1->u - p2->u;
+    *(out[7]) = p1->v - p2->v;
+    *(out[8]) = p1->w - p2->w;
+    return EMCPOSE_ERR_OK;
+}
+
+static inline void SetRotaryUnlock(tp_shared_t *ts,
+				   int axis,
+				   hal_bit_t unlock)
+{
+    if (ts->SetRotaryUnlock)
+	ts->SetRotaryUnlock(axis, unlock);
+}
+
+static inline int GetRotaryIsUnlocked(tp_shared_t *ts,
+				      int axis)
+{
+    if (ts->GetRotaryIsUnlocked)
+	return ts->GetRotaryIsUnlocked(axis);
+    return 0;
+}
+
+#endif //_TP_SHARED_H

--- a/src/emc/tp/tp_types.h
+++ b/src/emc/tp/tp_types.h
@@ -134,6 +134,7 @@ typedef struct {
 				   FALSE if in position mode */
     double uu_per_rev;          /* user units per spindle revolution */
 
+    double old_spindlepos; // temporary in tpUpdateRigidTapState
 
     syncdio_t syncdio; //record tpSetDout's here
 

--- a/src/emc/tp/tp_types.h
+++ b/src/emc/tp/tp_types.h
@@ -85,6 +85,8 @@ typedef struct {
      int waiting_for_atspeed;
 } tp_spindle_t;
 
+typedef struct tp_shared_t tp_shared_t; // see tp_shared.h
+
 /**
  * Trajectory planner state structure.
  * Stores persistant data for the trajectory planner that should be accessible
@@ -93,6 +95,7 @@ typedef struct {
 typedef struct {
     TC_QUEUE_STRUCT queue;
     tp_spindle_t spindle; //Spindle data
+    tp_shared_t *shared;
 
     EmcPose currentPos;
     EmcPose goalPos;
@@ -135,5 +138,6 @@ typedef struct {
     syncdio_t syncdio; //record tpSetDout's here
 
 } TP_STRUCT;
+
 
 #endif				/* TP_TYPES_H */

--- a/src/emc/tp/tpmain.c
+++ b/src/emc/tp/tpmain.c
@@ -1,0 +1,78 @@
+#include "rtapi.h"		/* RTAPI realtime OS API */
+#include "rtapi_app.h"		/* RTAPI realtime module decls */
+#include "hal.h"
+#include "vtable.h"
+#include "tp.h"
+#include "tp_private.h"
+
+#define VTVERSION  VTTP_VERSION1
+
+MODULE_AUTHOR("Michael Haberler");
+MODULE_DESCRIPTION("machinekit trajectory planner");
+MODULE_LICENSE("GPL");
+
+
+// tp method dispatch vtable
+static vtp_t vtp = {
+    .tpCreate          = tpCreate,
+    .tpClear           = tpClear,
+    .tpInit            = tpInit,
+    .tpClearDIOs       = tpClearDIOs,
+    .tpSetCycleTime    = tpSetCycleTime,
+    .tpSetVmax         = tpSetVmax,
+    .tpSetVlimit       = tpSetVlimit,
+    .tpSetAmax         = tpSetAmax,
+    .tpSetId           = tpSetId,
+    .tpGetExecId       = tpGetExecId,
+    .tpGetExecTag      = tpGetExecTag,
+    .tpSetTermCond     = tpSetTermCond,
+    .tpSetPos          = tpSetPos,
+    .tpAddCurrentPos   = tpAddCurrentPos,
+    .tpSetCurrentPos   = tpSetCurrentPos,
+    .tpAddRigidTap     = tpAddRigidTap,
+    .tpAddLine         = tpAddLine,
+    .tpAddCircle       = tpAddCircle,
+    .tpRunCycle        = tpRunCycle,
+    .tpPause           = tpPause,
+    .tpResume          = tpResume,
+    .tpAbort           = tpAbort,
+    .tpGetPos          = tpGetPos,
+    .tpIsDone          = tpIsDone,
+    .tpQueueDepth      = tpQueueDepth,
+    .tpActiveDepth     = tpActiveDepth,
+    .tpGetMotionType   = tpGetMotionType,
+    .tpSetSpindleSync  = tpSetSpindleSync,
+    .tpToggleDIOs      = tpToggleDIOs,
+    .tpSetAout         = tpSetAout,
+    .tpSetDout         = tpSetDout,
+    .tpIsPaused        = tpIsPaused,
+    .tpSnapshot        = tpSnapshot,
+    .tcqFull           = tcqFull,
+};
+
+static int comp_id, vtable_id;
+const  char *mod_name = "tp";
+static char *name = "tp";
+RTAPI_MP_STRING(name, "tp vtable name");
+
+int rtapi_app_main(void) {
+    comp_id = hal_init(mod_name);
+    if(comp_id > 0) {
+	vtable_id = hal_export_vtable(name, VTVERSION, &vtp, comp_id);
+	if (vtable_id < 0) {
+	    rtapi_print_msg(RTAPI_MSG_ERR,
+			    "%s: ERROR: hal_export_vtable(%s,%d,%p) failed: %d\n",
+			    mod_name, name, VTVERSION, &vtp, vtable_id );
+	    return -ENOENT;
+	}
+	hal_ready(comp_id);
+	return 0;
+    }
+    return comp_id;
+}
+
+void rtapi_app_exit(void)
+{
+    hal_remove_vtable(vtable_id);
+    hal_exit(comp_id);
+}

--- a/src/hal/lib/Submakefile
+++ b/src/hal/lib/Submakefile
@@ -12,6 +12,7 @@ HALLIBSRCS := $(HALLIBDIR)/hal_lib.c \
 	$(HALLIBDIR)/hal_ring.c \
 	$(HALLIBDIR)/hal_iter.c \
 	$(HALLIBDIR)/hal_rcomp.c \
+	$(HALLIBDIR)/hal_vtable.c \
 	rtapi/rtapi_heap.c
 
 # protobuf support functions which depend on HAL - on RT host only
@@ -70,5 +71,6 @@ hal_lib-objs := hal/lib/hal_lib.o $(MATHSTUB)
 hal_lib-objs += hal/lib/hal_group.o
 hal_lib-objs += hal/lib/hal_ring.o
 hal_lib-objs += hal/lib/hal_rcomp.o
+hal_lib-objs += hal/lib/hal_vtable.o
 
 $(RTLIBDIR)/hal_lib$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hal_lib-objs))

--- a/src/hal/lib/hal.h
+++ b/src/hal/lib/hal.h
@@ -906,6 +906,20 @@ extern int hal_start_threads(void);
 */
 extern int hal_stop_threads(void);
 
+// returns vtable ID (handle, >0) or error code (< 0)
+// mark as owned by comp comp_id (optional, zero if not owned)
+int hal_export_vtable(const char *name, int version, void *vtable, int comp_id);
+int hal_remove_vtable(int vtable_id);
+
+// returns vtable_id (handle) or error code
+// increases refcount
+int hal_reference_vtable(const char *name, int version, void **vtable);
+
+// drops refcount
+int hal_unreference_vtable(int vtable_id);
+
+
+
 /** HAL 'constructor' typedef
     If it is not NULL, this points to a function which can construct a new
     instance of its component.  Return value is >=0 for success,

--- a/src/hal/lib/hal_lib.c
+++ b/src/hal/lib/hal_lib.c
@@ -2902,6 +2902,7 @@ static int init_hal_data(void)
     hal_data->param_list_ptr = 0;
     hal_data->funct_list_ptr = 0;
     hal_data->thread_list_ptr = 0;
+    hal_data->vtable_list_ptr = 0;
     hal_data->base_period = 0;
     hal_data->threads_running = 0;
     hal_data->oldname_free_ptr = 0;
@@ -2910,6 +2911,7 @@ static int init_hal_data(void)
     hal_data->sig_free_ptr = 0;
     hal_data->param_free_ptr = 0;
     hal_data->funct_free_ptr = 0;
+    hal_data->vtable_free_ptr = 0;
     hal_data->pending_constructor = 0;
     hal_data->constructor_prefix[0] = 0;
     list_init_entry(&(hal_data->funct_entry_free));
@@ -3735,7 +3737,7 @@ const char *hal_lasterror()
 }
 
 #ifdef RTAPI
-/* only export symbols when we're building a kernel module */
+/* only export symbols when we're building a realtime module */
 
 EXPORT_SYMBOL(hal_init);
 EXPORT_SYMBOL(hal_init_mode);

--- a/src/hal/lib/hal_priv.h
+++ b/src/hal/lib/hal_priv.h
@@ -210,6 +210,8 @@ typedef struct {
     int param_list_ptr;		/* root of linked list of parameters */
     int funct_list_ptr;		/* root of linked list of functions */
     int thread_list_ptr;	/* root of linked list of threads */
+    int vtable_list_ptr;	        /* root of linked list of vtables */
+
     long base_period;		/* timer period for realtime tasks */
     int threads_running;	/* non-zero if threads are started */
     int oldname_free_ptr;	/* list of free oldname structs */
@@ -220,6 +222,7 @@ typedef struct {
     int funct_free_ptr;		/* list of free function structs */
     hal_list_t funct_entry_free;	/* list of free funct entry structs */
     int thread_free_ptr;	/* list of free thread structs */
+    int vtable_free_ptr;   	/* list of free vtable structs */
     int exact_base_period;      /* if set, pretend that rtapi satisfied our
 				   period request exactly */
     unsigned char lock;         /* hal locking, can be one of the HAL_LOCK_* types */
@@ -368,6 +371,20 @@ typedef struct {
     char name[HAL_NAME_LEN + 1];	/* thread name */
 } hal_thread_t;
 
+
+// represents a HAL vtable object
+typedef struct {
+    int next_ptr;		   // next vtable in linked list
+    int context;                   // 0 for RT, pid for userland
+    int comp_id;                   // optional owning comp reference, 0 if unused
+    int handle;                    // unique ID
+    int refcount;                  // prevents unloading while referenced
+    int version;                   // tags switchs struct version
+    void *vtable;     // pointer to vtable (valid in loading context only)
+    char name[HAL_NAME_LEN + 1];   // vtable name
+} hal_vtable_t;
+
+
 /* IMPORTANT:  If any of the structures in this file are changed, the
    version code (HAL_VER) must be incremented, to ensure that
    incompatible utilities, etc, aren't used to manipulate data in
@@ -498,6 +515,10 @@ extern hal_funct_t *halpr_find_funct_by_owner(hal_comp_t * owner,
     the next matching pin.  If no match is found, it returns NULL
 */
 extern hal_pin_t *halpr_find_pin_by_sig(hal_sig_t * sig, hal_pin_t * start);
+
+hal_vtable_t *halpr_find_vtable_by_name(const char *name, int version);
+hal_vtable_t *halpr_find_vtable_by_id(int vtable_id);
+
 
 // automatically release the local hal_data->mutex on scope exit.
 // if a local variable is declared like so:

--- a/src/hal/lib/hal_ring.c
+++ b/src/hal/lib/hal_ring.c
@@ -184,7 +184,7 @@ int hal_ring_delete(const char *name)
 	}
 
 	ringheader_t *rhptr;
-	int shmid;
+	int shmid = -1;
 
 	if (hrptr->flags & ALLOC_HALMEM) {
 	    // ring exists as HAL memory.

--- a/src/hal/lib/hal_vtable.c
+++ b/src/hal/lib/hal_vtable.c
@@ -1,0 +1,320 @@
+
+#include "config.h"
+#include "rtapi.h"		/* RTAPI realtime OS API */
+#include "hal.h"		/* HAL public API decls */
+#include "hal_priv.h"		/* HAL private decls */
+
+#if defined(ULAPI)
+#include <stdio.h>
+#include <sys/types.h>		/* pid_t */
+#include <unistd.h>		/* getpid() */
+#endif
+
+static hal_vtable_t *alloc_vtable_struct(void);
+static void free_vtable_struct(hal_vtable_t *c);
+
+
+/***********************************************************************
+*                     Public HAL vtable functions                       *
+************************************************************************/
+int hal_export_vtable(const char *name, int version, void *vtref, int comp_id)
+{
+    if (hal_data == 0) {
+	hal_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: hal_export_vtable called before init\n");
+	return -EINVAL;
+    }
+    if (vtref == NULL) {
+	hal_print_msg(RTAPI_MSG_ERR,
+		      "HAL: ERROR: hal_export_vtable called with NULL vtable\n");
+	return -EINVAL;
+    }
+    if (!name) {
+	hal_print_msg(RTAPI_MSG_ERR,
+			"HAL: ERROR: hal_export_vtable: NULL name\n");
+	return -EINVAL;
+    }
+    if (strlen(name) > HAL_NAME_LEN) {
+	hal_print_msg(RTAPI_MSG_ERR,
+			"HAL: ERROR: vtable name '%s' is too long\n", name);
+	return -EINVAL;
+    }
+    {
+	hal_vtable_t *vt __attribute__((cleanup(halpr_autorelease_mutex)));
+
+	rtapi_mutex_get(&(hal_data->mutex));
+
+	if (hal_data->lock & HAL_LOCK_LOAD)  {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			    "HAL: ERROR: hal_export_vtable called while HAL locked\n");
+	    return -EPERM;
+	}
+
+	// make sure no such vtable name already exists
+	if ((vt = halpr_find_vtable_by_name(name, version)) != 0) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			    "HAL: ERROR: vtable '%s' already exists\n", name);
+	    return -EEXIST;
+	}
+
+	// allocate a new vtable descriptor in the HAL shm segment
+	if ((vt = alloc_vtable_struct()) == NULL) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			  "HAL: ERROR: insufficient memory for vtable '%s'\n",
+			  name);
+	    return -ENOMEM;
+	}
+
+	vt->refcount = 0;
+	vt->vtable  =  vtref;
+	vt->version =  version;
+	vt->handle = rtapi_next_handle();
+	vt->comp_id = comp_id;
+#ifdef RTAPI
+	vt->context = 0;  // this is in RTAPI, and can be shared
+#else
+	vt->context = getpid(); // in per-process memory, no shareable code
+#endif
+	rtapi_snprintf(vt->name, sizeof(vt->name), "%s", name);
+
+	// insert new structure at head of vtable list
+	vt->next_ptr = hal_data->vtable_list_ptr;
+	hal_data->vtable_list_ptr = SHMOFF(vt);
+
+	hal_print_msg(RTAPI_MSG_DBG, "HAL: created vtable '%s' vtable=%p version=%d\n",
+		      vt->name, vt->vtable, vt->version);
+
+	// automatic unlock by scope exit
+	return vt->handle;
+    }
+}
+
+
+int hal_remove_vtable(int vtable_id)
+{
+    if (hal_data == 0) {
+	hal_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: hal_remove_vtable called before init\n");
+	return -EINVAL;
+    }
+    {
+	hal_vtable_t *vt __attribute__((cleanup(halpr_autorelease_mutex)));
+	rtapi_mutex_get(&(hal_data->mutex));
+	if (hal_data->lock & HAL_LOCK_LOAD)  {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			    "HAL: ERROR: hal_remove_vtable called while HAL locked\n");
+	    return -EPERM;
+	}
+
+	// make sure no such vtable name already exists
+	if ((vt = halpr_find_vtable_by_id(vtable_id)) == NULL) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			  "HAL: ERROR: hal_remove_vtable(%d): vtable not found\n", vtable_id);
+	    return -ENOENT;
+	}
+	// still referenced?
+	if (vt->refcount > 0) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			  "HAL: ERROR: hal_remove_vtable(%d): busy (refcount=%d)\n",
+			  vtable_id, vt->refcount);
+	    return -ENOENT;
+
+	}
+	int *prev, next;
+	hal_vtable_t *c;
+
+	prev = &(hal_data->vtable_list_ptr);
+	next = *prev;
+	while (1) {
+	    if (next == 0) {
+		hal_print_msg(RTAPI_MSG_ERR,
+			      "HAL: ERROR: vtable %d not found\n", vtable_id);
+		return -EINVAL;
+	    }
+	    c = SHMPTR(next);
+	    if ( c == vt ) {
+		*prev = c->next_ptr; // unlink
+		break;
+	    }
+	    prev = &(c->next_ptr);
+	    next = *prev;
+	}
+	free_vtable_struct(vt);
+	hal_print_msg(RTAPI_MSG_DBG,
+		      "HAL: hal_remove_vtable(%d): vtable %s/%d removed\n",
+		      vtable_id, vt->name, vt->version);
+	return 0;
+    }
+}
+
+// returns vtable_id (handle) or error code
+// increases refcount
+int hal_reference_vtable(const char *name, int version, void **vtableref)
+{
+    if (hal_data == 0) {
+	hal_print_msg(RTAPI_MSG_ERR,
+		      "HAL: ERROR: hal_reference_vtable called before init\n");
+	return -EINVAL;
+    }
+    if (vtableref == NULL) {
+	hal_print_msg(RTAPI_MSG_ERR,
+		      "HAL: ERROR: hal_reference_vtable called with NULL vtable\n");
+	return -EINVAL;
+    }
+    if (!name) {
+	hal_print_msg(RTAPI_MSG_ERR,
+		      "HAL: ERROR: hal_export_vtable: NULL name\n");
+	return -EINVAL;
+    }
+    {
+	hal_vtable_t *vt __attribute__((cleanup(halpr_autorelease_mutex)));
+
+	rtapi_mutex_get(&(hal_data->mutex));
+
+	if (hal_data->lock & HAL_LOCK_LOAD)  {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			  "HAL: ERROR: hal_reference_vtable called while HAL locked\n");
+	    return -EPERM;
+	}
+
+	// make sure no such vtable name already exists
+	if ((vt = halpr_find_vtable_by_name(name, version)) == NULL) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			  "HAL: ERROR: vtable '%s' version %d not found\n",
+			  name, version);
+	    return -ENOENT;
+	}
+
+	// make sure it's in the proper context
+#ifdef RTAPI
+	int context = 0;  // this is in RTAPI, and can be shared
+#else
+	int context = getpid(); // in per-process memory, no shareable code
+#endif
+	if (vt->context != context) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			  "HAL: ERROR: hal_reference_vtable(%s,%d): "
+			  "context mismatch - found context %d\n",
+			  name, version, vt->context);
+	    return -ENOENT;
+	}
+
+	vt->refcount += 1;
+	*vtableref = vt->vtable;
+	hal_print_msg(RTAPI_MSG_DBG,
+		      "HAL: hal_reference_vtable(%s,%d) found vtable=%p context=%d\n",
+		      vt->name, vt->version, vt->vtable, vt->context);
+
+	// automatic unlock by scope exit
+	return vt->handle;
+    }
+}
+
+// drops refcount
+int hal_unreference_vtable(int vtable_id)
+{
+    if (hal_data == 0) {
+	hal_print_msg(RTAPI_MSG_ERR,
+		      "HAL: ERROR: hal_unreference_vtable called before init\n");
+	return -EINVAL;
+    }
+    {
+	hal_vtable_t *vt __attribute__((cleanup(halpr_autorelease_mutex)));
+	rtapi_mutex_get(&(hal_data->mutex));
+
+	// make sure no such vtable name already exists
+	if ((vt = halpr_find_vtable_by_id(vtable_id)) == NULL) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			  "HAL: ERROR: hal_unreference_vtable(id=%d) not found\n",
+			  vtable_id);
+	    return -ENOENT;
+	}
+
+	// make sure it's in the proper context
+#ifdef RTAPI
+	int context = 0;  // this is in RTAPI, and can be shared
+#else
+	int context = getpid(); // in per-process memory, no shareable code
+#endif
+	if (vt->context != context) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			  "HAL: ERROR: hal_unreference_vtable(%d) (name=%s): "
+			  "context mismatch - calling context %d vtable context %d\n",
+			  vtable_id, vt->name, context, vt->context);
+	    return -ENOENT;
+	}
+
+	vt->refcount -= 1;
+	hal_print_msg(RTAPI_MSG_DBG,
+		      "HAL: hal_unreference_vtable(%d) (name=%s) refcount=%d\n",
+		      vtable_id, vt->name, vt->refcount);
+
+	// automatic unlock by scope exit
+	return 0;
+    }
+}
+
+// private HAL API
+
+hal_vtable_t *halpr_find_vtable_by_name(const char *name, int version)
+{
+    int next;
+    hal_vtable_t *vt;
+
+    next = hal_data->vtable_list_ptr;
+    while (next != 0) {
+	vt = SHMPTR(next);
+	if (((strcmp(vt->name, name) == 0) &&
+	     vt->version == version)) {
+	    return vt;
+	}
+	next = vt->next_ptr;
+    }
+    return 0;
+}
+
+hal_vtable_t *halpr_find_vtable_by_id(int vtable_id)
+{
+    int next;
+    hal_vtable_t *vt;
+
+    next = hal_data->vtable_list_ptr;
+    while (next != 0) {
+	vt = SHMPTR(next);
+	if (vt->handle == vtable_id) {
+	    return vt;
+	}
+	next = vt->next_ptr;
+    }
+    return 0;
+}
+
+
+static hal_vtable_t *alloc_vtable_struct(void)
+{
+    hal_vtable_t *p;
+
+    if (hal_data->vtable_free_ptr != 0) {
+	p = SHMPTR(hal_data->vtable_free_ptr);
+	hal_data->vtable_free_ptr = p->next_ptr;
+	p->next_ptr = 0;
+    } else {
+	p = shmalloc_dn(sizeof(hal_vtable_t));
+    }
+    return p;
+}
+
+static void free_vtable_struct(hal_vtable_t * p)
+{
+    p->next_ptr = hal_data->vtable_free_ptr;
+    hal_data->vtable_free_ptr = SHMOFF(p);
+}
+
+
+#ifdef RTAPI
+
+EXPORT_SYMBOL(hal_export_vtable);
+EXPORT_SYMBOL(hal_remove_vtable);
+EXPORT_SYMBOL(hal_reference_vtable);
+EXPORT_SYMBOL(hal_unreference_vtable);
+EXPORT_SYMBOL(halpr_find_vtable_by_name);
+EXPORT_SYMBOL(halpr_find_vtable_by_id);
+#endif

--- a/src/hal/lib/vtable.h
+++ b/src/hal/lib/vtable.h
@@ -1,0 +1,15 @@
+#ifndef _VTABLE_H
+#define _VTABLE_H
+
+
+// whenever a new type of/new layout of a vtable is exported,
+// add a unique signature here
+// this signature is used to match up exporting and referencing code
+
+typedef enum {
+    VTKINEMATICS_VERSION1 = 1000,
+
+    VTTP_VERSION1 = 2000,
+} vtable_t;
+
+#endif // _VTABLE_H

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -1417,52 +1417,12 @@ int do_ping_cmd(void)
 static int unloadrt_comp(char *mod_name)
 {
     int retval;
-    /* char *argv[10]; */
-    /* int m=0; */
-    /* char executable[PATH_MAX]; */
 
     retval = rtapi_unloadrt(rtapi_instance, mod_name);
     /* print success message */
     halcmd_info("Realtime module '%s' unloaded rc=%d\n",
 		mod_name, retval);
     return retval;
-#if 0
-    if (!(current_flavor->flags & FLAVOR_KERNEL_BUILD)) {
-	char inst[50];
-	snprintf(inst,sizeof(inst),"--instance=%d", rtapi_instance);
-	if (get_rtapi_config(executable,"rtapi_app",PATH_MAX) != 0) {
-	    halcmd_error("rtapi_app executable path not found in rtapi.ini\n");
-	    return -ENOENT;
-	}
-	argv[m++] = executable;
-	argv[m++] = inst;
-	argv[m++] = "unload";
-    }  else {
-	if (get_rtapi_config(executable,"linuxcnc_module_helper",
-			     PATH_MAX) != 0) {
-	    halcmd_error("linuxcnc_module_helper executable path not found "
-			 "in rtapi.ini\n");
-	    return -ENOENT;
-	}
-	argv[m++] = executable;
-	argv[m++] = "remove";
-    }
-    argv[m++] = mod_name;
-    /* add a NULL to terminate the argv array */
-    argv[m++] = NULL;
-
-    retval = hal_systemv(argv);
-
-    if ( retval != 0 ) {
-	halcmd_error("rmmod failed, returned %d\n", retval);
-	return -1;
-    }
-    /* print success message */
-    halcmd_info("Realtime module '%s' unloaded\n",
-	mod_name);
-    return 0;
-#endif
-
 }
 
 int do_unload_cmd(char *mod_name) {
@@ -3029,7 +2989,7 @@ void dump_rings(const char *where, int attach, int detach)
 static void print_ring_info(char **patterns)
 {
     int next_ring, retval;
-    hal_ring_t *rptr; //  __attribute__((cleanup(halpr_autorelease_mutex)));
+    hal_ring_t *rptr;
     ringheader_t *rh;
     ringbuffer_t ringbuffer;
 

--- a/src/hal/utils/halcmd_completion.c
+++ b/src/hal/utils/halcmd_completion.c
@@ -57,7 +57,7 @@ static const char *command_table[] = {
     "newring","delring","ringdump","ringwrite","ringread",
     "newcomp","newpin","ready","waitbound", "waitunbound", "waitexists",
     "log","shutdown","ping","newthread","delthread",
-	"sleep",
+    "sleep","vtable",
     NULL,
 };
 
@@ -73,7 +73,7 @@ static const char *alias_table[] = {
 
 static const char *show_table[] = {
     "all", "alias", "comp", "pin", "sig", "param", "funct", "thread", "group", "member",
-    "ring", "eps",
+    "ring", "eps","vtable",
     NULL,
 };
 

--- a/src/hal/vtable-example/README
+++ b/src/hal/vtable-example/README
@@ -1,0 +1,56 @@
+HAL vtable objects
+------------------
+
+see https://github.com/machinekit/machinekit/issues/438
+
+
+$ halcmd -f -k
+
+halcmd: loadrt vtexport
+<stdin>:1: Realtime module 'vtexport' loaded
+halcmd: loadrt vt
+vtexport  vtuse
+halcmd: loadrt vtuse
+<stdin>:2: Realtime module 'vtuse' loaded
+halcmd: show comp
+Loaded HAL Components:
+ID      Type  Name                                      PID   State
+    73  RT    vtuse                                     RT    ready, u1:0 u2:0
+    71  RT    vtexport                                  RT    ready, u1:0 u2:0
+    69  User  halcmd12463                               12463 ready, u1:0 u2:0
+
+halcmd: show vtable
+Exported vtables:
+ID      Name                  Version Refcnt  Context Owner
+    72  example-vtable        1234    1       RT      71    vtexport
+
+halcmd: unloadrt vtuse
+<stdin>:5: Realtime module 'vtuse' unloaded rc=0
+halcmd: show vtable
+Exported vtables:
+ID      Name                  Version Refcnt  Context Owner
+    72  example-vtable        1234    0       RT      71    vtexport
+
+halcmd:
+
+
+log:
+
+Feb  2 23:16:38 nwheezy msgd:0: hal_lib:12457:rt HAL: initializing component 'vtexport' type=1 arg1=0 arg2=0/0x0
+Feb  2 23:16:38 nwheezy msgd:0: hal_lib:12457:rt HAL: component 'vtexport' initialized, ID = 71
+Feb  2 23:16:38 nwheezy msgd:0: hal_lib:12457:rt HAL: created vtable 'example-vtable' vtable=0xb74fb158 version=1234
+Feb  2 23:16:38 nwheezy msgd:0: rtapi_app:12457:user vtexport: loaded from vtexport.so
+Feb  2 23:16:43 nwheezy msgd:0: hal_lib:12457:rt HAL: initializing component 'vtuse' type=1 arg1=0 arg2=0/0x0
+Feb  2 23:16:43 nwheezy msgd:0: hal_lib:12457:rt HAL: component 'vtuse' initialized, ID = 73
+Feb  2 23:16:43 nwheezy msgd:0: hal_lib:12457:rt HAL: hal_reference_vtable(example-vtable,1234) found vtable=0xb74fb158 context=0
+
+Feb  2 23:16:43 nwheezy msgd:0: hal_lib:12457:rt vte_hello: vtuse   <------------- vtable method called
+
+Feb  2 23:16:43 nwheezy msgd:0: rtapi_app:12457:user vtuse: loaded from vtuse.so
+
+Feb  2 23:17:09 nwheezy msgd:0: hal_lib:12457:rt vte_goodbye: vtuse  <------------- vtable method called
+
+Feb  2 23:17:09 nwheezy msgd:0: hal_lib:12457:rt HAL: hal_unreference_vtable(72) (name=example-vtable) refcount=0
+Feb  2 23:17:09 nwheezy msgd:0: hal_lib:12457:rt HAL: removing component 73
+Feb  2 23:17:09 nwheezy msgd:0: hal_lib:12457:rt HAL: component 73 removed, name = 'vtuse'
+Feb  2 23:17:09 nwheezy msgd:0: rtapi_app:12457:user  'vtuse' unloaded

--- a/src/hal/vtable-example/Submakefile
+++ b/src/hal/vtable-example/Submakefile
@@ -1,0 +1,21 @@
+VTABLEEXAMPLE_DIR := hal/vtable-example
+INCLUDES += $(VTABLEEXAMPLE_DIR)
+
+../include/%.h: ./$(VTABLEEXAMPLE_DIR)/%.h
+	cp $^ $@
+
+obj-m += vtexport.o
+vtexport-objs := \
+	$(VTABLEEXAMPLE_DIR)/vtexport.o \
+	$(VTABLEEXAMPLE_DIR)/vcode.o
+
+obj-m += vtuse.o
+vtuse-objs := \
+	$(VTABLEEXAMPLE_DIR)/vtuse.o \
+
+ifneq "$(filter normal user-dso,$(BUILD_SYS))" ""
+$(RTLIBDIR)/vtexport$(MODULE_EXT): \
+	$(addprefix $(OBJDIR)/,$(vtexport-objs))
+$(RTLIBDIR)/vtuse$(MODULE_EXT): \
+	$(addprefix $(OBJDIR)/,$(vtuse-objs))
+endif

--- a/src/hal/vtable-example/vcode.c
+++ b/src/hal/vtable-example/vcode.c
@@ -1,0 +1,23 @@
+#include "rtapi.h"
+
+#include "vtexample.h"
+
+// the 'methods exported through the vtable'
+static int vte_hello(const char *s)
+{
+    rtapi_print_msg(RTAPI_MSG_INFO, "vte_hello: %s\n", s);
+    return 0;
+}
+
+static int vte_goodbye(const char *s)
+{
+    rtapi_print_msg(RTAPI_MSG_INFO, "vte_goodbye: %s\n", s);
+    return 0;
+}
+
+// intramodule symbol, referenced in vtexport.c
+
+vtexample_t demo_vtable = {
+    vte_hello,
+    vte_goodbye
+};

--- a/src/hal/vtable-example/vtexample.h
+++ b/src/hal/vtable-example/vtexample.h
@@ -1,0 +1,10 @@
+
+// example methods exported via vtable
+
+typedef int (*vte_hello_t)(const char *);
+typedef int (*vte_goodbye_t)(const char *);
+
+typedef struct {
+    vte_hello_t   hello;
+    vte_goodbye_t goodbye;
+} vtexample_t;

--- a/src/hal/vtable-example/vtexport.c
+++ b/src/hal/vtable-example/vtexport.c
@@ -1,0 +1,55 @@
+
+#include "rtapi.h"
+#include "rtapi_app.h"
+#include "hal.h"
+#include "hal_priv.h"
+
+#include "vtexample.h"
+
+MODULE_AUTHOR("Michael Haberler");
+MODULE_DESCRIPTION("demo component exporting a vtable");
+MODULE_LICENSE("GPL");
+
+static char *name = "example-vtable";
+RTAPI_MP_STRING(name, "vtable name");
+
+static int version = 1234;
+RTAPI_MP_INT(version, "vtable version tag");
+
+static int comp_id, vtable_id;
+static char *compname = "vtexport";
+
+extern vtexample_t demo_vtable;  // see vcode.c & vtexample.h
+
+int rtapi_app_main(void)
+{
+    comp_id = hal_init(compname);
+    if (comp_id < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: hal_init() failed - %d\n",
+			compname, comp_id);
+	return -1;
+    }
+    hal_ready(comp_id);
+
+    vtable_id = hal_export_vtable(name, version, &demo_vtable, comp_id);
+    if (vtable_id < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: ERROR: hal_export_vtable(%s,%d,%p) failed: %d\n",
+			compname, name, version, &demo_vtable, vtable_id );
+	hal_exit(comp_id);
+	return -ENOENT;
+    }
+    return 0;
+}
+
+void rtapi_app_exit(void)
+{
+    int retval = hal_remove_vtable(vtable_id);
+    if (retval < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR, "%s: vtable %d not removed\n",
+			  compname, vtable_id);
+    } else {
+	// safe to exit comp
+	hal_exit(comp_id);
+    }
+}

--- a/src/hal/vtable-example/vtuse.c
+++ b/src/hal/vtable-example/vtuse.c
@@ -1,0 +1,65 @@
+
+#include "rtapi.h"
+#include "rtapi_app.h"
+#include "hal.h"
+#include "hal_priv.h"
+
+#include "vtexample.h"
+
+MODULE_AUTHOR("Michael Haberler");
+MODULE_DESCRIPTION("demo component using a vtable");
+MODULE_LICENSE("GPL");
+
+static char *name = "example-vtable";
+RTAPI_MP_STRING(name, "vtable name");
+
+static int version = 1234;
+RTAPI_MP_INT(version, "vtable version tag");
+
+static int comp_id, vtable_id;
+static char *compname = "vtuse";
+
+static vtexample_t *vtp;
+
+int rtapi_app_main(void)
+{
+    comp_id = hal_init(compname);
+    if (comp_id < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: hal_init() failed - %d\n",
+			compname, comp_id);
+	return -1;
+    }
+
+    vtable_id = hal_reference_vtable(name, version, (void **) &vtp);
+    if (vtable_id < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"ERROR: %s: hal_reference_vtable(%s,%d) failed: %d\n",
+			compname, name, version, vtable_id);
+	hal_exit(comp_id);
+	return -ENOENT;
+    }
+    hal_ready(comp_id);
+
+    // at this point, the vtable can be used:
+    vtp->hello(compname);
+
+    return 0;
+}
+
+void rtapi_app_exit(void)
+{
+
+    // the vtable can still be used:
+    vtp->goodbye(compname);
+
+    int retval = hal_unreference_vtable(vtable_id);
+    if (retval < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR, "%s: hal_unreference_vtable(%d) failed: %d",
+			compname, vtable_id, retval);
+    }
+    // NB: vtable methods may not be referenced anymore here
+    // vtp is a dangling reference (!)
+    // calling an vtp->method() here will crash rtapi_app (userland) or panic (kthreads)
+
+    hal_exit(comp_id);
+}

--- a/src/rtapi/rtapi_common.c
+++ b/src/rtapi/rtapi_common.c
@@ -256,7 +256,7 @@ void init_rtapi_data(rtapi_data_t * data)
 int _rtapi_task_update_stats(void)
 {
 #ifdef HAVE_RTAPI_TASK_UPDATE_STATS_HOOK
-    extern int _rtapi_task_update_stats_hook();
+    extern int _rtapi_task_update_stats_hook(void);
 
     return _rtapi_task_update_stats_hook();
 #else

--- a/tests/interp/subroutine-return/core_sim.hal
+++ b/tests/interp/subroutine-return/core_sim.hal
@@ -3,8 +3,10 @@
 # first load all the RT modules that will be needed
 # kinematics
 loadrt trivkins
+# trajectory planner
+loadrt tp
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES kins=trivkins tp=tp
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt count=6
 # load additional blocks

--- a/tests/linuxcncrsh/core_sim.hal
+++ b/tests/linuxcncrsh/core_sim.hal
@@ -3,8 +3,10 @@
 # first load all the RT modules that will be needed
 # kinematics
 loadrt trivkins
+# trajectory planner
+loadrt tp
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES kins=trivkins tp=tp
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt count=6
 # load additional blocks

--- a/tests/mdi-queue/core_sim.hal
+++ b/tests/mdi-queue/core_sim.hal
@@ -3,8 +3,10 @@
 # first load all the RT modules that will be needed
 # kinematics
 loadrt trivkins
+# trajectory planner
+loadrt tp
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES kins=trivkins tp=tp
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt count=6
 # load additional blocks

--- a/tests/t0/core_sim.hal
+++ b/tests/t0/core_sim.hal
@@ -3,8 +3,10 @@
 # first load all the RT modules that will be needed
 # kinematics
 loadrt trivkins
+# trajectory planner
+loadrt tp
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES kins=trivkins tp=tp
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt count=6
 # load additional blocks

--- a/tests/toolchanger/core_sim.hal
+++ b/tests/toolchanger/core_sim.hal
@@ -3,8 +3,10 @@
 # first load all the RT modules that will be needed
 # kinematics
 loadrt trivkins
+# trajectory planner
+loadrt tp
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES kins=trivkins tp=tp
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt count=6
 # load additional blocks

--- a/tests/toolchanger/m61/core_sim.hal
+++ b/tests/toolchanger/m61/core_sim.hal
@@ -3,8 +3,10 @@
 # first load all the RT modules that will be needed
 # kinematics
 loadrt trivkins
+# trajectory planner
+loadrt tp
 # motion controller, get name and thread periods from ini file
-loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES kins=trivkins tp=tp
 # load 6 differentiators (for velocity and accel signals
 loadrt ddt count=6
 # load additional blocks


### PR DESCRIPTION
introduce HAL vtables, tp becomes a module, kinematics and tp use vtables
the configs are not adapted yet (just 205 .hal files ..)
other than that, axis_mm.ini works fine, and runtests are ok

gh seems to pick up the wrong branch on PR's if there's another branch whose name is a prefix of the current branch; I dont understand why - the last two commits in https://github.com/mhaberler/machinekit/commits/vtable-tp-and-kins-try2 are:

5a68463 configs/common/core_sim.hal: load tp, add motmod vtable references
dbfba1f   runtests: adapt for loadable tp

hm, interesting - the sha's are correct, but the order of commits is different