### PR TITLE
msgd: log logbuffer highwater mark on exit, increase size

### DIFF
--- a/src/rtapi/rtapi_global.h
+++ b/src/rtapi/rtapi_global.h
@@ -69,7 +69,7 @@
 #include "rtapi_heap_private.h"
 
 
-#define MESSAGE_RING_SIZE (4096 * 64)
+#define MESSAGE_RING_SIZE (4096 * 128)
 
 // the universally shared global structure
 typedef struct {


### PR DESCRIPTION
using tp debugging has shown we're scratching the limit, so increase to 512k:

before, tp debugging on (extreme usage):
Mar 24 17:53:43 nwheezy msgd:0: log buffer hwm: 122% (4105 msgs, 288318 net bytes out of 262144)

just realtime start+stop:
Mar 24 17:54:13 nwheezy msgd:0: log buffer hwm: 0% (17 msgs, 1138 net bytes out of 262144)