### PR TITLE
configs: Add missing board argument to CRAMPS.hal file

### DIFF
--- a/configs/ARM/BeagleBone/CRAMPS/CRAMPS.hal
+++ b/configs/ARM/BeagleBone/CRAMPS/CRAMPS.hal
@@ -32,7 +32,7 @@ loadrt limit1 count=2
 
 # Python user-mode HAL module to read ADC value and generate a thermostat output for PWM
 # c = analog input channel and thermistor table
-loadusr -Wn Therm hal_temp_bbb -n Therm -c 04:epcos_B57560G1104,05:epcos_B57560G1104
+loadusr -Wn Therm hal_temp_bbb -n Therm -c 04:epcos_B57560G1104,05:epcos_B57560G1104 -b CRAMPS
 
 # ################################################
 # THREADS


### PR DESCRIPTION
Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>