### PR TITLE
TP Fixes ported from LinuxCNC 2.7.0~pre5

### DIFF
--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -1403,7 +1403,7 @@ void NURBS_FEED(int lineno, std::vector<CONTROL_POINT> nurbs_control_points, uns
 
 /**
  * Simple circular shift function for PM_CARTESIAN type.
- * Cycle around axes without changing the individual values. A circshift of 1
+ * Cycle around axes without changing the individual values. A circshift of -1
  * makes the X value become the new Y, Y become the Z, and Z become the new X.
  */
 static PM_CARTESIAN circshift(PM_CARTESIAN & vec, int steps)
@@ -1718,7 +1718,7 @@ void ARC_FEED(int line_number,
 
     // KLUDGE: assumes 0,1,2 for X Y Z
     // Find normal axis
-    int norm_axis_ind = 3 + shift_ind % 3;
+    int norm_axis_ind = (2 - shift_ind) % 3;
     // Find maximum velocities and accelerations for planar axes
     int axis1 = (norm_axis_ind + 1) % 3;
     int axis2 = (norm_axis_ind + 2) % 3;

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -1718,7 +1718,7 @@ void ARC_FEED(int line_number,
 
     // KLUDGE: assumes 0,1,2 for X Y Z
     // Find normal axis
-    int norm_axis_ind = 2 + shift_ind % 3;
+    int norm_axis_ind = 3 + shift_ind % 3;
     // Find maximum velocities and accelerations for planar axes
     int axis1 = (norm_axis_ind + 1) % 3;
     int axis2 = (norm_axis_ind + 2) % 3;

--- a/src/emc/tp/blendmath.c
+++ b/src/emc/tp/blendmath.c
@@ -1177,8 +1177,8 @@ int blendCheckConsume(BlendParameters * const param,
     double L_prev = prev_tc->target - points->trim1;
     double prev_seg_time = L_prev / param->v_plan;
 
-    bool need_prev = prev_tc->blend_prev || prev_tc->atspeed;
-    param->consume = (prev_seg_time < gap_cycles * prev_tc->cycle_time && !need_prev);
+    bool can_consume = tcCanConsume(prev_tc);
+    param->consume = (prev_seg_time < gap_cycles * prev_tc->cycle_time && can_consume);
     if (param->consume) {
         tp_debug_print("consuming prev line, L_prev = %g\n",
                 L_prev);

--- a/src/emc/tp/tc.c
+++ b/src/emc/tp/tc.c
@@ -126,6 +126,25 @@ int tcGetIntersectionPoint(TC_STRUCT const * const prev_tc,
     return TP_ERR_OK;
 }
 
+
+/**
+ * Check if a segment can be consumed without disrupting motion or synced IO.
+ */
+int tcCanConsume(TC_STRUCT const * const tc)
+{
+    if (!tc) {
+        return false;
+    }
+
+    if (tc->syncdio.anychanged || tc->blend_prev || tc->atspeed) {
+        //TODO add other conditions here (for any segment that should not be consumed by blending
+        return false;
+    }
+
+    return true;
+
+}
+
 /**
  * Find the geometric tangent vector to a helical arc.
  * Unlike the acceleration vector, the result of this calculation is a vector

--- a/src/emc/tp/tc.h
+++ b/src/emc/tp/tc.h
@@ -33,20 +33,16 @@ int tcGetStartTangentUnitVector(TC_STRUCT const * const tc, PmCartesian * const 
 int tcGetIntersectionPoint(TC_STRUCT const * const prev_tc,
         TC_STRUCT const * const tc, PmCartesian * const point);
 
-int pmCircleFromPoints(PmCircle * const arc, PmCartesian const * const start,
-        PmCartesian const * const middle, PmCartesian const * const end,
-        double radius, PmCartesian * const circ_start, PmCartesian * const circ_end);
-
-int pmCircleFromLines(PmCircle * const arc, PmCartLine const * const line1,
-        PmCartLine const * const line2, double radius,
-        double blend_dist, double center_dist, PmCartesian * const start, PmCartesian * const end);
+int tcCanConsume(TC_STRUCT const * const tc);
 
 int tcSetTermCond(TC_STRUCT * const tc, int term_cond);
+
 int tcConnectBlendArc(TC_STRUCT * const prev_tc, TC_STRUCT * const tc,
         PmCartesian const * const circ_start,
         PmCartesian const * const circ_end);
 
 int tcIsBlending(TC_STRUCT * const tc);
+
 
 int tcFindBlendTolerance(TC_STRUCT const * const prev_tc,
         TC_STRUCT const * const tc, double * const T_blend, double * const nominal_tolerance);

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -1559,9 +1559,9 @@ STATIC int tpRunOptimization(TP_STRUCT * const tp) {
         }
 
 
-        int progress_ratio = prev1_tc->progress / prev1_tc->target;
+        double progress_ratio = prev1_tc->progress / prev1_tc->target;
         // can safely decelerate to halfway point of segment from 25% of segment
-        int cutoff_ratio = BLEND_DIST_FRACTION / 2.0;
+        double cutoff_ratio = BLEND_DIST_FRACTION / 2.0;
 
         if (progress_ratio >= cutoff_ratio) {
             tp_debug_print("segment %d has moved past %f percent progress, cannot blend safely!\n",

--- a/src/emc/tp/tp_shared.h
+++ b/src/emc/tp/tp_shared.h
@@ -209,6 +209,25 @@ static inline int emcPoseSub2fp(EmcPose const * const p1,
     return EMCPOSE_ERR_OK;
 }
 
+static inline int emcPoseZero2fp(hal_float_t ** const out)
+{
+#ifdef EMCPOSE_PEDANTIC
+    if (!pos) {
+        return EMCPOSE_ERR_INPUT_MISSING;
+    }
+#endif
+    *(out[0]) = 0.0;
+    *(out[1]) = 0.0;
+    *(out[2]) = 0.0;
+    *(out[3]) = 0.0;
+    *(out[4]) = 0.0;
+    *(out[5]) = 0.0;
+    *(out[6]) = 0.0;
+    *(out[7]) = 0.0;
+    *(out[8]) = 0.0;
+    return EMCPOSE_ERR_OK;
+}
+
 static inline void SetRotaryUnlock(tp_shared_t *ts,
 				   int axis,
 				   hal_bit_t unlock)


### PR DESCRIPTION
These commits from me and Chris Radek un-break blending. This branch also fixes some emcmotStatus fields, which were not properly set to default values when the motion queue is empty.