### PR TITLE
delayline with typed (pin)samples

### DIFF
--- a/man/man9/delayline.9
+++ b/man/man9/delayline.9
@@ -1,0 +1,112 @@
+.TH DELAYLINE "9" "2015-01-03" "Machinekit Documentation" "HAL Component"
+.de TQ
+.br
+.ns
+.TP \\$1
+..
+
+.SH NAME
+
+delayline \- buffer for delaying pins
+
+.SH SYNOPSIS
+.HP
+.B loadrt delayline names=foo,bar max_delay=500,2500 samples=ffb,ffbsu
+
+.SH DELAYLINE
+The delayline will sample the value of an input pin, and put the sample
+in the output pin after a certain amount of periods.
+
+With this component it is possible to attach with another component to
+inspect the buffer. For example to create a virtual look-ahead by delaying
+certain pins (motion) without other actuators. This delay
+will buy time to inspect and change buffer record values.
+
+\fImax_delay\fR will specify the max allowble delay time. When entering a
+value higher than max_delay the time will be cropped to this max value
+
+\fIsamples\fR specifies the different types of pins to be created.
+These pins must be of the type of BIT (b), FLOAT (f), S32 (s), or U32 (u). 
+
+There can be different (amount of) pins that are going to be created and
+they will all have the same delay.
+
+The number of periods to delay is taken from the delay pin of the component
+
+The pins of the component are created in a HAL section of the ring buffer
+thus making the values of the pins available thru attaching to the ring.
+
+.SH THREADS
+.TP 
+.B delayline.\fBsample\fR use like: \fIaddf delayline.sample realtime-thread\fR
+
+To be called by a thread to be executed. This function puts the sample from
+a pin into the buffer. 
+
+.TP 
+.B delayline.\fBoutput\fR use like: \fIaddf delayline.output realtime-thread\fR
+
+To be called by a thread to be executed. This function reads the sample
+from the the buffer, and puts it into the pins. When delay time is decreased
+the records between the current (old position) record, and the new position
+read record (current sample - new delay) will be dropped.
+
+
+.SH PINS
+.TP 
+.B delayline.\fBenable\fR bit in
+
+Enables the delayline, when not enabled, the input sample is set directly
+to the output pin.
+
+.TP
+.B delayline.\fBabort\fR bit in
+
+This flushes the buffer. The user is responsible for whether this pin is attached.
+
+.TP
+.B delayline.\fBdelay\fR float in
+
+The delay in thread periods.
+
+.TP
+.B delayline.\fI{type}\fB-in\fI{N}\fR the input sample pin
+
+\fI{type}\fR corresponds with \fIbit\fR, \fIflt\fR, \fIu32\fR or \fIs32\fR
+
+\fI{N}\fR corresponds with the consecutive number of the pin in the line, 
+so flt-in2 is the pin that is generated after bit-in1.
+
+The input sample pin is matched by output sample pin.
+\fIdelayline.flt-in0\fR is the source of the delayed \fIdelayline.flt-out0\fR 
+pin
+
+.TP
+.B delayline.\fI{type}\fB-out\fI{N}\fR the input sample pin
+
+\fI{type}\fR corresponds with \fIbit\fR, \fIflt\fR, \fIu32\fR or \fIs32\fR
+
+\fI{N}\fR corresponds with the consecutive number of the pin in the line, 
+so flt-out2 is the pin that is generated after bit-out1.
+
+The output sample pin is matched by input sample pin
+\fIdelayline.flt-out0\fR is the delay of the \fIdelayline.flt-out0 input 
+sample\fR
+
+.TP
+.B delayline.\fBwrite-fail\fR u32 out
+counter of failed writes
+
+.TP
+.B delayline.\fBread-fail\fR u32 out
+counter of failed reads
+
+.TP
+.B delayline.\fBtoo-old\fR u32 out
+counter of records being too old
+
+.SH NOTES
+When enabled, the delay time can be changed during use. This can result in 
+dropped records (decreasing delay time), or records being extra delayed 
+(increasing delay time).
+

--- a/src/hal/components/Submakefile
+++ b/src/hal/components/Submakefile
@@ -165,3 +165,11 @@ hal/components/conv_u32_bit.comp: hal/components/conv.comp.in hal/components/mkc
 hal/components/conv_u32_s32.comp: hal/components/conv.comp.in hal/components/mkconv.sh $(HALCOMP_SUBMAKEFILE)
 	$(ECHO) converting conv for $(notdir $@)
 	$(Q)sh hal/components/mkconv.sh u32 s32 "" -1 2147483647 < $< > $@
+
+
+# build instructions for the delayline module
+obj-m += delayline.o
+# the list of parts
+delayline-objs := hal/components/delayline.o $(MATHSTUB)
+
+$(RTLIBDIR)/delayline$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(delayline-objs))

--- a/src/hal/components/delayline.c
+++ b/src/hal/components/delayline.c
@@ -135,8 +135,13 @@ static void write_sample_to_ring(void *arg, long period)
     hal_delayline_t *hd = rb->scratchpad;    // per-instance HAL data
     sample_t *s;
 
-    if (!*(hd->enable)) // skip if not sampling
+    if (!*(hd->enable)) {	// skip if not sampling, just put the input 
+				//values into the output values
+	for (j = 0; j < hd->nsamples; j++) {
+		*(hd->flt_out[j]) = *(hd->flt_in[j]);
+    	}
 	goto DONE;
+    }
 
     // use non-copying write:
     // allocate space in the ringbuffer and retrieve a pointer to it

--- a/src/hal/components/delayline.c
+++ b/src/hal/components/delayline.c
@@ -1,0 +1,285 @@
+/*
+  component written by Bas de Bruijn
+  todo other info and stuff
+*/
+
+#ifndef MODULE
+#include <stdint.h>
+#endif
+#include "rtapi.h"
+#include "rtapi_app.h"
+#include "rtapi_string.h"
+#include "hal.h"
+#include "hal_ring.h"
+
+MODULE_AUTHOR("Bas de Bruijn");
+MODULE_DESCRIPTION("Delay line component for Machinekit HAL");
+MODULE_LICENSE("GPLv2");
+
+#define MAX_INST 8
+#define DEFAULT_SAMPLES 3
+#define MAX_SAMPLES 9       // a pose has 9 doubles
+#define DEFAULT_DELAY 1000  // 1 sec at default servo rate
+#define RB_HEADROOM 1.2     // ringbuffer size overallocation
+
+static char *names[MAX_INST] = { "delayline.0", };
+RTAPI_MP_ARRAY_STRING(names, MAX_INST,"delayline names");
+
+static int delay[MAX_INST] = {
+    DEFAULT_DELAY,DEFAULT_DELAY,DEFAULT_DELAY,DEFAULT_DELAY,
+    DEFAULT_DELAY,DEFAULT_DELAY,DEFAULT_DELAY,DEFAULT_DELAY
+};
+RTAPI_MP_ARRAY_INT(delay, MAX_INST,"number of samples to delay for each line");
+
+static int samples[MAX_INST] = {
+    DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,
+    DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,
+};
+RTAPI_MP_ARRAY_INT(samples, MAX_INST,"number of pins to sample in each line");
+
+typedef struct {
+    // pins
+    hal_bit_t *enable;           /* pin: enable this                   */
+    hal_bit_t *abort;            /* pin: abort pin                     */
+    hal_float_t *flt_in[MAX_SAMPLES];   /* pin: array incoming value          */
+    hal_float_t *flt_out[MAX_SAMPLES];  /* pin: array delayed value           */
+    hal_u32_t  *write_fail;      // error counter, write side
+    hal_u32_t  *read_fail;       // error counter, read side
+    hal_u32_t  *too_old;         // error counter, samples skipped because too old
+
+    // other params & instance data
+    uint64_t  output_ts, input_ts;
+    unsigned  delay;             // delay in periods
+    int nsamples;                // number of pins in this line
+    size_t sample_size;          // sizeof(sample_t)  + num_channel * sizeof (hal_float_t)
+    hal_bit_t last_abort;        // tracking value for edge detection
+    char name[HAL_NAME_LEN + 1]; // of this instance
+} hal_delayline_t;
+
+typedef struct {
+    uint64_t timestamp;          /* timestamp of measurement           */
+    hal_float_t value[0];        /* measured value                     */
+} sample_t;
+
+
+static ringbuffer_t *instance[MAX_INST]; // instance data
+static int count;              // number of instances
+static int comp_id;
+const char *cname = "delayline";
+
+// thread functions
+static void write_sample_to_ring(void *arg, long period);
+static void read_sample_from_ring(void *arg, long period);
+
+// this is the routine where the pins are made
+static int export_delayline(int n);
+
+// initialisation routine
+int rtapi_app_main(void)
+{
+    int n, retval;
+
+    // determine number of instances
+    for (count = 0; (names[count] != NULL) && (count < MAX_INST); count++);
+
+    comp_id = hal_init(cname);
+    if (comp_id < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: ERROR: hal_init() failed, rc=%d\n", cname, comp_id);
+	return -1;
+    }
+
+    // export variables and function for each DELAYLINE loop */
+    for (n = 0; n < count; n++) {
+	if ((retval = export_delayline(n))) {
+	    rtapi_print_msg(RTAPI_MSG_ERR,
+			    "%s: ERROR: loop %d var export failed\n", cname, n);
+	    hal_exit(comp_id);
+	    return -1;
+	}
+    }
+
+    rtapi_print_msg(RTAPI_MSG_INFO,
+		    "%s: installed %d lines\n", cname, count);
+    hal_ready(comp_id);
+    return 0;
+}
+
+// exiting routine
+void rtapi_app_exit(void)
+{
+    hal_exit(comp_id);
+
+    //detach from all rings, and delete them
+    int n;
+    for (n = 0; n < count; n++) {
+	if (instance[n]) {
+	    hal_delayline_t *hd = instance[n]->scratchpad;
+
+	    char ringname[HAL_NAME_LEN + 1];
+	    snprintf(ringname, HAL_NAME_LEN, "%s.samples", hd->name);
+	    hal_ring_detach(ringname, instance[n]);
+	    hal_ring_delete(ringname);
+	}
+    }
+}
+
+
+/* write_sample_to_ring() will take the pins with the actual value and
+   put them into the ring.
+*/
+static void write_sample_to_ring(void *arg, long period)
+{
+    int j;
+    ringbuffer_t *rb = (ringbuffer_t *) arg;
+    hal_delayline_t *hd = rb->scratchpad;    // per-instance HAL data
+    sample_t *s;
+
+    if (!*(hd->enable)) // skip if not sampling
+	goto DONE;
+
+    // use non-copying write:
+    // allocate space in the ringbuffer and retrieve a pointer to it
+    if (record_write_begin(rb, (void ** )&s, hd->sample_size)) {
+	*(hd->write_fail) += 1;
+	goto DONE;
+    }
+
+    // deposit record directly in rb memory
+    s->timestamp = hd->input_ts;
+    for (j = 0; j < hd->nsamples; j++) {
+	s->value[j] = *(hd->flt_in[j]);
+    }
+
+    // commit the write given the actual write size (which is the same as given in
+    // record_write_begin in our case).
+    // this makes the record actually visible on the read side (advances pointer)
+    if (record_write_end(rb, s, hd->sample_size))
+	*(hd->write_fail) += 1;
+
+ DONE:
+    hd->input_ts++;
+}
+
+// sample the pins to the current rb record
+static inline void apply(const sample_t *s, const hal_delayline_t *hd)
+{
+    int i;
+    for (i = 0; i < hd->nsamples; i++)
+	*(hd->flt_out[i]) = s->value[i];
+}
+
+static void read_sample_from_ring(void *arg, long period)
+{
+    ringbuffer_t *rb = (ringbuffer_t *) arg;
+    hal_delayline_t *hd = rb->scratchpad;
+    const sample_t *s;
+    size_t size;
+
+    // detect rising edge on abort pin, and flush rb if so
+    if (*(hd->abort) && (*(hd->abort) ^ hd->last_abort)) {
+	int dropped = record_flush(rb);
+	rtapi_print_msg(RTAPI_MSG_INFO,
+			"%s: %s aborted - dropped %d samples\n",
+			cname, hd->name, dropped);
+    }
+
+    // peek at the head of the queue
+    while (record_read(rb, (const void **)&s, &size) == 0) {
+
+	// do nothing if timestamp is in the future
+	if (s->timestamp > hd->output_ts)
+	    goto NOTYET;
+
+	if (s->timestamp == hd->output_ts)
+	    // the time is right
+	    apply(s, hd);
+	else
+	    // skip old samples and bump an error counter
+	    *(hd->too_old) += 1;
+
+	// sanity: if (size != hd->sample_size).. terribly wrong.
+	record_shift(rb); // consume record
+    }
+ NOTYET:
+    hd->output_ts++; // always bump the timestamp
+    hd->last_abort = *(hd->abort);
+}
+
+static int export_delayline(int n)
+{
+    int retval, i;
+    char buf[HAL_NAME_LEN + 1];
+
+    // determine the required size of the ringbuffer
+    size_t nsamples =  samples[n];
+    size_t sample_size = sizeof(sample_t) + (nsamples * sizeof(hal_float_t));
+
+    // add some headroom to be sure we dont overrun
+    size_t rbsize = record_space(sample_size) * delay[n] * RB_HEADROOM;
+
+    // create the delay queue
+    snprintf(buf, HAL_NAME_LEN, "%s.samples", names[n]);
+    if ((retval = hal_ring_new(buf, rbsize,
+			       sizeof(hal_delayline_t), ALLOC_HALMEM))) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: failed to create new ring %s: %d\n",
+			cname, buf, retval);
+	return -1;
+    }
+
+    // use the per-using component ring access structure as the instance data,
+    // which will also give us a handle on the scratchpad which we use for
+    // HAL pins and other shared data
+    if ((instance[n] = hal_malloc(sizeof(ringbuffer_t))) == NULL)
+	return -1;
+    if ((retval = hal_ring_attach(buf, instance[n], NULL))) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: attach to ring %s failed: %d\n",
+			cname, buf, retval);
+	return -1;
+    }
+
+    // fill in instance data
+    hal_delayline_t *hd = instance[n]->scratchpad;
+    strncpy(hd->name, names[n], sizeof(hd->name));
+    hd->nsamples = nsamples;
+    hd->sample_size = sample_size;
+    hd->delay = delay[n];
+
+    hd->output_ts = 0;
+    hd->input_ts =  hd->delay;
+
+    // init pins
+    for (i = 0; i < hd->nsamples; i++) {
+	if (((retval = hal_pin_float_newf(HAL_IN, &(hd->flt_in[i]), comp_id,
+					  "%s.in%d", hd->name, i))) ||
+	    ((retval = hal_pin_float_newf(HAL_OUT, &(hd->flt_out[i]), comp_id,
+					  "%s.out%d", hd->name, i))))
+	    return retval;
+    }
+    if (((retval = hal_pin_bit_newf(HAL_IN, &(hd->enable), comp_id,
+				    "%s.enable",  hd->name))) ||
+	((retval = hal_pin_bit_newf(HAL_IN, &(hd->abort), comp_id,
+				    "%s.abort",  hd->name))) ||
+	((retval = hal_pin_u32_newf(HAL_OUT, &(hd->write_fail), comp_id,
+				    "%s.write-fail", hd->name))) ||
+	((retval = hal_pin_u32_newf(HAL_OUT, &(hd->read_fail), comp_id,
+				    "%s.too-old", hd->name))) ||
+	((retval = hal_pin_u32_newf(HAL_OUT, &(hd->too_old), comp_id,
+				    "%s.read-fail", hd->name))))
+	return retval;
+
+    // export thread functions
+    rtapi_snprintf(buf, sizeof(buf), "%s.sample", hd->name);
+    if ((retval = hal_export_funct(buf, write_sample_to_ring,
+				   instance[n], 1, 0, comp_id))) {
+	return retval;
+    }
+    rtapi_snprintf(buf, sizeof(buf), "%s.output", hd->name);
+    if ((retval = hal_export_funct(buf, read_sample_from_ring,
+				   instance[n], 1, 0, comp_id))) {
+	return retval;
+    }
+    return 0;
+}

--- a/src/hal/components/delayline.c
+++ b/src/hal/components/delayline.c
@@ -1,7 +1,15 @@
-/*
-  component written by Bas de Bruijn
-  todo other info and stuff
-*/
+// this component brings a multi-purpose delay line.
+//
+// input pins of bit, float, u32 or s32 will be measured and put in a buffer
+// with a timestamp (hal_delayline_t->input_ts).
+// The reading part of this component will look at the record in
+// the buffer, and when the timestamp matches it's own timestamp
+// (hal_delayline_t->output_ts which is less then hal_delayline_t->input_ts)
+// the value will be put into the output pins.
+//
+// changing the hal_delayline_t->delay pin will set the amount of delay
+//
+// see manpage delayline.9
 
 #ifndef MODULE
 #include <stdint.h>
@@ -17,7 +25,7 @@ MODULE_DESCRIPTION("Delay line component for Machinekit HAL");
 MODULE_LICENSE("GPLv2");
 
 #define MAX_INST 8
-#define DEFAULT_SAMPLES 3
+#define DEFAULT_SAMPLES 1
 #define MAX_SAMPLES 9       // a pose has 9 doubles
 #define MAX_DELAY 1000      // 1 sec at default servo rate
 #define RB_HEADROOM 1.2     // ringbuffer size overallocation
@@ -29,38 +37,44 @@ static int max_delay[MAX_INST] = {
 	MAX_DELAY,MAX_DELAY,MAX_DELAY,MAX_DELAY,
 	MAX_DELAY,MAX_DELAY,MAX_DELAY,MAX_DELAY
 };
-RTAPI_MP_ARRAY_INT(max_delay, MAX_INST,"max number of samples to delay for each line");
+RTAPI_MP_ARRAY_INT(max_delay, MAX_INST,"delayline max number of samples");
 
-static int samples[MAX_INST] = {
-	DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,
-	DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,
-};
-RTAPI_MP_ARRAY_INT(samples, MAX_INST,"number of pins to sample in each line");
+
+char *samples[MAX_INST];
+RTAPI_MP_ARRAY_STRING(samples, MAX_INST, "delayline pintype sample specifiers");
+
+typedef union {
+	// union for using channels of different types
+	hal_float_t		*pin_flt;
+	hal_bit_t		*pin_bit;
+	hal_u32_t		*pin_u32;
+	hal_s32_t		*pin_s32;
+} u_value;
 
 typedef struct {
 	// pins
-	hal_bit_t *enable;                  /* pin: enable this                   */
-	hal_bit_t *abort;                   /* pin: abort pin                     */
-	hal_float_t *flt_in[MAX_SAMPLES];   /* pin: array incoming value          */
-	hal_float_t *flt_out[MAX_SAMPLES];  /* pin: array delayed value           */
-	hal_u32_t	*pin_delay;             /* pin: delay time, standard zero     */
-	hal_u32_t  *write_fail;             // error counter, write side
-	hal_u32_t  *read_fail;              // error counter, read side
-	hal_u32_t  *too_old;                // error counter, samples skipped because too old
+	hal_bit_t		*enable;					// pin: enable this
+	hal_bit_t		*abort;						// pin: abort pin
+	u_value			*pins_in[MAX_SAMPLES];		// pin: array incoming value
+	u_value			*pins_out[MAX_SAMPLES];		// pin: array delayed value
+	hal_u32_t		*pin_delay;					// pin: delay time, standard zero
+	hal_u32_t 		*write_fail;				// error counter, write side
+	hal_u32_t 		*read_fail;					// error counter, read side
+	hal_u32_t 		*too_old;					// error counter, samples skipped because too old
 
 	// other params & instance data
 	uint64_t  output_ts, input_ts;
-	unsigned  max_delay;         // max delay of this line in periods
-	unsigned  delay;             // delay in periods
-	int nsamples;                // number of pins in this line
-	size_t sample_size;          // sizeof(sample_t)  + num_channel * sizeof (hal_float_t)
-	hal_bit_t last_abort;        // tracking value for edge detection
-	char name[HAL_NAME_LEN + 1]; // of this instance
+	unsigned  max_delay;         	// max delay of this line in periods
+	unsigned  delay;             	// delay in periods
+	int nsamples;                	// number of pins in this line
+	size_t sample_size;          	// size determined by union u_value
+	hal_bit_t last_abort;        	// tracking value for edge detection
+	char name[HAL_NAME_LEN + 1];	// of this instance
 } hal_delayline_t;
 
 typedef struct {
-	uint64_t timestamp;          /* timestamp of measurement           */
-	hal_float_t value[0];        /* measured value                     */
+	uint64_t timestamp;			// timestamp of measurement
+	u_value value[0];			// measured value
 } sample_t;
 
 
@@ -75,6 +89,7 @@ static void read_sample_from_ring(void *arg, long period);
 
 // this is the routine where the pins are made
 static int export_delayline(int n);
+static int return_instance_samples(int n);
 
 // initialisation routine
 int rtapi_app_main(void)
@@ -90,15 +105,49 @@ int rtapi_app_main(void)
 			"%s: ERROR: hal_init() failed, rc=%d\n", cname, comp_id);
 	return -1;
 	}
-
-	// export variables and function for each DELAYLINE loop */
-	for (n = 0; n < count; n++) {
-	if ((retval = export_delayline(n))) {
-		rtapi_print_msg(RTAPI_MSG_ERR,
-				"%s: ERROR: loop %d var export failed\n", cname, n);
-		hal_exit(comp_id);
-		return -1;
+	
+	// check if nr of array members in sample lines configuration string
+	// correspond with number of instances. initiation is like:
+	// samples="bb,sf,fus" (bit, float, signed, unsigned)
+	if (!samples[0]) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+        	"%s : ERROR: a string declaring valid pintypes is needed\n",
+        	cname);
+        hal_exit(comp_id);
+        return -1;
+    }
+    // parse the samples array for sanity
+    int nr_of_samples;
+	for (n = 0; (samples[n] != NULL) || (n < count); n++) {	
+		nr_of_samples = return_instance_samples(n);
+		if (nr_of_samples <= 0) {
+			rtapi_print_msg(RTAPI_MSG_ERR,
+				"%s: ERROR: erroneous number of samples (%d) for instance %d\n",
+				cname, nr_of_samples, n);
+			hal_exit(comp_id);
+			return -1;
+		}
+		rtapi_print_msg(RTAPI_MSG_INFO,
+			"%s: there are %d samples for instance %d\n",
+			cname, nr_of_samples, n);
 	}
+	if (n != count) {
+		rtapi_print_msg(RTAPI_MSG_ERR,
+				"%s: ERROR: \"samples=\" array amount mismatch with number of"
+				" instances\n",	cname);
+			hal_exit(comp_id);
+			return -1;
+	}
+
+	// done with input checking, and all should be fine
+	// export variables and function for each DELAYLINE loop
+	for (n = 0; n < count; n++) {
+		if ((retval = export_delayline(n))) {
+			rtapi_print_msg(RTAPI_MSG_ERR,
+					"%s: ERROR: loop %d var export failed\n", cname, n);
+			hal_exit(comp_id);
+			return -1;
+		}
 	}
 
 	rtapi_print_msg(RTAPI_MSG_INFO,
@@ -115,21 +164,20 @@ void rtapi_app_exit(void)
 	//detach from all rings, and delete them
 	int n;
 	for (n = 0; n < count; n++) {
-	if (instance[n]) {
-		hal_delayline_t *hd = instance[n]->scratchpad;
+		if (instance[n]) {
+			hal_delayline_t *hd = instance[n]->scratchpad;
 
-		char ringname[HAL_NAME_LEN + 1];
-		snprintf(ringname, HAL_NAME_LEN, "%s.samples", hd->name);
-		hal_ring_detach(ringname, instance[n]);
-		hal_ring_delete(ringname);
-	}
+			char ringname[HAL_NAME_LEN + 1];
+			snprintf(ringname, HAL_NAME_LEN, "%s.samples", hd->name);
+			hal_ring_detach(ringname, instance[n]);
+			hal_ring_delete(ringname);
+		}
 	}
 }
 
 
-/* write_sample_to_ring() will take the pins with the actual value and
-   put them into the ring.
-*/
+// write_sample_to_ring() will take the pins with the actual value 
+// and put them into the ring.
 static void write_sample_to_ring(void *arg, long period)
 {
 	int j;
@@ -157,7 +205,7 @@ static void write_sample_to_ring(void *arg, long period)
 	if (!*(hd->enable)) {	// skip if not sampling, just put the input 
 							// values into the output values
 	for (j = 0; j < hd->nsamples; j++) {
-		*(hd->flt_out[j]) = *(hd->flt_in[j]);
+		*(hd->pins_out[j]) = *(hd->pins_in[j]);
 		}
 	goto DONE;
 	}
@@ -172,12 +220,12 @@ static void write_sample_to_ring(void *arg, long period)
 	// deposit record directly in rb memory
 	s->timestamp = hd->input_ts;
 	for (j = 0; j < hd->nsamples; j++) {
-	s->value[j] = *(hd->flt_in[j]);
+	s->value[j] = *(hd->pins_in[j]);
 	}
 
-	// commit the write given the actual write size (which is the same as given in
-	// record_write_begin in our case).
-	// this makes the record actually visible on the read side (advances pointer)
+	// commit the write given the actual write size (which is the same
+	// as given in record_write_begin in our case). This makes the
+	// record actually visible on the read side (advances pointer)
 	if (record_write_end(rb, s, hd->sample_size))
 	*(hd->write_fail) += 1;
 
@@ -190,7 +238,7 @@ static inline void apply(const sample_t *s, const hal_delayline_t *hd)
 {
 	int i;
 	for (i = 0; i < hd->nsamples; i++)
-	*(hd->flt_out[i]) = s->value[i];
+	*(hd->pins_out[i]) = s->value[i];
 }
 
 static void read_sample_from_ring(void *arg, long period)
@@ -249,14 +297,41 @@ static void read_sample_from_ring(void *arg, long period)
 	hd->last_abort = *(hd->abort);
 }
 
+static int return_instance_samples(int n)
+{
+	int i, nr_of_samples = 0;
+	char character;
+	// traverse the string to count the number of correct pins
+	for (i = 0; (character = samples[n][i]); i++) {
+		switch (character) {
+			case 'b':
+			case 'B':
+			case 'f':
+			case 'F':
+			case 's':
+			case 'S':
+			case 'u':
+			case 'U':
+				nr_of_samples++;
+				break;
+			default:
+				rtapi_print_msg(RTAPI_MSG_ERR, "invalid character in "
+					"\"samples=\" string. Needs to be only b,f,s or u\n");
+				hal_exit(comp_id);
+				return -1;
+		}
+	}
+	return nr_of_samples;	
+}
+
 static int export_delayline(int n)
 {
-	int retval, i;
+	int retval, nr_of_samples, i;
 	char buf[HAL_NAME_LEN + 1];
 
 	// determine the required size of the ringbuffer
-	size_t nsamples =  samples[n];
-	size_t sample_size = sizeof(sample_t) + (nsamples * sizeof(hal_float_t));
+	nr_of_samples = return_instance_samples(n);
+	size_t sample_size = sizeof(sample_t) + (nr_of_samples * sizeof(u_value));
 
 	// add some headroom to be sure we dont overrun
 	size_t rbsize = record_space(sample_size) * max_delay[n] * RB_HEADROOM;
@@ -286,7 +361,7 @@ static int export_delayline(int n)
 	// fill in instance data
 	hal_delayline_t *hd = instance[n]->scratchpad;
 	strncpy(hd->name, names[n], sizeof(hd->name));
-	hd->nsamples = nsamples;
+	hd->nsamples = nr_of_samples;
 	hd->sample_size = sample_size;
 	hd->max_delay = max_delay[n];
 	// set delay standard to value of zero
@@ -295,13 +370,105 @@ static int export_delayline(int n)
 	hd->input_ts = hd->delay;
 
 	// init pins
+	char character;
 	for (i = 0; i < hd->nsamples; i++) {
-	if (((retval = hal_pin_float_newf(HAL_IN, &(hd->flt_in[i]), comp_id,
-					  "%s.in%d", hd->name, i))) ||
-		((retval = hal_pin_float_newf(HAL_OUT, &(hd->flt_out[i]), comp_id,
-					  "%s.out%d", hd->name, i))))
-		return retval;
+		character = samples[n][i];
+		rtapi_print_msg(RTAPI_MSG_INFO, "\"samples=\" string = %s"
+										" character %d = %c \n", 
+										samples[n], i, character);
+		switch (character) {
+			case 'b':
+			case 'B':
+				// create bit sample pins
+				rtapi_snprintf(buf, sizeof(buf), "%s.bit-in%d", hd->name, i);
+				retval = hal_pin_new(buf, HAL_BIT, HAL_IN, 
+					&hd->pins_in[i], comp_id );
+				if (retval != 0) {
+					rtapi_print_msg(RTAPI_MSG_ERR,
+						"%s: ERROR: creation of bit-in%d for instance %d\n",
+						cname, i, n);
+					return retval;
+				}
+				rtapi_snprintf(buf, sizeof(buf), "%s.bit-out%d", hd->name, i);
+				retval = hal_pin_new(buf, HAL_BIT, HAL_OUT, 
+					&hd->pins_out[i], comp_id );
+				if (retval != 0) {
+					rtapi_print_msg(RTAPI_MSG_ERR,
+						"%s: ERROR: creation of bit-out%d for instance %d\n",
+						cname, i, n);
+					return retval;
+				}
+				break;
+			case 'f':
+			case 'F':
+				// create float sample pins
+				rtapi_snprintf(buf, sizeof(buf), "%s.flt-in%d", hd->name, i);
+				retval = hal_pin_new(buf, HAL_FLOAT, HAL_IN, 
+					&hd->pins_in[i], comp_id );
+				if (retval != 0) {
+					rtapi_print_msg(RTAPI_MSG_ERR,
+						"%s: ERROR: creation of flt-in%d for instance %d\n",
+						cname, i, n);
+					return retval;
+				}
+				rtapi_snprintf(buf, sizeof(buf), "%s.flt-out%d", hd->name, i);
+				retval = hal_pin_new(buf, HAL_FLOAT, HAL_OUT, 
+					&hd->pins_out[i], comp_id );
+				if (retval != 0) {
+					rtapi_print_msg(RTAPI_MSG_ERR,
+						"%s: ERROR: creation of flt-out%d for instance %d\n",
+						cname, i, n);
+					return retval;
+				}
+				break;
+			case 's':
+			case 'S':
+				// create s32 sample pins
+				rtapi_snprintf(buf, sizeof(buf), "%s.s32-in%d", hd->name, i);
+				retval = hal_pin_new(buf, HAL_S32, HAL_IN, 
+					&hd->pins_in[i], comp_id );
+				if (retval != 0) {
+					rtapi_print_msg(RTAPI_MSG_ERR,
+						"%s: ERROR: creation of s32-in%d for instance %d\n",
+						cname, i, n);
+					return retval;
+				}
+				rtapi_snprintf(buf, sizeof(buf), "%s.s32-out%d", hd->name, i);
+				retval = hal_pin_new(buf, HAL_S32, HAL_OUT, 
+					&hd->pins_out[i], comp_id );
+				if (retval != 0) {
+					rtapi_print_msg(RTAPI_MSG_ERR,
+						"%s: ERROR: creation of s32-out%d for instance %d\n",
+						cname, i, n);
+					return retval;
+				}
+				break;
+			case 'u':
+			case 'U':
+				// create u32 sample pins
+				rtapi_snprintf(buf, sizeof(buf), "%s.u32-in%d", hd->name, i);
+				retval = hal_pin_new(buf, HAL_U32, HAL_IN, 
+					&hd->pins_in[i], comp_id );
+				if (retval != 0) {
+					rtapi_print_msg(RTAPI_MSG_ERR,
+						"%s: ERROR: creation of u32-in%d for instance %d\n",
+						cname, i, n);
+					return retval;
+				}
+				rtapi_snprintf(buf, sizeof(buf), "%s.u32-out%d", hd->name, i);
+				retval = hal_pin_new(buf, HAL_U32, HAL_OUT, 
+					&hd->pins_out[i], comp_id );
+				if (retval != 0) {
+					rtapi_print_msg(RTAPI_MSG_ERR,
+						"%s: ERROR: creation of u32-out%d for instance %d\n",
+						cname, i, n);
+					return retval;
+				}
+				break;
+			}
 	}
+
+	// create other pins
 	if (((retval = hal_pin_bit_newf(HAL_IN, &(hd->enable), comp_id,
 					"%s.enable",  hd->name))) ||
 	((retval = hal_pin_bit_newf(HAL_IN, &(hd->abort), comp_id,

--- a/src/hal/components/delayline.c
+++ b/src/hal/components/delayline.c
@@ -143,7 +143,7 @@ static void write_sample_to_ring(void *arg, long period)
 	// if time has increased, then take action by setting the input_ts to the
 	// result of output_ts + delay. Otherwise do nothing. The situation of
 	// decreasing the time will be acted upon in read_sample_to_ring()
-	if (hd->pin_delay > (hal_u32_t * )((hd->input_ts) - (hd->output_ts))) {
+	if ( *(hd->pin_delay) > (hal_u32_t)( hd->input_ts - hd->output_ts)) {
 		if ( *(hd->pin_delay) > hd->max_delay) {
 			hd->delay = hd->max_delay;
 		}
@@ -216,8 +216,8 @@ static void read_sample_from_ring(void *arg, long period)
 	// loss of some records. Make sure you're in a safe situation! 
 	// The situation of increasing the time will be acted upon in
 	// write_sample_to_ring()
-	if (hd->pin_delay < (hal_u32_t * )((hd->input_ts - hd->output_ts))) {
-		if (hd->pin_delay < 0) {
+	if ( *(hd->pin_delay) < (hal_u32_t)(hd->input_ts - hd->output_ts)) {
+		if ( *(hd->pin_delay) < 0) {
 			hd->delay = 0;
 		}
 		else {

--- a/src/hal/components/delayline.c
+++ b/src/hal/components/delayline.c
@@ -19,46 +19,48 @@ MODULE_LICENSE("GPLv2");
 #define MAX_INST 8
 #define DEFAULT_SAMPLES 3
 #define MAX_SAMPLES 9       // a pose has 9 doubles
-#define DEFAULT_DELAY 1000  // 1 sec at default servo rate
+#define MAX_DELAY 1000      // 1 sec at default servo rate
 #define RB_HEADROOM 1.2     // ringbuffer size overallocation
 
 static char *names[MAX_INST] = { "delayline.0", };
 RTAPI_MP_ARRAY_STRING(names, MAX_INST,"delayline names");
 
-static int delay[MAX_INST] = {
-    DEFAULT_DELAY,DEFAULT_DELAY,DEFAULT_DELAY,DEFAULT_DELAY,
-    DEFAULT_DELAY,DEFAULT_DELAY,DEFAULT_DELAY,DEFAULT_DELAY
+static int max_delay[MAX_INST] = {
+	MAX_DELAY,MAX_DELAY,MAX_DELAY,MAX_DELAY,
+	MAX_DELAY,MAX_DELAY,MAX_DELAY,MAX_DELAY
 };
-RTAPI_MP_ARRAY_INT(delay, MAX_INST,"number of samples to delay for each line");
+RTAPI_MP_ARRAY_INT(max_delay, MAX_INST,"max number of samples to delay for each line");
 
 static int samples[MAX_INST] = {
-    DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,
-    DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,
+	DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,
+	DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,DEFAULT_SAMPLES,
 };
 RTAPI_MP_ARRAY_INT(samples, MAX_INST,"number of pins to sample in each line");
 
 typedef struct {
-    // pins
-    hal_bit_t *enable;           /* pin: enable this                   */
-    hal_bit_t *abort;            /* pin: abort pin                     */
-    hal_float_t *flt_in[MAX_SAMPLES];   /* pin: array incoming value          */
-    hal_float_t *flt_out[MAX_SAMPLES];  /* pin: array delayed value           */
-    hal_u32_t  *write_fail;      // error counter, write side
-    hal_u32_t  *read_fail;       // error counter, read side
-    hal_u32_t  *too_old;         // error counter, samples skipped because too old
+	// pins
+	hal_bit_t *enable;                  /* pin: enable this                   */
+	hal_bit_t *abort;                   /* pin: abort pin                     */
+	hal_float_t *flt_in[MAX_SAMPLES];   /* pin: array incoming value          */
+	hal_float_t *flt_out[MAX_SAMPLES];  /* pin: array delayed value           */
+	hal_u32_t	*pin_delay;             /* pin: delay time, standard zero     */
+	hal_u32_t  *write_fail;             // error counter, write side
+	hal_u32_t  *read_fail;              // error counter, read side
+	hal_u32_t  *too_old;                // error counter, samples skipped because too old
 
-    // other params & instance data
-    uint64_t  output_ts, input_ts;
-    unsigned  delay;             // delay in periods
-    int nsamples;                // number of pins in this line
-    size_t sample_size;          // sizeof(sample_t)  + num_channel * sizeof (hal_float_t)
-    hal_bit_t last_abort;        // tracking value for edge detection
-    char name[HAL_NAME_LEN + 1]; // of this instance
+	// other params & instance data
+	uint64_t  output_ts, input_ts;
+	unsigned  max_delay;         // max delay of this line in periods
+	unsigned  delay;             // delay in periods
+	int nsamples;                // number of pins in this line
+	size_t sample_size;          // sizeof(sample_t)  + num_channel * sizeof (hal_float_t)
+	hal_bit_t last_abort;        // tracking value for edge detection
+	char name[HAL_NAME_LEN + 1]; // of this instance
 } hal_delayline_t;
 
 typedef struct {
-    uint64_t timestamp;          /* timestamp of measurement           */
-    hal_float_t value[0];        /* measured value                     */
+	uint64_t timestamp;          /* timestamp of measurement           */
+	hal_float_t value[0];        /* measured value                     */
 } sample_t;
 
 
@@ -77,51 +79,51 @@ static int export_delayline(int n);
 // initialisation routine
 int rtapi_app_main(void)
 {
-    int n, retval;
+	int n, retval;
 
-    // determine number of instances
-    for (count = 0; (names[count] != NULL) && (count < MAX_INST); count++);
+	// determine number of instances
+	for (count = 0; (names[count] != NULL) && (count < MAX_INST); count++);
 
-    comp_id = hal_init(cname);
-    if (comp_id < 0) {
+	comp_id = hal_init(cname);
+	if (comp_id < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 			"%s: ERROR: hal_init() failed, rc=%d\n", cname, comp_id);
 	return -1;
-    }
-
-    // export variables and function for each DELAYLINE loop */
-    for (n = 0; n < count; n++) {
-	if ((retval = export_delayline(n))) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-			    "%s: ERROR: loop %d var export failed\n", cname, n);
-	    hal_exit(comp_id);
-	    return -1;
 	}
-    }
 
-    rtapi_print_msg(RTAPI_MSG_INFO,
-		    "%s: installed %d lines\n", cname, count);
-    hal_ready(comp_id);
-    return 0;
+	// export variables and function for each DELAYLINE loop */
+	for (n = 0; n < count; n++) {
+	if ((retval = export_delayline(n))) {
+		rtapi_print_msg(RTAPI_MSG_ERR,
+				"%s: ERROR: loop %d var export failed\n", cname, n);
+		hal_exit(comp_id);
+		return -1;
+	}
+	}
+
+	rtapi_print_msg(RTAPI_MSG_INFO,
+			"%s: installed %d lines\n", cname, count);
+	hal_ready(comp_id);
+	return 0;
 }
 
 // exiting routine
 void rtapi_app_exit(void)
 {
-    hal_exit(comp_id);
+	hal_exit(comp_id);
 
-    //detach from all rings, and delete them
-    int n;
-    for (n = 0; n < count; n++) {
+	//detach from all rings, and delete them
+	int n;
+	for (n = 0; n < count; n++) {
 	if (instance[n]) {
-	    hal_delayline_t *hd = instance[n]->scratchpad;
+		hal_delayline_t *hd = instance[n]->scratchpad;
 
-	    char ringname[HAL_NAME_LEN + 1];
-	    snprintf(ringname, HAL_NAME_LEN, "%s.samples", hd->name);
-	    hal_ring_detach(ringname, instance[n]);
-	    hal_ring_delete(ringname);
+		char ringname[HAL_NAME_LEN + 1];
+		snprintf(ringname, HAL_NAME_LEN, "%s.samples", hd->name);
+		hal_ring_detach(ringname, instance[n]);
+		hal_ring_delete(ringname);
 	}
-    }
+	}
 }
 
 
@@ -130,161 +132,200 @@ void rtapi_app_exit(void)
 */
 static void write_sample_to_ring(void *arg, long period)
 {
-    int j;
-    ringbuffer_t *rb = (ringbuffer_t *) arg;
-    hal_delayline_t *hd = rb->scratchpad;    // per-instance HAL data
-    sample_t *s;
+	int j;
+	ringbuffer_t *rb = (ringbuffer_t *) arg;
+	hal_delayline_t *hd = rb->scratchpad;    // per-instance HAL data
+	sample_t *s;
 
-    if (!*(hd->enable)) {	// skip if not sampling, just put the input 
-				//values into the output values
+	// if pin_delay > max_delay then use max_delay, otherwise
+	// use delay pin value
+
+	// if time has increased, then take action by setting the input_ts to the
+	// result of output_ts + delay. Otherwise do nothing. The situation of
+	// decreasing the time will be acted upon in read_sample_to_ring()
+	if (hd->pin_delay > (hal_u32_t * )((hd->input_ts) - (hd->output_ts))) {
+		if ( *(hd->pin_delay) > hd->max_delay) {
+			hd->delay = hd->max_delay;
+		}
+		else {
+			hd->delay = *(hd->pin_delay);
+		}
+			// set the new timestamp 
+			hd->input_ts = hd->output_ts + (uint64_t)(hd->delay);
+	}
+
+	if (!*(hd->enable)) {	// skip if not sampling, just put the input 
+							// values into the output values
 	for (j = 0; j < hd->nsamples; j++) {
 		*(hd->flt_out[j]) = *(hd->flt_in[j]);
-    	}
+		}
 	goto DONE;
-    }
+	}
 
-    // use non-copying write:
-    // allocate space in the ringbuffer and retrieve a pointer to it
-    if (record_write_begin(rb, (void ** )&s, hd->sample_size)) {
+	// use non-copying write:
+	// allocate space in the ringbuffer and retrieve a pointer to it
+	if (record_write_begin(rb, (void ** )&s, hd->sample_size)) {
 	*(hd->write_fail) += 1;
 	goto DONE;
-    }
+	}
 
-    // deposit record directly in rb memory
-    s->timestamp = hd->input_ts;
-    for (j = 0; j < hd->nsamples; j++) {
+	// deposit record directly in rb memory
+	s->timestamp = hd->input_ts;
+	for (j = 0; j < hd->nsamples; j++) {
 	s->value[j] = *(hd->flt_in[j]);
-    }
+	}
 
-    // commit the write given the actual write size (which is the same as given in
-    // record_write_begin in our case).
-    // this makes the record actually visible on the read side (advances pointer)
-    if (record_write_end(rb, s, hd->sample_size))
+	// commit the write given the actual write size (which is the same as given in
+	// record_write_begin in our case).
+	// this makes the record actually visible on the read side (advances pointer)
+	if (record_write_end(rb, s, hd->sample_size))
 	*(hd->write_fail) += 1;
 
  DONE:
-    hd->input_ts++;
+	hd->input_ts++;
 }
 
 // sample the pins to the current rb record
 static inline void apply(const sample_t *s, const hal_delayline_t *hd)
 {
-    int i;
-    for (i = 0; i < hd->nsamples; i++)
+	int i;
+	for (i = 0; i < hd->nsamples; i++)
 	*(hd->flt_out[i]) = s->value[i];
 }
 
 static void read_sample_from_ring(void *arg, long period)
 {
-    ringbuffer_t *rb = (ringbuffer_t *) arg;
-    hal_delayline_t *hd = rb->scratchpad;
-    const sample_t *s;
-    size_t size;
+	ringbuffer_t *rb = (ringbuffer_t *) arg;
+	hal_delayline_t *hd = rb->scratchpad;
+	const sample_t *s;
+	size_t size;
 
-    // detect rising edge on abort pin, and flush rb if so
-    if (*(hd->abort) && (*(hd->abort) ^ hd->last_abort)) {
+	// detect rising edge on abort pin, and flush rb if so
+	if (*(hd->abort) && (*(hd->abort) ^ hd->last_abort)) {
 	int dropped = record_flush(rb);
 	rtapi_print_msg(RTAPI_MSG_INFO,
 			"%s: %s aborted - dropped %d samples\n",
 			cname, hd->name, dropped);
-    }
+	}
 
-    // peek at the head of the queue
-    while (record_read(rb, (const void **)&s, &size) == 0) {
+	// if pin_delay < 0 then use 0, otherwise
+	// use delay pin value
 
-	// do nothing if timestamp is in the future
-	if (s->timestamp > hd->output_ts)
-	    goto NOTYET;
+	// if time has decreased, then take action by setting the output_ts to the
+	// result of input_ts - delay. Otherwise do nothing. This will result in
+	// loss of some records. Make sure you're in a safe situation! 
+	// The situation of increasing the time will be acted upon in
+	// write_sample_to_ring()
+	if (hd->pin_delay < (hal_u32_t * )((hd->input_ts - hd->output_ts))) {
+		if (hd->pin_delay < 0) {
+			hd->delay = 0;
+		}
+		else {
+			hd->delay = *(hd->pin_delay);
+		}
+			// set the new timestamp 
+			hd->input_ts =  hd->input_ts - (uint64_t)(hd->delay);
+	}
 
-	if (s->timestamp == hd->output_ts)
-	    // the time is right
-	    apply(s, hd);
-	else
-	    // skip old samples and bump an error counter
-	    *(hd->too_old) += 1;
+	// peek at the head of the queue
+	while (record_read(rb, (const void **)&s, &size) == 0) {
 
-	// sanity: if (size != hd->sample_size).. terribly wrong.
-	record_shift(rb); // consume record
-    }
+		// do nothing if timestamp is in the future
+		if (s->timestamp > hd->output_ts)
+			goto NOTYET;
+
+		if (s->timestamp == hd->output_ts)
+			// the time is right
+			apply(s, hd);
+		else
+			// skip old samples and bump an error counter
+			*(hd->too_old) += 1;
+
+		// sanity: if (size != hd->sample_size).. terribly wrong.
+		record_shift(rb); // consume record
+	}
  NOTYET:
-    hd->output_ts++; // always bump the timestamp
-    hd->last_abort = *(hd->abort);
+	hd->output_ts++; // always bump the timestamp
+	hd->last_abort = *(hd->abort);
 }
 
 static int export_delayline(int n)
 {
-    int retval, i;
-    char buf[HAL_NAME_LEN + 1];
+	int retval, i;
+	char buf[HAL_NAME_LEN + 1];
 
-    // determine the required size of the ringbuffer
-    size_t nsamples =  samples[n];
-    size_t sample_size = sizeof(sample_t) + (nsamples * sizeof(hal_float_t));
+	// determine the required size of the ringbuffer
+	size_t nsamples =  samples[n];
+	size_t sample_size = sizeof(sample_t) + (nsamples * sizeof(hal_float_t));
 
-    // add some headroom to be sure we dont overrun
-    size_t rbsize = record_space(sample_size) * delay[n] * RB_HEADROOM;
+	// add some headroom to be sure we dont overrun
+	size_t rbsize = record_space(sample_size) * max_delay[n] * RB_HEADROOM;
 
-    // create the delay queue
-    snprintf(buf, HAL_NAME_LEN, "%s.samples", names[n]);
-    if ((retval = hal_ring_new(buf, rbsize,
-			       sizeof(hal_delayline_t), ALLOC_HALMEM))) {
+	// create the delay queue
+	snprintf(buf, HAL_NAME_LEN, "%s.samples", names[n]);
+	if ((retval = hal_ring_new(buf, rbsize,
+				   sizeof(hal_delayline_t), ALLOC_HALMEM))) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 			"%s: failed to create new ring %s: %d\n",
 			cname, buf, retval);
 	return -1;
-    }
+	}
 
-    // use the per-using component ring access structure as the instance data,
-    // which will also give us a handle on the scratchpad which we use for
-    // HAL pins and other shared data
-    if ((instance[n] = hal_malloc(sizeof(ringbuffer_t))) == NULL)
+	// use the per-using component ring access structure as the instance data,
+	// which will also give us a handle on the scratchpad which we use for
+	// HAL pins and other shared data
+	if ((instance[n] = hal_malloc(sizeof(ringbuffer_t))) == NULL)
 	return -1;
-    if ((retval = hal_ring_attach(buf, instance[n], NULL))) {
+	if ((retval = hal_ring_attach(buf, instance[n], NULL))) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 			"%s: attach to ring %s failed: %d\n",
 			cname, buf, retval);
 	return -1;
-    }
+	}
 
-    // fill in instance data
-    hal_delayline_t *hd = instance[n]->scratchpad;
-    strncpy(hd->name, names[n], sizeof(hd->name));
-    hd->nsamples = nsamples;
-    hd->sample_size = sample_size;
-    hd->delay = delay[n];
+	// fill in instance data
+	hal_delayline_t *hd = instance[n]->scratchpad;
+	strncpy(hd->name, names[n], sizeof(hd->name));
+	hd->nsamples = nsamples;
+	hd->sample_size = sample_size;
+	hd->max_delay = max_delay[n];
+	// set delay standard to value of zero
+	hd->delay = 0;
+	hd->output_ts = 0;
+	hd->input_ts = hd->delay;
 
-    hd->output_ts = 0;
-    hd->input_ts =  hd->delay;
-
-    // init pins
-    for (i = 0; i < hd->nsamples; i++) {
+	// init pins
+	for (i = 0; i < hd->nsamples; i++) {
 	if (((retval = hal_pin_float_newf(HAL_IN, &(hd->flt_in[i]), comp_id,
 					  "%s.in%d", hd->name, i))) ||
-	    ((retval = hal_pin_float_newf(HAL_OUT, &(hd->flt_out[i]), comp_id,
+		((retval = hal_pin_float_newf(HAL_OUT, &(hd->flt_out[i]), comp_id,
 					  "%s.out%d", hd->name, i))))
-	    return retval;
-    }
-    if (((retval = hal_pin_bit_newf(HAL_IN, &(hd->enable), comp_id,
-				    "%s.enable",  hd->name))) ||
+		return retval;
+	}
+	if (((retval = hal_pin_bit_newf(HAL_IN, &(hd->enable), comp_id,
+					"%s.enable",  hd->name))) ||
 	((retval = hal_pin_bit_newf(HAL_IN, &(hd->abort), comp_id,
-				    "%s.abort",  hd->name))) ||
+					"%s.abort",  hd->name))) ||
+	((retval = hal_pin_u32_newf(HAL_IN, &(hd->pin_delay), comp_id,
+					  "%s.delay", hd->name))) ||
 	((retval = hal_pin_u32_newf(HAL_OUT, &(hd->write_fail), comp_id,
-				    "%s.write-fail", hd->name))) ||
+					"%s.write-fail", hd->name))) ||
 	((retval = hal_pin_u32_newf(HAL_OUT, &(hd->read_fail), comp_id,
-				    "%s.too-old", hd->name))) ||
+					"%s.too-old", hd->name))) ||
 	((retval = hal_pin_u32_newf(HAL_OUT, &(hd->too_old), comp_id,
-				    "%s.read-fail", hd->name))))
+					"%s.read-fail", hd->name))))
 	return retval;
 
-    // export thread functions
-    rtapi_snprintf(buf, sizeof(buf), "%s.sample", hd->name);
-    if ((retval = hal_export_funct(buf, write_sample_to_ring,
+	// export thread functions
+	rtapi_snprintf(buf, sizeof(buf), "%s.sample", hd->name);
+	if ((retval = hal_export_funct(buf, write_sample_to_ring,
 				   instance[n], 1, 0, comp_id))) {
 	return retval;
-    }
-    rtapi_snprintf(buf, sizeof(buf), "%s.output", hd->name);
-    if ((retval = hal_export_funct(buf, read_sample_from_ring,
+	}
+	rtapi_snprintf(buf, sizeof(buf), "%s.output", hd->name);
+	if ((retval = hal_export_funct(buf, read_sample_from_ring,
 				   instance[n], 1, 0, comp_id))) {
 	return retval;
-    }
-    return 0;
+	}
+	return 0;
 }

--- a/src/hal/components/delayline.c
+++ b/src/hal/components/delayline.c
@@ -19,6 +19,7 @@
 #include "rtapi_string.h"
 #include "hal.h"
 #include "hal_ring.h"
+#include "hal_priv.h"
 
 MODULE_AUTHOR("Bas de Bruijn");
 MODULE_DESCRIPTION("Delay line component for Machinekit HAL");
@@ -43,38 +44,32 @@ RTAPI_MP_ARRAY_INT(max_delay, MAX_INST,"delayline max number of samples");
 char *samples[MAX_INST];
 RTAPI_MP_ARRAY_STRING(samples, MAX_INST, "delayline pintype sample specifiers");
 
-typedef union {
-	// union for using channels of different types
-	hal_float_t		*pin_flt;
-	hal_bit_t		*pin_bit;
-	hal_u32_t		*pin_u32;
-	hal_s32_t		*pin_s32;
-} u_value;
-
 typedef struct {
 	// pins
 	hal_bit_t		*enable;					// pin: enable this
 	hal_bit_t		*abort;						// pin: abort pin
-	u_value			*pins_in[MAX_SAMPLES];		// pin: array incoming value
-	u_value			*pins_out[MAX_SAMPLES];		// pin: array delayed value
+	hal_data_u		*pins_in[MAX_SAMPLES];		// pin: array incoming value
+	hal_data_u		*pins_out[MAX_SAMPLES];		// pin: array delayed value
 	hal_u32_t		*pin_delay;					// pin: delay time, standard zero
 	hal_u32_t 		*write_fail;				// error counter, write side
 	hal_u32_t 		*read_fail;					// error counter, read side
-	hal_u32_t 		*too_old;					// error counter, samples skipped because too old
+	hal_u32_t 		*too_old;					// error counter, samples skipped 
+												//				because too old
 
 	// other params & instance data
-	uint64_t  output_ts, input_ts;
+	hal_type_t pintype[MAX_SAMPLES];// the array which holds the pintype
+	uint64_t  output_ts, input_ts;	// output timestamp and input timestamp
 	unsigned  max_delay;         	// max delay of this line in periods
 	unsigned  delay;             	// delay in periods
 	int nsamples;                	// number of pins in this line
-	size_t sample_size;          	// size determined by union u_value
+	size_t sample_size;          	// size determined by hal_data_u
 	hal_bit_t last_abort;        	// tracking value for edge detection
 	char name[HAL_NAME_LEN + 1];	// of this instance
 } hal_delayline_t;
 
 typedef struct {
 	uint64_t timestamp;			// timestamp of measurement
-	u_value value[0];			// measured value
+	hal_data_u value[0];		// measured value
 } sample_t;
 
 
@@ -111,7 +106,7 @@ int rtapi_app_main(void)
 	// samples="bb,sf,fus" (bit, float, signed, unsigned)
 	if (!samples[0]) {
         rtapi_print_msg(RTAPI_MSG_ERR,
-        	"%s : ERROR: a string declaring valid pintypes is needed\n",
+        	"%s : ERROR: a string declaring valid pintype is needed\n",
         	cname);
         hal_exit(comp_id);
         return -1;
@@ -204,10 +199,25 @@ static void write_sample_to_ring(void *arg, long period)
 
 	if (!*(hd->enable)) {	// skip if not sampling, just put the input 
 							// values into the output values
-	for (j = 0; j < hd->nsamples; j++) {
-		*(hd->pins_out[j]) = *(hd->pins_in[j]);
+		for (j = 0; j < hd->nsamples; j++) {
+			// *(hd->pins_out[j]) = *(hd->pins_in[j]);
+			switch (hd->pintype[j])
+			{
+				case HAL_BIT:
+					hd->pins_out[j]->b = hd->pins_in[j]->b;
+					break;
+				case HAL_FLOAT:
+					hd->pins_out[j]->f = hd->pins_in[j]->f;
+					break;
+				case HAL_S32:
+					hd->pins_out[j]->s = hd->pins_in[j]->s;
+					break;
+				case HAL_U32:
+					hd->pins_out[j]->u = hd->pins_in[j]->u;
+					break;
+			}
 		}
-	goto DONE;
+		goto DONE;
 	}
 
 	// use non-copying write:
@@ -220,7 +230,22 @@ static void write_sample_to_ring(void *arg, long period)
 	// deposit record directly in rb memory
 	s->timestamp = hd->input_ts;
 	for (j = 0; j < hd->nsamples; j++) {
-	s->value[j] = *(hd->pins_in[j]);
+		// s->value[j] = *(hd->pins_in[j]);
+		switch (hd->pintype[j])
+		{
+			case HAL_BIT:
+				s->value[j].b = hd->pins_in[j]->b;
+				break;
+			case HAL_FLOAT:
+				s->value[j].f = hd->pins_in[j]->f;
+				break;
+			case HAL_S32:
+				s->value[j].s = hd->pins_in[j]->s;
+				break;
+			case HAL_U32:
+				s->value[j].u = hd->pins_in[j]->u;
+				break;
+		}
 	}
 
 	// commit the write given the actual write size (which is the same
@@ -233,12 +258,31 @@ static void write_sample_to_ring(void *arg, long period)
 	hd->input_ts++;
 }
 
-// sample the pins to the current rb record
+// sample the output pins to the current rb record
 static inline void apply(const sample_t *s, const hal_delayline_t *hd)
 {
 	int i;
 	for (i = 0; i < hd->nsamples; i++)
-	*(hd->pins_out[i]) = s->value[i];
+	{
+		// *(hd->pins_out[i]) = s->value[i];
+		// because of the union the values and pins must be properly
+		// dereferenced against their type
+		switch (hd->pintype[i])
+		{
+			case HAL_BIT:
+				hd->pins_out[i]->b = s->value[i].b;
+				break;
+			case HAL_FLOAT:
+				hd->pins_out[i]->f = s->value[i].f;
+				break;
+			case HAL_S32:
+				hd->pins_out[i]->s = s->value[i].s;
+				break;
+			case HAL_U32:
+				hd->pins_out[i]->u = s->value[i].u;
+				break;
+		}
+	}
 }
 
 static void read_sample_from_ring(void *arg, long period)
@@ -331,7 +375,7 @@ static int export_delayline(int n)
 
 	// determine the required size of the ringbuffer
 	nr_of_samples = return_instance_samples(n);
-	size_t sample_size = sizeof(sample_t) + (nr_of_samples * sizeof(u_value));
+	size_t sample_size = sizeof(sample_t) + (nr_of_samples * sizeof(hal_data_u));
 
 	// add some headroom to be sure we dont overrun
 	size_t rbsize = record_space(sample_size) * max_delay[n] * RB_HEADROOM;
@@ -369,7 +413,8 @@ static int export_delayline(int n)
 	hd->output_ts = 0;
 	hd->input_ts = hd->delay;
 
-	// init pins
+	// init pins, and at the same time fill the puntype array with
+	// the type of pin[i] so we can later dereference proper
 	char character;
 	for (i = 0; i < hd->nsamples; i++) {
 		character = samples[n][i];
@@ -379,6 +424,8 @@ static int export_delayline(int n)
 		switch (character) {
 			case 'b':
 			case 'B':
+				// fill the pintype[i] array
+				hd->pintype[i] = HAL_BIT;
 				// create bit sample pins
 				rtapi_snprintf(buf, sizeof(buf), "%s.bit-in%d", hd->name, i);
 				retval = hal_pin_new(buf, HAL_BIT, HAL_IN, 
@@ -401,6 +448,8 @@ static int export_delayline(int n)
 				break;
 			case 'f':
 			case 'F':
+				// fill the pintype[i] array
+				hd->pintype[i] = HAL_FLOAT;
 				// create float sample pins
 				rtapi_snprintf(buf, sizeof(buf), "%s.flt-in%d", hd->name, i);
 				retval = hal_pin_new(buf, HAL_FLOAT, HAL_IN, 
@@ -423,6 +472,8 @@ static int export_delayline(int n)
 				break;
 			case 's':
 			case 'S':
+				// fill the pintype[i] array
+				hd->pintype[i] = HAL_S32;
 				// create s32 sample pins
 				rtapi_snprintf(buf, sizeof(buf), "%s.s32-in%d", hd->name, i);
 				retval = hal_pin_new(buf, HAL_S32, HAL_IN, 
@@ -445,6 +496,8 @@ static int export_delayline(int n)
 				break;
 			case 'u':
 			case 'U':
+				// fill the pintype[i] array
+				hd->pintype[i] = HAL_U32;
 				// create u32 sample pins
 				rtapi_snprintf(buf, sizeof(buf), "%s.u32-in%d", hd->name, i);
 				retval = hal_pin_new(buf, HAL_U32, HAL_IN, 
@@ -466,6 +519,22 @@ static int export_delayline(int n)
 				}
 				break;
 			}
+		// now set the output pins to zero for good measure
+		switch (hd->pintype[i])
+		{
+		case HAL_BIT:
+			hd->pins_out[i]->b = 0;
+			break;
+		case HAL_FLOAT:
+			hd->pins_out[i]->f = 0.0;
+			break;
+		case HAL_S32:
+			hd->pins_out[i]->s = 0;
+			break;
+		case HAL_U32:
+			hd->pins_out[i]->u = 0;
+			break;
+		}
 	}
 
 	// create other pins

--- a/src/hal/components/delayline.hal
+++ b/src/hal/components/delayline.hal
@@ -1,0 +1,26 @@
+# HAL delayline demo
+
+loadrt siggen
+setp siggen.0.frequency 1.0 # Hz
+
+loadrt delayline names=foo,bar delay=500,2500 samples=2,2
+loadusr halscope
+
+net sawtooth siggen.0.sawtooth foo.in0
+net sine     siggen.0.sine     foo.in1
+
+net square   siggen.0.square   bar.in0
+net triangle siggen.0.triangle bar.in1
+
+newthread servo 1000000 fp
+
+addf siggen.0.update servo
+addf foo.sample      servo
+addf bar.sample      servo
+addf foo.output      servo
+addf bar.output      servo
+
+setp foo.enable true
+setp bar.enable true
+
+start

--- a/src/hal/components/delayline.hal
+++ b/src/hal/components/delayline.hal
@@ -3,7 +3,7 @@
 loadrt siggen
 setp siggen.0.frequency 1.0 # Hz
 
-loadrt delayline names=foo,bar delay=500,2500 samples=2,2
+loadrt delayline names=foo,bar max_delay=500,2500 samples=2,2
 loadusr halscope
 
 net sawtooth siggen.0.sawtooth foo.in0

--- a/src/hal/components/delayline.hal
+++ b/src/hal/components/delayline.hal
@@ -3,14 +3,14 @@
 loadrt siggen
 setp siggen.0.frequency 1.0 # Hz
 
-loadrt delayline names=foo,bar max_delay=500,2500 samples=2,2
+loadrt delayline names=foo,bar max_delay=500,2500 samples=ffb,ffbsu
 loadusr halscope
 
-net sawtooth siggen.0.sawtooth foo.in0
-net sine     siggen.0.sine     foo.in1
+net sawtooth siggen.0.sawtooth foo.flt-in0
+net sine     siggen.0.sine     foo.flt-in1
 
-net square   siggen.0.square   bar.in0
-net triangle siggen.0.triangle bar.in1
+net square   siggen.0.square   bar.flt-in0
+net triangle siggen.0.triangle bar.flt-in1
 
 newthread servo 1000000 fp
 
@@ -22,5 +22,10 @@ addf bar.output      servo
 
 setp foo.enable true
 setp bar.enable true
+
+setp foo.bit-in2 true
+setp bar.bit-in2 true
+setp bar.s32-in3 -5
+setp bar.u32-in4 21
 
 start

--- a/src/hal/lib/hal_ring.c
+++ b/src/hal/lib/hal_ring.c
@@ -271,7 +271,17 @@ int hal_ring_attach(const char *name, ringbuffer_t *rbptr,unsigned *flags)
 	    hal_print_msg(RTAPI_MSG_ERR,
 			    "HAL: hal_ring_attach: no such ring '%s'\n",
 			    name);
-	    return -EINVAL;
+	    return -ENOENT;
+	}
+
+	// calling hal_ring_attach(name, NULL, NULL) is a way to determine
+	// if a given ring exists.
+	// hal_ring_attach(name, NULL, &flags) is a way to inspect the flags
+	// of an existing ring without actually attaching it.
+	if (rbptr == NULL) {
+	    if (flags)
+		*flags = rbdesc->flags;
+	    return 0;
 	}
 
 	if (rbdesc->flags & ALLOC_HALMEM) {

--- a/src/hal/lib/hal_ring.h
+++ b/src/hal/lib/hal_ring.h
@@ -60,10 +60,21 @@ int hal_ring_new(const char *name, int size, int spsize, int mode);
 // will fail if the refcount is > 0 (meaning the ring is still attached somewhere).
 int hal_ring_delete(const char *name);
 
-// make an existing ringbuffer accessible to a component
-// rb must point to storage of type ringbuffer_t.
-// Increases the reference count.
-// store halring flags in *flags if non-zero.
+// make an existing ringbuffer accessible to a component, or test for
+// existence and flags of a ringbuffer
+//
+// to attach:
+//     rb must point to storage of type ringbuffer_t.
+//     Increases the reference count on successful attach
+//     store halring flags in *flags if non-zero.
+//
+// to test for existence:
+//     hal_ring_attach(name, NULL, NULL) returns 0 if the ring exists, < 0 otherwise
+//
+// to test for existence and retrieve the ring's flags:
+//     hal_ring_attach(name, NULL, &f) - if the ring exists, returns 0
+//     and the ring's flags are returned in f
+//
 int hal_ring_attach(const char *name, ringbuffer_t *rb, unsigned *flags);
 
 // detach a ringbuffer. Decreases the reference count.

--- a/src/rtapi/ring.h
+++ b/src/rtapi/ring.h
@@ -459,6 +459,21 @@ static inline size_t record_write_space(const ringheader_t *h)
     return MAXIMUM(0, avail - (2 * RB_ALIGN));
 }
 
+/* helper for sizing a record mode ringbuffer
+ * given the size of an record, it will return the space used
+ * in the ring buffer, including any overhead and
+ * alignment requirements
+ *
+ * example: to hold 1000 records of struct foo a ringbuffer will need
+ * a size of at least record_space(sizeof(struct foo)) * 1000
+ *
+ * (to be on the safe side, add some headroom to that)
+ */
+static inline size_t record_space(size_t element)
+{
+    return size_aligned(element + sizeof(ring_size_t));
+}
+
 
 /* internal function */
 static inline ring_size_t _ring_shift_offset(const ringbuffer_t *ring, size_t offset)


### PR DESCRIPTION
This component will enable HAL pins to be delayed by a ringbuffer. Arbitrary number of lines with arbitrary number of pins of arbitrary types can be created.