### PR TITLE
machinekit/launcher.py: fix inifile passing to halcmd

### DIFF
--- a/lib/python/machinekit/launcher.py
+++ b/lib/python/machinekit/launcher.py
@@ -105,9 +105,10 @@ def stop_processes():
 def load_hal_file(filename, ini=None):
     sys.stdout.write("loading " + filename + '... ')
     sys.stdout.flush()
-    command = 'halcmd -f ' + filename
+    command = 'halcmd'
     if ini is not None:
         command += ' -i ' + ini
+    command +=  ' -f ' + filename
     subprocess.check_call(command, shell=True)
     sys.stdout.write('done\n')
 

--- a/src/rtapi/rtapi_app.h
+++ b/src/rtapi/rtapi_app.h
@@ -26,7 +26,10 @@
 */
 
 #if defined(BUILD_SYS_USER_DSO)
+
+#if defined(USERMODE_PCI)
 #include "userpci/module.h"
+#endif
 /*  For kernel modules (hm2_pci, hostmot2) to compile in usermode without lots
     of changes, the EXPORT_SYMBOL lines, below, need to be defined *ONLY* if
     there is actually an rtapi_app_* function in the code.  This is handeled 


### PR DESCRIPTION
thanks to the arcane code in halcmd.