### PR TITLE
HAL + RTAPI fixes

### DIFF
--- a/src/hal/lib/hal.h
+++ b/src/hal/lib/hal.h
@@ -599,6 +599,13 @@ extern int hal_pin_s32_newf(hal_pin_dir_t dir,
 extern int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
     void **data_ptr_addr, int comp_id);
 
+// printf-style version of hal_pin_new():
+int hal_pin_newf(hal_type_t type,
+		 hal_pin_dir_t dir,
+		 void ** data_ptr_addr,
+		 int comp_id,
+		 const char *fmt, ...);
+
 /** There is no 'hal_pin_delete()' function.  Once a component has
     created a pin, that pin remains as long as the component exists.
     All pins belonging to a component are removed when the component
@@ -746,6 +753,13 @@ extern int hal_param_s32_newf(hal_param_dir_t dir,
 extern int hal_param_new(const char *name, hal_type_t type, hal_param_dir_t dir,
     void *data_addr, int comp_id);
 
+// printf-style version of hal_param_new()
+int hal_param_newf(hal_type_t type,
+		   hal_param_dir_t dir,
+		   void * data_addr,
+		   int comp_id,
+		   const char *fmt, ...);
+
 /** There is no 'hal_param_delete()' function.  Once a component has
     created a parameter, that parameter remains as long as the
     component exists.  All parameters belonging to a component are
@@ -828,6 +842,16 @@ extern int hal_param_set(const char *name, hal_type_t type, void *value_addr);
 */
 extern int hal_export_funct(const char *name, void (*funct) (void *, long),
     void *arg, int uses_fp, int reentrant, int comp_id);
+
+// printf-style version of the above
+int hal_export_functf(void (*funct) (void *, long),
+		      void *arg,
+		      int uses_fp,
+		      int reentrant,
+		      int comp_id,
+		      const char *fmt, ... )
+    __attribute__((format(printf,6,7)));
+
 
 /** hal_create_thread() establishes a realtime thread that will
     execute one or more HAL functions periodically.

--- a/src/hal/lib/hal_funct.c
+++ b/src/hal/lib/hal_funct.c
@@ -11,6 +11,43 @@ static hal_funct_entry_t *alloc_funct_entry_struct(void);
 #ifdef RTAPI
 hal_funct_t *alloc_funct_struct(void);
 
+// varargs helper for hal_export_funct()
+static int hal_export_functfv(void (*funct) (void *, long),
+			      void *arg,
+			      int uses_fp,
+			      int reentrant,
+			      int comp_id,
+			      const char *fmt,
+			      va_list ap)
+{
+    char name[HAL_NAME_LEN + 1];
+    int sz;
+    sz = rtapi_vsnprintf(name, sizeof(name), fmt, ap);
+    if(sz == -1 || sz > HAL_NAME_LEN) {
+        hal_print_msg(RTAPI_MSG_ERR,
+		      "%s: length %d too long for name starting '%s'\n",
+		      __FUNCTION__, sz, name);
+	return -ENOMEM;
+    }
+    return hal_export_funct(name, funct, arg, uses_fp, reentrant, comp_id);
+}
+
+// printf-style version of hal_export_funct
+int hal_export_functf(void (*funct) (void *, long),
+		      void *arg,
+		      int uses_fp,
+		      int reentrant,
+		      int comp_id,
+		      const char *fmt, ... )
+{
+    va_list ap;
+    int ret;
+    va_start(ap, fmt);
+    ret = hal_export_functfv(funct, arg, uses_fp, reentrant, comp_id, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
 int hal_export_funct(const char *name, void (*funct) (void *, long),
 		     void *arg, int uses_fp, int reentrant, int comp_id)
 {

--- a/src/hal/lib/hal_lib.c
+++ b/src/hal/lib/hal_lib.c
@@ -520,6 +520,7 @@ EXPORT_SYMBOL(hal_pin_float_new);
 EXPORT_SYMBOL(hal_pin_u32_new);
 EXPORT_SYMBOL(hal_pin_s32_new);
 EXPORT_SYMBOL(hal_pin_new);
+EXPORT_SYMBOL(hal_pin_newf);
 
 EXPORT_SYMBOL(hal_pin_bit_newf);
 EXPORT_SYMBOL(hal_pin_float_newf);
@@ -537,6 +538,7 @@ EXPORT_SYMBOL(hal_param_float_new);
 EXPORT_SYMBOL(hal_param_u32_new);
 EXPORT_SYMBOL(hal_param_s32_new);
 EXPORT_SYMBOL(hal_param_new);
+EXPORT_SYMBOL(hal_param_newf);
 
 EXPORT_SYMBOL(hal_param_bit_newf);
 EXPORT_SYMBOL(hal_param_float_newf);
@@ -552,6 +554,7 @@ EXPORT_SYMBOL(hal_param_set);
 EXPORT_SYMBOL(hal_set_constructor);
 
 EXPORT_SYMBOL(hal_export_funct);
+EXPORT_SYMBOL(hal_export_functf);
 
 EXPORT_SYMBOL(hal_create_thread);
 EXPORT_SYMBOL(hal_thread_delete);
@@ -576,6 +579,7 @@ EXPORT_SYMBOL(halpr_find_param_by_owner);
 EXPORT_SYMBOL(halpr_find_funct_by_owner);
 
 EXPORT_SYMBOL(halpr_find_pin_by_sig);
+EXPORT_SYMBOL(hal_print_msg);
 EXPORT_SYMBOL(hal_lasterror);
 
 #endif /* rtapi */

--- a/src/hal/lib/hal_param.c
+++ b/src/hal/lib/hal_param.c
@@ -96,6 +96,20 @@ int hal_param_s32_newf(hal_param_dir_t dir, hal_s32_t * data_addr,
     return ret;
 }
 
+// printf-style version of hal_param_new()
+int hal_param_newf(hal_type_t type,
+		   hal_param_dir_t dir,
+		   void * data_addr,
+		   int comp_id,
+		   const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+    va_start(ap, fmt);
+    ret = hal_param_newfv(type, dir, data_addr, comp_id, fmt, ap);
+    va_end(ap);
+    return ret;
+}
 
 /* this is a generic function that does the majority of the work. */
 

--- a/src/hal/lib/hal_pin.c
+++ b/src/hal/lib/hal_pin.c
@@ -99,6 +99,20 @@ int hal_pin_s32_newf(hal_pin_dir_t dir,
     return ret;
 }
 
+// printf-style version of hal_pin_new()
+int hal_pin_newf(hal_type_t type,
+		 hal_pin_dir_t dir,
+		 void ** data_ptr_addr,
+		 int comp_id,
+		 const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+    va_start(ap, fmt);
+    ret = hal_pin_newfv(type, dir, data_ptr_addr, comp_id, fmt, ap);
+    va_end(ap);
+    return ret;
+}
 
 /* this is a generic function that does the majority of the work. */
 

--- a/src/hal/lib/hal_ring.c
+++ b/src/hal/lib/hal_ring.c
@@ -271,7 +271,17 @@ int hal_ring_attach(const char *name, ringbuffer_t *rbptr,unsigned *flags)
 	    hal_print_msg(RTAPI_MSG_ERR,
 			    "HAL: hal_ring_attach: no such ring '%s'\n",
 			    name);
-	    return -EINVAL;
+	    return -ENOENT;
+	}
+
+	// calling hal_ring_attach(name, NULL, NULL) is a way to determine
+	// if a given ring exists.
+	// hal_ring_attach(name, NULL, &flags) is a way to inspect the flags
+	// of an existing ring without actually attaching it.
+	if (rbptr == NULL) {
+	    if (flags)
+		*flags = rbdesc->flags;
+	    return 0;
 	}
 
 	if (rbdesc->flags & ALLOC_HALMEM) {

--- a/src/hal/lib/hal_ring.h
+++ b/src/hal/lib/hal_ring.h
@@ -60,10 +60,21 @@ int hal_ring_new(const char *name, int size, int spsize, int mode);
 // will fail if the refcount is > 0 (meaning the ring is still attached somewhere).
 int hal_ring_delete(const char *name);
 
-// make an existing ringbuffer accessible to a component
-// rb must point to storage of type ringbuffer_t.
-// Increases the reference count.
-// store halring flags in *flags if non-zero.
+// make an existing ringbuffer accessible to a component, or test for
+// existence and flags of a ringbuffer
+//
+// to attach:
+//     rb must point to storage of type ringbuffer_t.
+//     Increases the reference count on successful attach
+//     store halring flags in *flags if non-zero.
+//
+// to test for existence:
+//     hal_ring_attach(name, NULL, NULL) returns 0 if the ring exists, < 0 otherwise
+//
+// to test for existence and retrieve the ring's flags:
+//     hal_ring_attach(name, NULL, &f) - if the ring exists, returns 0
+//     and the ring's flags are returned in f
+//
 int hal_ring_attach(const char *name, ringbuffer_t *rb, unsigned *flags);
 
 // detach a ringbuffer. Decreases the reference count.

--- a/src/hal/lib/hal_ring.h
+++ b/src/hal/lib/hal_ring.h
@@ -54,11 +54,19 @@ typedef struct {
 // components do not make sense as owners since their lifetime
 // might be shorter than the ring
 
-int hal_ring_new(const char *name, int size, int spsize, int mode);
+int hal_ring_new(const char *name, int size, int sp_size, int mode);
+
+// printf-style version of the above
+int hal_ring_newf(int size, int sp_size, int mode, const char *fmt, ...)
+    __attribute__((format(printf,4,5)));
 
 // delete a ring buffer.
 // will fail if the refcount is > 0 (meaning the ring is still attached somewhere).
 int hal_ring_delete(const char *name);
+
+// printf-style version of the above
+int hal_ring_deletef(const char *fmt, ...)
+    __attribute__((format(printf,1,2)));
 
 // make an existing ringbuffer accessible to a component, or test for
 // existence and flags of a ringbuffer
@@ -77,12 +85,20 @@ int hal_ring_delete(const char *name);
 //
 int hal_ring_attach(const char *name, ringbuffer_t *rb, unsigned *flags);
 
+// printf-style version of the above
+int hal_ring_attachf(ringbuffer_t *rb, unsigned *flags, const char *fmt, ...)
+    __attribute__((format(printf,3,4)));
+
 // detach a ringbuffer. Decreases the reference count.
 int hal_ring_detach(const char *name, ringbuffer_t *rb);
+
+// printf-style version of the above
+int hal_ring_detachf(ringbuffer_t *rb, const char *fmt, ...)
+    __attribute__((format(printf,2,3)));
 
 // not part of public API. Use with HAL lock engaged.
 hal_ring_t *halpr_find_ring_by_name(const char *name);
 
 RTAPI_END_DECLS
 
-#endif /* HAL_RING_PRIV_H */
+#endif /* HAL_RING_H */

--- a/src/rtapi/ring.h
+++ b/src/rtapi/ring.h
@@ -459,6 +459,21 @@ static inline size_t record_write_space(const ringheader_t *h)
     return MAXIMUM(0, avail - (2 * RB_ALIGN));
 }
 
+/* helper for sizing a record mode ringbuffer
+ * given the size of an record, it will return the space used
+ * in the ring buffer, including any overhead and
+ * alignment requirements
+ *
+ * example: to hold 1000 records of struct foo a ringbuffer will need
+ * a size of at least record_space(sizeof(struct foo)) * 1000
+ *
+ * (to be on the safe side, add some headroom to that)
+ */
+static inline size_t record_space(size_t element)
+{
+    return size_aligned(element + sizeof(ring_size_t));
+}
+
 
 /* internal function */
 static inline ring_size_t _ring_shift_offset(const ringbuffer_t *ring, size_t offset)


### PR DESCRIPTION

this is fallout from the work with Bas on the delayline component

the first two are backwards-compatible extensions of the ring API

the second two are convenience helpers:  make generic pin/param creation, funct export, and ring ops work printf-style as well - this should get rid of a ton of rtapi_snprintf() code needed; sometimes the obvious is missing.