### PR TITLE
BUILDBOT TEST: xenomai-usr/build: link -rtdm into rtapi_app

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -1466,7 +1466,7 @@ if test -n "$XENOMAI_THREADS_RTS"; then
     fi
     XENOMAI_KERNEL_THREADS_KERNEL_MATH_CFLAGS="$flags"
     # ldflags
-    flags="$($XENOMAI_THREADS_RTS --ldflags)"
+    flags="$($XENOMAI_THREADS_RTS --ldflags) -lrtdm"
     XENOMAI_THREADS_LDFLAGS="$XENOMAI_THREADS_LDFLAGS $flags"
     XENOMAI_KERNEL_THREADS_LDFLAGS="$XENOMAI_KERNEL_THREADS_LDFLAGS $flags"
 fi


### PR DESCRIPTION
This enables usage of the Xenomai RTDM API from HAL RT components
(xenomai-user flavor only), for instance RT-CAN.

Compiling such components will need an extra

   RTFLAGS += backtick xeno-config --skin native --cflags backtick

to get at the Xenomai headers.

No functional changes, and no impact expected.

Test PR to see what the buildbot has to say on this.