### PR TITLE
more cosmetic rebranding of Axis

### DIFF
--- a/share/axis/tcl/axis.tcl
+++ b/share/axis/tcl/axis.tcl
@@ -1778,7 +1778,7 @@ text .about.message \
 	.about.message configure -cursor hand2
 	.about.message tag configure link -foreground red}
 .about.message tag bind link <ButtonPress-1><ButtonRelease-1> {launch_website}
-.about.message insert end [subst [_ "Machinekit/AXIS version \$version\n\nCopyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012 Jeff Epler and Chris Radek.\n\nThis is free software, and you are welcome to redistribute it under certain conditions.  See the file COPYING, included with Machinekit.\n\nVisit the Machinekit web site: "]] {} {http://www.machinekit.iog/} link
+.about.message insert end [subst [_ "Machinekit/AXIS version \$version\n\nCopyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012 Jeff Epler and Chris Radek.\n\nThis is free software, and you are welcome to redistribute it under certain conditions.  See the file COPYING, included with Machinekit.\n\nVisit the Machinekit web site: "]] {} {http://www.machinekit.io/} link
 .about.message configure -state disabled
 
 button .about.ok \

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1872,7 +1872,7 @@ class TclCommands(nf.TclCommands):
 
     def launch_website(event=None):
         import webbrowser
-        webbrowser.open("http://www.linuxcnc.org/")
+        webbrowser.open("http://www.machinekit.io/")
 
     def set_spindlerate(newval):
         global spindlerate_blackout
@@ -3053,7 +3053,7 @@ while s.axes == 0:
     statwait *= 2
     if statfail > 8:
         raise SystemExit, (
-            "A configuration error is preventing LinuxCNC from starting.\n"
+            "A configuration error is preventing Machinekit from starting.\n"
             "More information may be available when running from a terminal.")
     s.poll()
 

--- a/src/emc/usr_intf/axis/scripts/debuglevel.py
+++ b/src/emc/usr_intf/axis/scripts/debuglevel.py
@@ -19,7 +19,7 @@ s.poll()
 c = linuxcnc.command()
 
 t = Tkinter.Tk(className="LinuxCNCDebugLevel")
-t.wm_title(_("LinuxCNC Debug Level"))
+t.wm_title(_("Machinekit Debug Level"))
 t.wm_iconname(_("debuglevel"))
 t.wm_resizable(0, 0)
 

--- a/src/emc/usr_intf/axis/scripts/linuxcnctop.py
+++ b/src/emc/usr_intf/axis/scripts/linuxcnctop.py
@@ -99,7 +99,7 @@ def gui():
     from _tkinter import TclError
     root = Tkinter.Tk(className="LinuxCNCTop")
     rs274.options.install(root)
-    root.title(_("LinuxCNC Status"))
+    root.title(_("Machinekit Status"))
 
     t = Tkinter.Text()
     sb = Tkinter.Scrollbar(command=t.yview)

--- a/src/emc/usr_intf/axis/scripts/teach-in.py
+++ b/src/emc/usr_intf/axis/scripts/teach-in.py
@@ -66,7 +66,7 @@ def show():
     label2.configure(text='Position: %s' % p)
     app.after(100, show)
 
-app = Tkinter.Tk(); app.wm_title('LinuxCNC Teach-In')
+app = Tkinter.Tk(); app.wm_title('Machinekit Teach-In')
 
 world = Tkinter.IntVar(app)
 

--- a/tcl/bin/emccalib.tcl
+++ b/tcl/bin/emccalib.tcl
@@ -77,7 +77,7 @@ foreach wizard_image $wizard_image_search {
     }
 }
 
-wm title . [msgcat::mc "LinuxCNC Servo Axis Calibration"]
+wm title . [msgcat::mc "Machinekit Servo Axis Calibration"]
 set logo [label .logo -image $logo]
 set main [frame .main ]
 set top [NoteBook .main.top]

--- a/tcl/bin/pickconfig.tcl
+++ b/tcl/bin/pickconfig.tcl
@@ -151,7 +151,7 @@ proc title {node} {
   } else {
     set txt ""
   }
-  wm title . "[msgcat::mc "MachineKit Configuration Selector"] $txt"
+  wm title . "[msgcat::mc "Machinekit Configuration Selector"] $txt"
 }
 
 proc find_usable_nodes {startdir} {


### PR DESCRIPTION
Picked up most but no doubt not all of the instances of `LinuxCNC` in titles of windows related to Axis.
Also fixed the annoying habit of Axis of opening a webbrowser on `http://www.linuxcnc.org` when Help-> About Axis is selected.