### PR TITLE
Added CRAMPS-QCVP config example

### DIFF
--- a/configs/ARM/BeagleBone/CRAMPS-QVCP/CRAMPS_QVCP.hal
+++ b/configs/ARM/BeagleBone/CRAMPS-QVCP/CRAMPS_QVCP.hal
@@ -1,0 +1,820 @@
+# #######################################
+#
+# HAL file for BeagleBone + CRAMPS cape with 4 stepper-drivers
+# Designed for Machineface & Cetus UI's
+#
+# Derived from thecooltool UNIPRINT-3D-stepper config
+#
+# ########################################
+
+# start haltalk server
+loadusr -W haltalk
+
+# Launch the setup script to make sure hardware setup looks good
+loadusr -w ./setup.sh
+
+
+# ###################################
+# Core EMC/HAL Loads
+# ###################################
+
+# kinematics
+loadrt trivkins
+
+# motion controller, get name and thread periods from ini file
+# trajectory planner
+loadrt tp
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES num_aio=50 num_dio=20 tp=tp kins=trivkins
+
+# motion controller, get name and thread periods from ini file
+#loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=4 num_aio=50 num_dio=20# [TRAJ]AXES
+
+
+# load low-level drivers
+loadrt hal_bb_gpio output_pins=816,822,823,824,825,826,914,923,925 input_pins=807,808,809,810,817,911,913
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg pru_period=5000
+
+
+# Python user-mode HAL module to read ADC value and generate a thermostat output for PWM
+# c = analog input channel and thermistor table
+loadusr -Wn Therm hal_temp_bbb -n Therm -c 04:[HBP]THERMISTOR,05:[EXTRUDER_0]THERMISTOR -b [CAPE]BOARD
+
+
+# other components
+loadrt pid names=pid.e0-temp,pid.hbp-temp
+loadrt limit1 names=limit1.e0-heater,limit1.hbp-heater,limit1.fdm-1-fan
+loadrt scale names=scale.f0,scale-exp0,scale.e0-fan-comp
+loadrt thermistor_check names=thermistor-check.e0,thermistor-check.hbp
+loadrt not names=not.e0-temp-range,not.hbp-temp-range,not.e0-error,not.hbp-error
+loadrt wcomp names=wcomp.e0-temp-range,wcomp.hbp-temp-range,wcomp.e0-temp-limit,wcomp.hbp-temp-limit
+loadrt lowpass names=lowpass.e0-temp,lowpass.hbp-temp
+loadrt sum2 names=sum2.e0-temp-range-neg,sum2.e0-temp-range-pos,sum2.hbp-temp-range-neg,sum2.hbp-temp-range-pos
+#loadrt mux2 names=mux2.exp0-pwm,mux2.exp0-val
+loadrt mux2 names=mux2.exp0-val
+loadrt logic names=estopchain,and3.e0-no-error,and3.hbp-no-error personality=0x106,0x103,0x103 # and 6 and 3 inputs
+#loadrt comp names=comp.exp0-temp,comp.e0-active,comp.e0-val-set,comp.e0-temp,comp.hbp-active
+loadrt comp names=comp.e0-active,comp.e0-val-set,comp.e0-temp,comp.hbp-active
+loadrt and2 names=and2.e0temp-val-50-act,and2.e0temp-80-act
+loadrt or2 names=or2.e0-fan-act
+
+addf    hpg.capture-position                servo-thread
+addf    bb_gpio.read                        servo-thread
+addf    motion-command-handler              servo-thread
+addf    motion-controller                   servo-thread
+# HBP
+addf    lowpass.hbp-temp                     servo-thread
+addf    pid.hbp-temp.do-pid-calcs           servo-thread
+addf    sum2.hbp-temp-range-neg             servo-thread
+addf    sum2.hbp-temp-range-pos             servo-thread
+addf    wcomp.hbp-temp-range                servo-thread
+addf    not.hbp-temp-range                  servo-thread
+addf    wcomp.hbp-temp-limit                servo-thread
+addf    limit1.hbp-heater                   servo-thread
+addf    and3.hbp-no-error                   servo-thread
+addf    not.hbp-error                       servo-thread
+addf    comp.hbp-active                     servo-thread
+# E0
+addf    scale.e0-fan-comp                   servo-thread
+addf    lowpass.e0-temp                      servo-thread
+addf    pid.e0-temp.do-pid-calcs            servo-thread
+addf    limit1.e0-heater                    servo-thread
+addf    sum2.e0-temp-range-neg              servo-thread
+addf    sum2.e0-temp-range-pos              servo-thread
+addf    wcomp.e0-temp-range                 servo-thread
+addf    not.e0-temp-range                   servo-thread
+addf    wcomp.e0-temp-limit                 servo-thread
+addf    and3.e0-no-error                    servo-thread
+addf    not.e0-error                        servo-thread
+addf    comp.e0-active                      servo-thread
+
+addf    comp.e0-val-set                     servo-thread
+addf    comp.e0-temp                        servo-thread
+addf    and2.e0temp-val-50-act              servo-thread
+addf    and2.e0temp-80-act                  servo-thread
+addf    or2.e0-fan-act                      servo-thread
+# F0
+addf   scale.f0                             servo-thread
+
+# E0 Fan
+addf   scale-exp0                             servo-thread
+addf   limit1.fdm-1-fan                     servo-thread
+addf   mux2.exp0-val                          servo-thread
+
+# Estop chain
+addf   thermistor-check.e0                  servo-thread
+addf   thermistor-check.hbp                 servo-thread
+addf   estopchain                           servo-thread
+
+# Update functions
+addf    hpg.update                          servo-thread
+addf    bb_gpio.write                       servo-thread
+
+#-----------------------------------------------------
+
+
+# ###################################
+# UI remote component definition
+# ###################################
+sete 1 0.1
+
+newcomp fdm-e0 timer=100
+newpin  fdm-e0 fdm-e0.temp.meas      float in eps=1
+newpin  fdm-e0 fdm-e0.temp.set       float io
+newpin  fdm-e0 fdm-e0.temp.standby   float in
+newpin  fdm-e0 fdm-e0.temp.limit.min float in
+newpin  fdm-e0 fdm-e0.temp.limit.max float in
+newpin  fdm-e0 fdm-e0.temp.in-range  bit   in
+newpin  fdm-e0 fdm-e0.error          bit   in
+newpin  fdm-e0 fdm-e0.active         bit   in
+ready   fdm-e0
+
+newcomp fdm-hbp timer=100
+newpin  fdm-hbp fdm-hbp.temp.meas      float in eps=1
+newpin  fdm-hbp fdm-hbp.temp.set       float io
+newpin  fdm-hbp fdm-hbp.temp.standby   float in
+newpin  fdm-hbp fdm-hbp.temp.limit.min float in
+newpin  fdm-hbp fdm-hbp.temp.limit.max float in
+newpin  fdm-hbp fdm-hbp.temp.in-range  bit   in
+newpin  fdm-hbp fdm-hbp.error          bit   in
+newpin  fdm-hbp fdm-hbp.active         bit   in
+ready   fdm-hbp
+
+newcomp fdm-f0 timer=100
+newpin fdm-f0 fdm-f0.set float io
+ready fdm-f0
+
+newcomp fdm-f1 timer=100
+newpin fdm-f1 fdm-f1.set float io
+ready fdm-f1
+
+newcomp fdm-f2 timer=100
+newpin fdm-f2 fdm-f2.set float io
+ready fdm-f2
+
+newcomp fdm-f3 timer=100
+newpin fdm-f3 fdm-f3.set float io
+ready fdm-f3
+
+newcomp fdm-l0 timer=100
+newpin fdm-l0 fdm-l0.r float io
+newpin fdm-l0 fdm-l0.g float io
+newpin fdm-l0 fdm-l0.b float io
+newpin fdm-l0 fdm-l0.w float io
+ready  fdm-l0
+
+newcomp fdm-e0-pid timer=100
+newpin fdm-e0-pid fdm-e0-pid.Pgain              float io
+newpin fdm-e0-pid fdm-e0-pid.Igain              float io
+newpin fdm-e0-pid fdm-e0-pid.Dgain              float io
+newpin fdm-e0-pid fdm-e0-pid.maxerrorI          float io
+newpin fdm-e0-pid fdm-e0-pid.bias               float io
+newpin fdm-e0-pid fdm-e0-pid.max                float in
+newpin fdm-e0-pid fdm-e0-pid.min                float in
+newpin fdm-e0-pid fdm-e0-pid.command            float io
+newpin fdm-e0-pid fdm-e0-pid.feedback           float in
+newpin fdm-e0-pid fdm-e0-pid.output             float in
+ready  fdm-e0-pid
+       
+
+# ######################################################
+# Axis-of-motion Specific Configs (not the GUI)
+# ######################################################
+
+
+# ################
+# X [0] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.00.enable bit
+sets emcmot.00.enable FALSE
+
+net emcmot.00.enable <= axis.0.amp-enable-out
+net emcmot.00.enable => hpg.stepgen.00.enable
+
+
+# position command and feedback
+net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
+
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
+net motor.00.pos-fb => axis.0.motor-pos-fb
+
+
+# timing parameters
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
+
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
+
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
+
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+
+#setp hpg.stepgen.00.step_type       0
+
+#setp hpg.stepgen.00.step_type       0
+setp hpg.stepgen.00.steppin         [AXIS_0]STEPPIN
+setp hpg.stepgen.00.dirpin          [AXIS_0]DIRPIN
+
+
+# ################
+# Y [1] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.01.enable bit
+sets emcmot.01.enable FALSE
+
+net emcmot.01.enable <= axis.1.amp-enable-out
+net emcmot.01.enable => hpg.stepgen.01.enable
+
+
+# position command and feedback
+net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
+
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
+net motor.01.pos-fb => axis.1.motor-pos-fb
+
+
+# timing parameters
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
+
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
+
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
+
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+
+#setp hpg.stepgen.01.step_type       0
+setp hpg.stepgen.01.steppin         [AXIS_1]STEPPIN
+setp hpg.stepgen.01.dirpin          [AXIS_1]DIRPIN
+
+
+# ################
+# Z [2] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.02.enable bit
+sets emcmot.02.enable FALSE
+
+net emcmot.02.enable <= axis.2.amp-enable-out
+net emcmot.02.enable => hpg.stepgen.02.enable
+
+
+# position command and feedback
+net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
+
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
+net motor.02.pos-fb => axis.2.motor-pos-fb
+
+
+# timing parameters
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
+
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
+
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
+
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+
+#setp hpg.stepgen.02.step_type       0
+setp hpg.stepgen.02.steppin         [AXIS_2]STEPPIN
+setp hpg.stepgen.02.dirpin          [AXIS_2]DIRPIN
+
+
+# ################
+# A [3] Axis (Extruder) - Velocity control
+# ################
+
+# axis enable chain
+newsig emcmot.03.enable bit
+sets emcmot.03.enable FALSE
+
+net emcmot.03.enable <= axis.3.amp-enable-out
+net emcmot.03.enable => hpg.stepgen.03.enable
+
+
+# position command and feedback
+net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
+
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
+net motor.03.pos-fb => axis.3.motor-pos-fb
+
+
+# timing parameters
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
+
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
+
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
+
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+
+#setp hpg.stepgen.03.step_type       0
+setp hpg.stepgen.03.steppin         [AXIS_3]STEPPIN
+setp hpg.stepgen.03.dirpin          [AXIS_3]DIRPIN
+
+
+# ##################################################
+# Standard I/O - EStop, Enables, Limit Switches, Etc
+# ##################################################
+
+# Create estop signal chain
+# Drive software estop to hardware
+#net estop-out iocontrol.0.user-enable-out => bb_gpio.p8.out-26
+net estop-user <= iocontrol.0.user-enable-out
+
+
+# Monitor estop input from hardware
+net estop-loop bb_gpio.p8.in-17 => iocontrol.0.emc-enable-in
+setp bb_gpio.p8.in-17.invert 1
+
+# create signals for tool loading loopback
+net tool-prep-loop iocontrol.0.tool-prepare => iocontrol.0.tool-prepared
+net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
+
+# Axis enable signal (active low)
+net emcmot.00.enable => bb_gpio.p9.out-14
+setp bb_gpio.p9.out-14.invert 1
+
+# Machine power
+# Use halui.machine.is-on instead?
+net emcmot.00.enable => bb_gpio.p9.out-23
+
+# Tie machine power signal to the CRAMPS LED
+# Feel free to tie any other signal you like to the LED
+net emcmot.00.enable => bb_gpio.p9.out-25
+
+# ################
+# Limit Switches
+# ################
+#newsig limit-x-min bit
+#newsig limit-x-max bit
+#newsig limit-y-min bit
+#newsig limit-y-max bit
+#newsig limit-z-min bit
+#newsig limit-z-max bit
+
+net limit-x-min <= bb_gpio.p8.in-08
+net limit-x-max <= bb_gpio.p8.in-07
+net limit-y-min <= bb_gpio.p8.in-10
+net limit-y-max <= bb_gpio.p8.in-09
+net limit-z-min <= bb_gpio.p9.in-13
+net limit-z-max <= bb_gpio.p9.in-11
+
+# Adjust as needed for your switch polarity
+setp bb_gpio.p8.in-08.invert 1
+setp bb_gpio.p8.in-07.invert 1
+setp bb_gpio.p8.in-10.invert 1
+setp bb_gpio.p8.in-09.invert 1
+setp bb_gpio.p9.in-11.invert 1
+setp bb_gpio.p9.in-13.invert 1
+
+# Uncomment if you actually have limit switches setup
+# You probably want to setup homing in the INI file, as well
+net limit-x-min => axis.0.home-sw-in
+#net limit-x-min => axis.0.neg-lim-sw-in
+#net limit-x-max => axis.0.pos-lim-sw-in
+net limit-y-min => axis.1.home-sw-in
+#net limit-y-min => axis.1.neg-lim-sw-in
+#net limit-y-max => axis.1.pos-lim-sw-in
+net limit-z-min => axis.2.home-sw-in
+#net limit-z-min => axis.2.neg-lim-sw-in
+#net limit-z-max => axis.2.pos-lim-sw-in
+
+# ################
+# Servo signals
+# ################
+
+# There is currently no driver to generate pulses for actual
+# radio-control style servos, but the buffered 5V output
+# signals can be used as GPIO
+
+# !!! WARNING !!!
+# BBB on-board eMMC *MUST* be disabled in order to use these!
+# Drive eMMC-disabled signal high to enable signals that overlap
+# with the eMMC pins on P8, otherwise they are tri-stated
+#
+# You also need to edit the setup.sh file to enable the GPIO pins
+
+# Signal the hardware that eMMC has been disabled and it is safe
+# to drive the signals connected to eMMC lines (active low)
+newsig eMMC-disabled bit
+sets eMMC-disabled 0
+net eMMC-disabled bb_gpio.p8.out-16
+setp bb_gpio.p8.out-16.invert 1
+
+# Servo signals, output only, driven by an 'ACT125
+
+newsig servo.1 bit
+newsig servo.2 bit
+newsig servo.3 bit
+newsig servo.4 bit
+
+sets servo.1 0
+sets servo.2 0
+sets servo.3 0
+sets servo.4 0
+
+net servo.1 bb_gpio.p8.out-25
+net servo.2 bb_gpio.p8.out-24
+net servo.3 bb_gpio.p8.out-23
+net servo.4 bb_gpio.p8.out-22
+
+# ##################################################
+# Temperature Signals
+# ##################################################
+
+# Extruder 0 temperature control
+# --------------------------------------------------------------------------
+newsig e0.temp.standby           float
+
+net e0.temp.measr  => lowpass.e0-temp.in
+net e0.temp.meas   <= lowpass.e0-temp.out
+setp lowpass.e0-temp.gain 0.003
+net e0.temp.measr   <= Therm.ch-04.value
+
+# PID
+net emcmot.00.enable  =>   pid.e0-temp.enable
+net e0.temp.meas   => pid.e0-temp.feedback
+net e0.temp.set    => pid.e0-temp.command
+net e0.heater      <= pid.e0-temp.output
+net e0.heater      => limit1.e0-heater.in
+net e0.heaterl     <= limit1.e0-heater.out
+
+# Limit heater PWM to positive values
+# PWM mimics hm2 implementation, which generates output for negative values
+setp limit1.e0-heater.min 0.0
+setp limit1.e0-heater.max 1.0
+net e0.temp.pwm.max => pid.e0-temp.maxoutput
+sets e0.temp.pwm.max [EXTRUDER_0]PWM_MAX
+
+# Temperature checking
+net e0.temp.set              => sum2.e0-temp-range-pos.in0
+net e0.temp.range.pos_error  => sum2.e0-temp-range-pos.in1
+net e0.temp.set              => sum2.e0-temp-range-neg.in0
+net e0.temp.range.neg_error  => sum2.e0-temp-range-neg.in1
+
+net e0.temp.range.min sum2.e0-temp-range-neg.out => wcomp.e0-temp-range.min
+net e0.temp.range.max sum2.e0-temp-range-pos.out => wcomp.e0-temp-range.max
+net e0.temp.meas                => wcomp.e0-temp-range.in
+#the output of wcomp.e0-temp-range will say if measured temperature is in range of set value
+#this needs to be coupled to a digital input for M66 readout
+net e0.temp.in-range <= wcomp.e0-temp-range.out
+
+# limit the output temperature to prevent damage when thermistor is broken/removed
+net e0.temp.limit.min         => wcomp.e0-temp-limit.min
+net e0.temp.limit.max        => wcomp.e0-temp-limit.max
+net e0.temp.meas              => wcomp.e0-temp-limit.in
+net e0.temp.in-limit          <= wcomp.e0-temp-limit.out
+
+# check the thermistor
+net e0.temp.meas              => thermistor-check.e0.temp
+net e0.temp.in-range          => not.e0-temp-range.in
+net e0.temp.in-range_n        <= not.e0-temp-range.out
+net e0.temp.in-range_n        => thermistor-check.e0.enable
+net e0.heaterl                => thermistor-check.e0.pid
+net e0.therm-ok               <= thermistor-check.e0.no-error
+
+# no error chain
+net e0.therm-ok      => and3.e0-no-error.in-00
+net e0.temp.in-limit => and3.e0-no-error.in-01
+net temp-ok          => and3.e0-no-error.in-02
+sets temp-ok            1
+net e0.no-error      <= and3.e0-no-error.and
+net e0.no-error      => not.e0-error.in
+net e0.error         <= not.e0-error.out
+
+setp comp.e0-active.in0 0.0001
+setp comp.e0-active.hyst 0.0
+net e0.heaterl => comp.e0-active.in1
+net e0.active  <= comp.e0-active.out
+
+# PID control linking
+net e0.pid.Pgain       fdm-e0-pid.Pgain     <=> pid.e0-temp.Pgain
+net e0.pid.Igain       fdm-e0-pid.Igain     <=> pid.e0-temp.Igain
+net e0.pid.Dgain       fdm-e0-pid.Dgain     <=> pid.e0-temp.Dgain
+net e0.pid.maxerrorI   fdm-e0-pid.maxerrorI <=> pid.e0-temp.maxerrorI
+#net e0.pid.bias        fdm-e0-pid.bias      <=> pid.e0-temp.bias
+net e0.temp.limit.min  => fdm-e0-pid.min
+net e0.temp.limit.max  => fdm-e0-pid.max
+net e0.temp.set       <=> fdm-e0-pid.command
+net e0.temp.meas       => fdm-e0-pid.feedback
+net e0.heater          => fdm-e0-pid.output
+
+# PID parameters
+sets e0.pid.Pgain     [EXTRUDER_0]PID_PGAIN
+sets e0.pid.Igain     [EXTRUDER_0]PID_IGAIN
+sets e0.pid.Dgain     [EXTRUDER_0]PID_DGAIN
+sets e0.pid.maxerrorI [EXTRUDER_0]PID_MAXERRORI
+#sets e0.pid.bias      [EXTRUDER_0]PID_BIAS
+
+# Parameters
+sets e0.temp.range.pos_error   [EXTRUDER_0]TEMP_RANGE_POS_ERROR
+sets e0.temp.range.neg_error   [EXTRUDER_0]TEMP_RANGE_NEG_ERROR
+sets e0.temp.limit.min         [EXTRUDER_0]TEMP_LIMIT_MIN
+sets e0.temp.limit.max         [EXTRUDER_0]TEMP_LIMIT_MAX
+sets e0.temp.standby           [EXTRUDER_0]TEMP_STANDBY
+
+# Fan compensation
+net f0.pwm => scale.e0-fan-comp.in
+net e0.pid.bias pid.e0-temp.bias <= scale.e0-fan-comp.out
+setp scale.e0-fan-comp.gain [EXTRUDER_0]FAN_BIAS
+
+# Thermistor checking
+setp thermistor-check.e0.wait 9.0
+setp thermistor-check.e0.min-pid 1.5 #disable 0.25
+setp thermistor-check.e0.min-temp 1.0
+net e0.pid.bias => thermistor-check.e0.bias
+
+# Bed temperature control
+# ----------------------------------------------------------------------------
+newsig hbp.temp.standby          float
+net hbp.temp.measr  => lowpass.hbp-temp.in
+net hbp.temp.meas   <= lowpass.hbp-temp.out
+setp lowpass.hbp-temp.gain 0.003
+net hbp.temp.measr   <= Therm.ch-05.value
+
+# PID
+net emcmot.00.enable => pid.hbp-temp.enable
+net hbp.temp.meas    => pid.hbp-temp.feedback
+net hbp.temp.set     => pid.hbp-temp.command
+net hbp.heater       <= pid.hbp-temp.output
+net hbp.heater       => limit1.hbp-heater.in
+net hbp.heaterl      <= limit1.hbp-heater.out
+
+# Limit heater PWM to positive values
+# PWM mimics hm2 implementation, which generates output for negative values
+setp limit1.hbp-heater.min 0
+setp limit1.hbp-heater.max [HBP]PWM_MAX
+net hbp.temp.pwm.max => pid.hbp-temp.maxoutput
+sets hbp.temp.pwm.max [HBP]PWM_MAX
+
+# Temperature checking
+net hbp.temp.set              => sum2.hbp-temp-range-pos.in0
+net hbp.temp.range.pos_error  => sum2.hbp-temp-range-pos.in1
+net hbp.temp.set              => sum2.hbp-temp-range-neg.in0
+net hbp.temp.range.neg_error  => sum2.hbp-temp-range-neg.in1
+
+net hbp.temp.range.min sum2.hbp-temp-range-neg.out => wcomp.hbp-temp-range.min
+net hbp.temp.range.max sum2.hbp-temp-range-pos.out => wcomp.hbp-temp-range.max
+net hbp.temp.meas                 => wcomp.hbp-temp-range.in
+#the output of wcomp.e0-temp-range will say if measured temperature is in range of set value
+#this needs to be coupled to a digital input for M66 readout
+net hbp.temp.in-range <= wcomp.hbp-temp-range.out
+
+# limit the output temperature to prevent damage when thermistor is broken/removed
+net hbp.temp.limit.min         => wcomp.hbp-temp-limit.min
+net hbp.temp.limit.max         => wcomp.hbp-temp-limit.max
+net hbp.temp.meas              => wcomp.hbp-temp-limit.in
+net hbp.temp.in-limit          <= wcomp.hbp-temp-limit.out
+
+# check the thermistor
+net hbp.temp.meas              => thermistor-check.hbp.temp
+net hbp.temp.in-range          => not.hbp-temp-range.in
+net hbp.temp.in-range_n        <= not.hbp-temp-range.out
+net hbp.temp.in-range_n        => thermistor-check.hbp.enable
+net hbp.heaterl                => thermistor-check.hbp.pid
+net hbp.heaterl                => hpg.pwmgen.00.out.00.value
+net hbp.therm-ok               <= thermistor-check.hbp.no-error
+
+# no error chain
+net hbp.therm-ok      => and3.hbp-no-error.in-00
+net hbp.temp.in-limit => and3.hbp-no-error.in-01
+net temp-ok           => and3.hbp-no-error.in-02
+net hbp.no-error      <= and3.hbp-no-error.and
+net hbp.no-error      => not.hbp-error.in
+net hbp.error         <= not.hbp-error.out
+
+setp comp.hbp-active.in0 0.0001
+setp comp.hbp-active.hyst 0.0
+net hbp.heaterl => comp.hbp-active.in1
+net hbp.active  <= comp.hbp-active.out
+
+# PID parameters
+setp pid.hbp-temp.Pgain     [HBP]PID_PGAIN
+setp pid.hbp-temp.Igain     [HBP]PID_IGAIN
+setp pid.hbp-temp.Dgain     [HBP]PID_DGAIN
+setp pid.hbp-temp.maxerrorI [HBP]PID_MAXERRORI
+setp pid.hbp-temp.bias      [HBP]PID_BIAS
+
+# Parameters
+sets hbp.temp.range.pos_error [HBP]TEMP_RANGE_POS_ERROR
+sets hbp.temp.range.neg_error [HBP]TEMP_RANGE_NEG_ERROR
+sets hbp.temp.limit.min       [HBP]TEMP_LIMIT_MIN
+sets hbp.temp.limit.max       [HBP]TEMP_LIMIT_MAX
+sets hbp.temp.standby         [HBP]TEMP_STANDBY
+
+setp thermistor-check.hbp.wait 18.0
+setp thermistor-check.hbp.min-pid 1.1   # disable
+setp thermistor-check.hbp.min-temp 1.5
+
+# ##################################################
+# Fans
+# ##################################################
+
+# F0
+setp scale.f0.gain 0.00392156862745
+net f0.set => scale.f0.in
+net f0.pwm <= scale.f0.out
+
+
+# F1
+########################################################
+#
+# turn fan 1 on at min 75%
+# if e0 temp set value > 50 or e0 temp > 80
+#
+########################################################
+setp comp.e0-val-set.in0 50.0
+setp comp.e0-val-set.hyst 0.0
+setp comp.e0-temp.in0 80.0
+setp comp.e0-temp.hyst 0.0
+
+net e0.temp.set => comp.e0-val-set.in1
+net e0temp-val-50-set <= comp.e0-val-set.out
+net e0.temp.meas => comp.e0-temp.in1
+net e0temp-80 <= comp.e0-temp.out
+
+net e0temp-val-50-set => and2.e0temp-val-50-act.in0
+net emcmot.00.enable => and2.e0temp-val-50-act.in1 
+net e0temp-val-50-act <= and2.e0temp-val-50-act.out
+net e0temp-80 => and2.e0temp-80-act.in0
+net emcmot.00.enable => and2.e0temp-80-act.in1 
+net e0temp-80-act <= and2.e0temp-80-act.out
+
+net e0temp-val-50-act => or2.e0-fan-act.in0
+net e0temp-80-act => or2.e0-fan-act.in1
+net e0-fan-on <= or2.e0-fan-act.out
+
+setp limit1.fdm-1-fan.min 192.0
+setp limit1.fdm-1-fan.max 255.0
+net f1.set => limit1.fdm-1-fan.in
+net exp0-cap <= limit1.fdm-1-fan.out
+ 
+setp scale-exp0.gain 0.00392156862745
+net e0-fan-on => mux2.exp0-val.sel
+net f1.set => mux2.exp0-val.in0
+net exp0-cap => mux2.exp0-val.in1 
+net f1.mux <= mux2.exp0-val.out
+net f1.mux => scale-exp0.in
+net f1.pwm <= scale-exp0.out
+
+
+# Hotend Fan
+#setp mux2.exp0-pwm.in0 0.0
+#setp mux2.exp0-pwm.in1 1.0
+#setp comp.exp0-temp.in0 50.0
+#setp comp.exp0-temp.hyst 2.0
+#net e0.temp.meas => comp.exp0-temp.in1
+#net exp0.fan.pwm <= mux2.exp0-pwm.out
+#net exp0.fan.enable <= comp.exp0-temp.out
+#net exp0.fan.enable => mux2.exp0-pwm.sel
+
+# ##################################################
+# PWM
+# ##################################################
+
+setp hpg.pwmgen.00.pwm_period       10000000
+
+# Bed Heater FET 1
+setp hpg.pwmgen.00.out.00.pin       811
+setp hpg.pwmgen.00.out.00.enable    1
+net hbp.heaterl                => hpg.pwmgen.00.out.00.value
+
+# E0 Heater FET 2
+setp hpg.pwmgen.00.out.01.pin       915
+setp hpg.pwmgen.00.out.01.enable    1
+net e0.heaterl                 => hpg.pwmgen.00.out.01.value
+
+# E1 Heater FET 3
+setp hpg.pwmgen.00.out.02.pin       927
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
+
+# E2 Heater FET 4
+setp hpg.pwmgen.00.out.03.pin       921
+setp hpg.pwmgen.00.out.03.enable    1
+setp hpg.pwmgen.00.out.03.value     0.0
+
+# FET 5 - Fan / LED
+setp hpg.pwmgen.00.out.04.pin       941
+setp hpg.pwmgen.00.out.04.enable    1
+net f0.pwm => hpg.pwmgen.00.out.04.value
+
+# FET 6 - Fan / LED
+setp hpg.pwmgen.00.out.05.pin       922
+setp hpg.pwmgen.00.out.05.enable    1
+net f1.pwm  => hpg.pwmgen.00.out.05.value
+
+net e0.temp.set     => pid.e0-temp.command
+
+# Limit heater PWM to positive values
+# PWM mimics hm2 implementation, which generates output for negative values
+setp limit1.e0-heater.min 0
+
+
+# Limit heater PWM to positive values
+# PWM mimics hm2 implementation, which generates output for negative values
+setp limit1.hbp-heater.min 0
+
+# ##################################################
+# Motion AIO and DIO
+# ##################################################
+
+net hbp.temp.set         <= motion.analog-out-io-00
+#net hbc.temp.set         <= motion.analog-out-io-01
+net e0.temp.set          <= motion.analog-out-io-02
+net f0.set               <= motion.analog-out-io-12
+net f1.set               <= motion.analog-out-io-13
+#net f2.set               <= motion.analog-out-io-14
+#net f3.set               <= motion.analog-out-io-15
+#net l0.r                 <= motion.analog-out-io-26
+#net l0.g                 <= motion.analog-out-io-27
+#net l0.b                 <= motion.analog-out-io-28
+#net l0.w                 <= motion.analog-out-io-29
+#net probe.sel-f          <= motion.analog-out-38
+#net ve.line-area         <= motion.analog-out-41
+#net ve.jog-velocity      <= motion.analog-out-io-42
+#net ve.jog-distance      <= motion.analog-out-io-43
+#net ve.filament-dia      <= motion.analog-out-io-44
+
+#net probe.enable         <= motion.digital-out-00
+#net ve.extruder-en       <= motion.digital-out-io-01
+#net ve.jog-trigger       <= motion.digital-out-io-02
+
+net hbp.temp.meas        => motion.analog-in-00
+#net hbc.temp.meas        => motion.analog-in-01
+net e0.temp.meas         => motion.analog-in-02
+net f0.set               => motion.analog-in-12
+net f1.set               => motion.analog-in-13
+#net f2.set               => motion.analog-in-14
+#net f3.set               => motion.analog-in-15
+#net l0.r                 => motion.analog-in-26
+#net l0.g                 => motion.analog-in-27
+#net l0.b                 => motion.analog-in-28
+#net l0.w                 => motion.analog-in-29
+
+net hbp.temp.in-range   => motion.digital-in-00
+#net hbc.temp.in-range   => motion.digital-in-01
+net e0.temp.in-range    => motion.digital-in-02
+#net ve.jog-trigger      => motion.digital-in-12
+
+
+
+# ##################################################
+# Estop chain
+# ##################################################
+net estop-user          => estopchain.in-00
+net e0.temp.in-limit    => estopchain.in-01
+net e0.therm-ok         => estopchain.in-02
+net hbp.temp.in-limit   => estopchain.in-03
+net hbp.therm-ok        => estopchain.in-04
+net temp-ok             => estopchain.in-05
+net estop-out           <= estopchain.and
+
+# drive estop-sw
+net estop-out => bb_gpio.p8.out-26
+setp bb_gpio.p8.out-26.invert 1
+
+# ##################################################
+# UI linking
+# ##################################################
+
+net hbp.temp.meas       => fdm-hbp.temp.meas
+net hbp.temp.set       <=> fdm-hbp.temp.set
+net hbp.temp.standby    => fdm-hbp.temp.standby
+net hbp.temp.limit.min  => fdm-hbp.temp.limit.min
+net hbp.temp.limit.max  => fdm-hbp.temp.limit.max
+net hbp.temp.in-range   => fdm-hbp.temp.in-range
+net hbp.error           => fdm-hbp.error
+net hbp.active          => fdm-hbp.active
+
+net e0.temp.meas        => fdm-e0.temp.meas
+net e0.temp.set        <=> fdm-e0.temp.set
+net e0.temp.standby     => fdm-e0.temp.standby
+net e0.temp.limit.min   => fdm-e0.temp.limit.min
+net e0.temp.limit.max   => fdm-e0.temp.limit.max
+net e0.temp.in-range    => fdm-e0.temp.in-range
+net e0.error            => fdm-e0.error
+net e0.active           => fdm-e0.active
+
+net f0.set             <=> fdm-f0.set
+net f1.set             <=> fdm-f1.set
+

--- a/configs/ARM/BeagleBone/CRAMPS-QVCP/CRAMPS_QVCP.ini
+++ b/configs/ARM/BeagleBone/CRAMPS-QVCP/CRAMPS_QVCP.ini
@@ -1,0 +1,434 @@
+[PRUCONF]
+DRIVER=hal_pru_generic
+CONFIG=pru=0 num_stepgens=4 num_pwmgens=6
+PRUBIN=xenomai/pru_generic.bin
+
+[CAPE]
+BOARD=CRAMPS 
+
+[EMC]
+
+# Name of machine, for use with display, etc.
+MACHINE =               Prusa-i3-CRAMPS2
+
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+#DEBUG =                0x00000003
+#DEBUG =                0x00000007
+DEBUG = 0
+
+
+[DISPLAY]
+
+# Name of display program, e.g., tkemc
+DISPLAY = mkwrapper
+
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.200
+
+# Path to help file
+HELP_FILE =             tklinucnc.txt
+
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.5
+
+# Display unit for velocity values
+TIME_UNITS = s
+
+# Prefix to be used
+PROGRAM_PREFIX = /home/machinekit/linuxcnc/nc_files
+
+# Introductory graphic
+INTRO_GRAPHIC =
+INTRO_TIME = 0
+
+# Increments for the JOG section
+#INCREMENTS = 10 1 0.1 0.01
+
+OPEN_FILE =
+
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+PROGRAM_EXTENSION = .gcode RepRap Flavour GCode
+
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+gcode = gcode-to-ngc
+
+[TASK]
+
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.010
+
+
+[RS274NGC]
+
+# File containing interpreter variables
+PARAMETER_FILE =        pru-stepper.var
+;USER_M_PATH = /home/machinekit/machinekit/nc_files
+
+# subroutine path for the custom FDM printing .ngc files used for remapping
+# use directory in config path until more suitable location. this w.r.t the
+# fact that not every machine will have an extruder and/or fan
+SUBROUTINE_PATH = /usr/share/linuxcnc/ncfiles/remap-subroutines/fdm
+#SUBROUTINE_PATH = subroutines
+
+# remapping Machinekit FDM GCodes
+REMAP=G22 modalgroup=1 ngc=g22
+REMAP=G23 modalgroup=1 ngc=g23
+REMAP=G28 modalgroup=1 argspec=xyza ngc=g28
+REMAP=G29 modalgroup=1 ngc=g29
+REMAP=G29.1 modalgroup=1 argspec=xyz ngc=g29_1
+REMAP=G29.2 modalgroup=1 argspec=xyz ngc=g29_2
+REMAP=G30 modalgroup=1 argspec=pxy ngc=g30
+REMAP=M104 modalgroup=10 argspec=iPt ngc=m104
+REMAP=M106 modalgroup=10 argspec=iPt ngc=m106
+REMAP=M107 modalgroup=10 argspec=it ngc=m107
+REMAP=M109 modalgroup=10 argspec=tP ngc=m109
+REMAP=M140 modalgroup=10 argspec=iP ngc=m140
+REMAP=M141 modalgroup=10 argspec=iP ngc=m141
+REMAP=M190 modalgroup=10 argspec=P ngc=m190
+REMAP=M191 modalgroup=10 argspec=P ngc=m191
+REMAP=M200 modalgroup=10 argspec=D ngc=m200
+REMAP=M226 modalgroup=10 ngc=m226
+REMAP=M280 modalgroup=10 argspec=itP ngc=m280
+REMAP=M300 modalgroup=10 argspec=iqP ngc=m300
+REMAP=M400 modalgroup=10 ngc=m400
+REMAP=M420 modalgroup=10 argspec=itredp ngc=m420
+
+# enable ini parameter passing
+FEATURES = 4
+
+[EMCMOT]
+
+EMCMOT =                motmod
+
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+
+# Interval between tries to emcmot, in seconds
+COMM_WAIT =             0.010
+
+# Servo task period, in nanoseconds
+SERVO_PERIOD =          1000000
+
+
+[HAL]
+
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+
+HALFILE =		CRAMPS_QVCP.hal
+
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =               save neta
+
+#POSTGUI_HALFILE =       3D.postgui.hal
+
+
+[TRAJ]
+
+ARC_BLEND_ENABLE =              1
+ARC_BLEND_FALLBACK_ENABLE =     0
+ARC_BLEND_OPTIMIZATION_DEPTH =  100
+ARC_BLEND_GAP_CYCLES =          4
+ARC_BLEND_RAMP_FREQ =           20
+
+AXES =                      4
+COORDINATES =               X Y Z A
+MAX_ANGULAR_VELOCITY =      45.00
+DEFAULT_ANGULAR_VELOCITY =  4.50
+LINEAR_UNITS =              mm
+ANGULAR_UNITS =             degree
+CYCLE_TIME =                0.010
+DEFAULT_LINEAR_VELOCITY =   20.0
+MAX_LINEAR_VELOCITY =       250.00
+DEFAULT_VELOCITY =          20.00
+MAX_VELOCITY =              250.00
+TIME_UNITS =                s
+
+
+
+[AXIS_0]
+# --- X ----
+# 
+# Step timing is 40 us steplen + 40 us stepspace
+# That gives 80 us step period = 12.5 KHz step freq
+#
+# Bah, even software stepping can handle that, hm2 doesnt buy you much with
+# such slow steppers.
+#
+# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
+#
+# This gives a maxvel of 12.5/1 = 12.5 ips
+#
+
+
+TYPE =              LINEAR
+MAX_VELOCITY =       250.0
+MAX_ACCELERATION =   3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    300.0
+STEPGEN_MAX_ACC =    3600.0
+
+BACKLASH =           0.000
+
+# scale is 200 steps/rev * 5 revs/inch
+SCALE =  -160
+# leadscrew
+#SCALE = -800  
+
+MIN_LIMIT =             -1.0
+MAX_LIMIT =             420.0
+
+FERROR =     1.0
+MIN_FERROR = 0.25
+
+HOME =                  0.000
+HOME_OFFSET =           0.00
+HOME_IGNORE_LIMITS =    YES
+HOME_USE_INDEX =        NO
+HOME_SEQUENCE =         0
+
+# Set to zero if you dont have physical home/limit switches
+# Set to the desired homing and latch velocity if you have switches
+# See: http://www.linuxcnc.org/docs/2.5/html/config/ini_homing.html
+HOME_SEARCH_VEL =       -40.0
+HOME_LATCH_VEL =        -5.0
+#HOME_SEARCH_VEL =       0
+#HOME_LATCH_VEL =        0
+
+# these are in nanoseconds
+DIRSETUP   =              650
+DIRHOLD    =              650
+STEPLEN    =              1900
+STEPSPACE  =              1900
+#DIRSETUP   =              600
+#DIRHOLD    =              600
+#STEPLEN    =              1250
+#STEPSPACE  =              1250
+
+# P8.43 PRU1.out2
+STEPPIN = 813
+# P8.44 PRU1.out4
+DIRPIN  = 812
+
+
+[AXIS_1]
+# --- Y ----
+
+TYPE =              LINEAR
+MAX_VELOCITY =       200.0
+MAX_ACCELERATION =   3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    240.0
+STEPGEN_MAX_ACC =    3600.0
+
+BACKLASH =           0.000
+
+SCALE =  -160.0
+
+MIN_LIMIT =             -1.0
+MAX_LIMIT =             240.0
+
+FERROR =     1.0
+MIN_FERROR = 0.25
+
+HOME =                  0.000
+HOME_OFFSET =           0.00
+HOME_IGNORE_LIMITS =    YES
+HOME_USE_INDEX =        NO
+HOME_SEQUENCE =         0
+
+# Set to zero if you dont have physical home/limit switches
+# Set to the desired homing and latch velocity if you have switches
+# See: http://www.linuxcnc.org/docs/2.5/html/config/ini_homing.html
+HOME_SEARCH_VEL =       -30.0
+HOME_LATCH_VEL =        -5.0
+#HOME_SEARCH_VEL =       0
+#HOME_LATCH_VEL =        0
+
+# these are in nanoseconds
+DIRSETUP   =              650
+DIRHOLD    =              650
+STEPLEN    =              1900
+STEPSPACE  =              1900
+
+# P8.42 PRU1.out5
+STEPPIN = 815
+# P8.39 PRU1.out6
+DIRPIN  = 814
+
+
+[AXIS_2]
+# --- Z ----
+
+TYPE =              LINEAR
+MAX_VELOCITY =      20.0
+MAX_ACCELERATION =  100.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    24
+STEPGEN_MAX_ACC =    125.0
+
+BACKLASH =           0.000
+
+#SCALE = 1511.81102362
+#SCALE = -3023.6
+#SCALE = -8004
+# leadscrew
+SCALE = -800  
+
+MIN_LIMIT =             -0.01
+MAX_LIMIT =             210.0
+
+FERROR =     1.0
+MIN_FERROR = 0.25
+
+HOME =                  0.000
+HOME_OFFSET =           0.00
+HOME_IGNORE_LIMITS =    YES
+HOME_USE_INDEX =        NO
+HOME_SEQUENCE =         0
+
+# Set to zero if you dont have physical home/limit switches
+# Set to the desired homing and latch velocity if you have switches
+# See: http://www.linuxcnc.org/docs/2.5/html/config/ini_homing.html
+HOME_SEARCH_VEL =       -10.0
+HOME_LATCH_VEL =        -0.5
+#HOME_SEARCH_VEL =       0
+#HOME_LATCH_VEL =        0
+
+# these are in nanoseconds
+DIRSETUP   =              650
+DIRHOLD    =              650
+STEPLEN    =              1900
+STEPSPACE  =              1900
+
+# P8.27 PRU1.out8
+STEPPIN = 819
+# P8.29 PRU1.out9
+DIRPIN  = 818
+
+
+[AXIS_3]
+# --- A ----
+
+TYPE = ANGULAR
+MAX_VELOCITY = 31.8993189453
+MAX_ACCELERATION = 3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL = 37.0
+STEPGEN_MAX_ACC = 3600.0
+
+BACKLASH =           0.000
+
+#SCALE = -744.530002058
+#SCALE = -1321.1
+#SCALE = -1342.58
+#SCALE = -1337.9
+#--- Direct filament driver
+#SCALE = -304.52
+SCALE = -307
+#SCALE = -732.32
+
+MIN_LIMIT = -999999999.0
+MAX_LIMIT = 999999999.0
+
+FERROR = 1.0
+MIN_FERROR = .25
+
+HOME =                  0.000
+HOME_OFFSET =           0.00
+HOME_IGNORE_LIMITS =    YES
+HOME_USE_INDEX =        NO
+HOME_SEQUENCE =         0
+
+# Set to zero if you dont have physical home/limit switches
+# Set to the desired homing and latch velocity if you have switches
+# See: http://www.linuxcnc.org/docs/2.5/html/config/ini_homing.html
+HOME_SEARCH_VEL =      0.0
+HOME_LATCH_VEL =        0.0
+
+DIRSETUP   =              650
+DIRHOLD    =              650
+STEPLEN    =              1900
+STEPSPACE  =              1900
+
+# P8.30 GPIO2.25
+STEPPIN = 916
+# P8.21 GPIO1.30
+DIRPIN  = 912
+
+[FDM]
+VELOCITY_EXTRUSION_ENABLE = 0
+
+
+[EXTRUDER_0]
+PID_PGAIN              = 0.11
+PID_IGAIN              = 0.0001
+PID_DGAIN              = 0.05
+PID_MAXERRORI          = 0.2
+PID_BIAS               = 0.0
+PWM_MAX                = 1.0
+TEMP_RANGE_POS_ERROR   = 1.0
+TEMP_RANGE_NEG_ERROR   = -1.0
+TEMP_RANGE_LOWPASSGAIN = 0.0008
+TEMP_LIMIT_MIN         = 0.0
+TEMP_LIMIT_MAX         = 280.0
+TEMP_STANDBY           = 180.0
+THERMISTOR             = epcos_B57560G104F
+
+RETRACT_LEN            = 0.6
+RETRACT_VEL            = 50.0
+
+FILAMENT_DIA           = 3.0
+
+FAN_BIAS               = 0.2
+
+[HBP]
+PID_PGAIN              = 1.0
+PID_IGAIN              = 0.0
+PID_DGAIN              = 0.03
+PID_MAXERRORI          = 1.0
+PID_BIAS               = 0.5
+PWM_MAX                = 0.7
+TEMP_RANGE_POS_ERROR   = 1.0
+TEMP_RANGE_NEG_ERROR   = -1.0
+TEMP_LIMIT_MIN         = 0.0
+TEMP_LIMIT_MAX         = 120.0
+TEMP_STANDBY           = 40.0
+THERMISTOR             = epcos_B57560G1104
+
+
+[P0]
+X = 0.0
+Y = 0.0
+
+
+[EMCIO]
+
+# Name of IO controller program, e.g., io
+EMCIO =                 io
+
+# cycle time, in seconds
+CYCLE_TIME =            0.100
+
+# tool table file
+TOOL_TABLE =            tool.tbl
+

--- a/configs/ARM/BeagleBone/CRAMPS-QVCP/CRAMPS_QVCP.py
+++ b/configs/ARM/BeagleBone/CRAMPS-QVCP/CRAMPS_QVCP.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+
+import sys
+import os
+import subprocess
+import importlib
+import argparse
+from time import *
+from machinekit import launcher
+
+
+launcher.register_exit_handler()
+#launcher.set_debug_level(5)
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
+
+try:
+    launcher.check_installation()                                     # make sure the Machinekit installation is sane
+    launcher.cleanup_session()                                        # cleanup a previous session
+#    launcher.load_bbio_file('myoverlay.bbio')                         # load a BBB universal overlay
+    launcher.install_comp('thermistor_check.comp')
+#    launcher.install_comp('gantry.comp')                              # install a comp HAL component of not already installed
+    launcher.start_process("configserver -n CRAMPS_QVCP-3D ~/Machineface ~/Cetus")   # start the configserver
+    launcher.start_process('linuxcnc CRAMPS_QVCP.ini')                        # start linuxcnc
+except subprocess.CalledProcessError:
+    launcher.end_session()
+    sys.exit(1)
+
+while True:
+    sleep(1)
+    launcher.check_processes()

--- a/configs/ARM/BeagleBone/CRAMPS-QVCP/CRAMPS_QVCP.qbs
+++ b/configs/ARM/BeagleBone/CRAMPS-QVCP/CRAMPS_QVCP.qbs
@@ -1,0 +1,12 @@
+import qbs
+
+MachinekitApplication {
+    name: "CRAMPS_QVCP_3D"
+    halFiles: ["CRAMPS_QVCP.hal"]
+    configFiles: ["CRAMPS_QVCP.ini"]
+    otherFiles: ["tool.tbl", "subroutines"]
+    pythonFiles: ["python"]
+    compFiles: ["thermistor_check.comp"]
+    linuxcncIni: "CRAMPS_QVCP.ini"
+    //display: "thinkpad.local:0.0"
+}

--- a/configs/ARM/BeagleBone/CRAMPS-QVCP/setup.sh
+++ b/configs/ARM/BeagleBone/CRAMPS-QVCP/setup.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Copyright 2013
+# Charles Steinkuehler <charles@steinkuehler.net>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+dtbo_err () {
+	echo "Error loading device tree overlay file: $DTBO" >&2
+	exit 1
+}
+
+pin_err () {
+	echo "Error exporting pin:$PIN" >&2
+	exit 1
+}
+
+dir_err () {
+	echo "Error setting direction:$DIR on pin:$PIN" >&2
+	exit 1
+}
+
+SLOTS=/sys/devices/bone_capemgr.*/slots
+
+# Make sure required device tree overlay(s) are loaded
+for DTBO in cape-universal cape-bone-iio ; do
+
+	if grep -q $DTBO $SLOTS ; then
+		echo $DTBO overlay found
+	else
+		echo Loading $DTBO overlay
+		sudo -A su -c "echo $DTBO > $SLOTS" || dtbo_err
+		sleep 1
+	fi
+done;
+
+if [ ! -r /sys/devices/ocp.*/helper.*/AIN0 ] ; then
+	echo Analog input files not found in /sys/devices/ocp.*/helper.* >&2
+	exit 1;
+fi
+
+if [ ! -r /sys/class/uio/uio0 ] ; then
+	echo PRU control files not found in /sys/class/uio/uio0 >&2
+	exit 1;
+fi
+
+# Export GPIO pins:
+# One pin needs to be exported to enable the low-level clocks for the GPIO
+# modules (there is probably a better way to do this)
+# 
+# Any GPIO pins driven by the PRU need to have their direction set properly
+# here.  The PRU does not do any setup of the GPIO, it just yanks on the
+# pins and assumes you have the output enables configured already
+# 
+# Direct PRU inputs and outputs do not need to be configured here, the pin
+# mux setup (which is handled by the device tree overlay) should be all
+# the setup needed.
+# 
+# Any GPIO pins driven by the hal_bb_gpio driver do not need to be
+# configured here.  The hal_bb_gpio module handles setting the output
+# enable bits properly.  These pins _can_ however be set here without
+# causing problems.  You may wish to do this for documentation or to make
+# sure the pin starts with a known value as soon as possible.
+
+sudo $(which config-pin) -f - <<- EOF
+
+	P8.07	in	# X Max
+	P8.08	in	# X Min
+	P8.09	in	# Y Max
+	P8.10	in	# Y Min
+	P8.11	low	# FET 1 : Heated Bed
+	P8.12	low	# X Dir
+	P8.13	low	# X Step
+	P8.14	low	# Y Dir
+	P8.15	low	# Y Step
+	P8.16	high	# eMMC Enable
+	P8.17	in	# ESTOP
+	P8.18	low	# Z Dir
+	P8.19	low	# Z Step
+
+# eMMC signals, uncomment *ONLY* if you have disabled the on-board eMMC!
+# MachineKit images disable eMMC and HDMI audio by default in uEnv.txt:
+#  capemgr.disable_partno=BB-BONELT-HDMI,BB-BONE-EMMC-2G
+#	P8.22	low	# Servo 4
+#	P8.23	low	# Servo 3
+#	P8.24	low	# Servo 2
+#	P8.25	low	# Servo 1
+
+	P8.26	high	# ESTOP Out
+
+	P9.11	in	# Z Max
+	P9.12	low	# E0 Dir
+	P9.13	in	# Z Min
+	P9.14	high	# Axis Enable, active low
+	P9.15	low	# FET 2 : E0
+	P9.16	low	# E0 Step
+	P9.17	low	# E1 Step
+	P9.18	low	# E1 Dir
+#	P9.19	low	# I2C SCL
+#	P9.20	low	# I2C SDA
+	P9.21	low	# FET 4 : E1
+	P9.22	low	# FET 6
+	P9.23	low	# Machine Power
+	P9.24	low	# E2 Step
+	P9.25	low	# LED
+	P9.26	low	# E2 Dir
+	P9.27	low	# FET 3 : E2
+	P9.28	low	# SPI CS0
+	P9.29	low	# SPI MISO
+	P9.30	low	# SPI MOSI
+	P9.31	low	# SPI SCLK
+
+	P9.41	low	# FET 5
+	P9.91	in	# Reserved, connected to P9.41
+
+	P9.42	low	# SPI CS1
+	P9.92	in	# Reserved, connected to P9.42
+EOF
+

--- a/configs/ARM/BeagleBone/CRAMPS-QVCP/thermistor_check.comp
+++ b/configs/ARM/BeagleBone/CRAMPS-QVCP/thermistor_check.comp
@@ -1,0 +1,135 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2014 Alexander Rössler
+ *
+ *
+ * This module checks the functionality of thermistors
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * THE AUTHORS OF THIS PROGRAM ACCEPT ABSOLUTELY NO LIABILITY FOR
+ * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE
+ * TO RELY ON SOFTWARE ALONE FOR SAFETY.  Any machinery capable of
+ * harming persons must have provisions for completely removing power
+ * from all motors, etc, before persons enter any danger area.  All
+ * machinery must be designed to comply with local and national safety
+ * codes, and the authors of this software can not, and do not, take
+ * any responsibility for such compliance.
+ *
+ * This code was written as part of the LinuxCNC project.  For more
+ * information, go to www.linuxcnc.org.
+ *
+ ******************************************************************************/
+
+component thermistor_check "LinuxCNC HAL component for checking functionality of thermistors";
+pin in  float   temp      "Temperature input";
+pin in  float   min_temp  "The minimum temperature change that should count";
+pin in  float   pid       "Output of PID control";
+pin in  float   min_pid   "The minimum PID control output to react to";
+pin in  float   bias      "Bias for the PID input. Can be used to correct errors due to cooling.";
+pin in  float   wait      "Time to wait before triggering an error in secods";
+pin in  bit     enable    "Enables or disables the component, out is TRUE when disabled";
+pin out bit     no_error  "Output value -> TRUE when the thermistor works as exspected";
+pin out bit     error     "Error value -> FALSE when the thermistor works as exspected";
+function _  fp "Update the output value";
+description """
+Component for checking functionality of thermistors
+.LP
+TODO
+""";
+license "GPL";
+variable float last_temp = 0.0;
+variable bool last_enable = 0;
+variable float oldwait = 0.0;
+variable int t_secs = 0;
+variable int t_nsecs = 0;
+variable int c_secs = 0;
+variable int c_nsecs = 0;
+variable bool start = 0;
+;;
+FUNCTION(_) {
+    bool active;
+    float temp_change;
+    float time;
+    
+    if (wait != oldwait)
+    {
+        time = wait;
+        if (time < 0) time = 0; // no negative timeout periods
+        // new timeout, convert to secs/ns
+        oldwait = time;
+        t_secs = time;
+        time -= t_secs;
+        t_nsecs = (1e9 * time);
+        
+        if (enable) {
+            // reset
+            start = 1;
+        }
+    }
+
+    if ((enable) && (pid >= (min_pid+bias)))
+    {
+        if (start == 1)
+        {
+            // reset
+            c_secs = t_secs;
+            c_nsecs = t_nsecs;
+            last_temp = temp;
+            start = 0;
+        }
+        else
+        {
+            c_nsecs -= period;
+            if (c_nsecs < 0)
+            {
+                c_nsecs += 1000000000;
+                if (c_secs > 0) 
+                {
+                    c_secs--;
+                }
+                else
+                {
+                    start = 1; // restart
+                }
+            }
+            
+            if (start == 1)
+            {
+                temp_change = temp - last_temp;
+
+                if (temp_change >= min_temp)    // correct
+                {
+                    no_error = 1;
+                    error = 0;
+                }
+                else
+                {
+                    no_error = 0;
+                    error = 1;
+                }
+            }
+        }
+    }
+    else
+    {
+        start = 1;
+        no_error = 1;
+        error = 0;
+    }
+}

--- a/configs/ARM/BeagleBone/CRAMPS-QVCP/tool.tbl
+++ b/configs/ARM/BeagleBone/CRAMPS-QVCP/tool.tbl
@@ -1,0 +1,5 @@
+T0 P0 ; Extruder 0
+T1 P1 ; Extruder 1
+T2 P2 ; Extruder 2
+T3 P3 ; Extruder 3
+T100 P100 X+35.000000 Z+0.900000 ; probe head


### PR DESCRIPTION
Hardware: BBB CRAMPS2 RepRap Prusa-i3 3D printer
Software: Machinface and Cetus (QTQuickVcp based)
-- Auto extruder fan turn on.
-- Autostop if thermistor  detached
-- FDM component standard
-- gcode remap subroutines
-- Preview workes
-- can print directly from Slicr Mach3/LinuxCNC  flavor G-code
! no velocity based extrusion ... yet

There is an optional addition to 
Machineface/Machineface/DisplayPanel.qml
adding some extra extruder fan control:

    FanControl {
        componentName: "fdm-f1"
        labelName: "Ext Fan"
    }

this is not part of the machinekit repo yet ...?