### PR TITLE
configs: Update all example configs to use proper PRUBIN path

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.hal
@@ -28,7 +28,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(LINUXCNC_HOME)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
 loadrt pid num_chan=2
 loadrt limit1 count=2
 

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.ini
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.ini
@@ -1,7 +1,7 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=1 num_stepgens=4 num_pwmgens=3
-PRUBIN=rtlib/xenomai/pru_generic.bin
+PRUBIN=xenomai/pru_generic.bin
 
 
 [EMC]

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.hal
@@ -30,7 +30,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(LINUXCNC_HOME)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
 loadrt pid num_chan=2
 loadrt limit1 count=2
 

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.ini
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.ini
@@ -1,7 +1,7 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=1 num_stepgens=4 num_pwmgens=3
-PRUBIN=rtlib/xenomai/pru_generic.bin
+PRUBIN=xenomai/pru_generic.bin
 
 
 

--- a/configs/ARM/BeagleBone/CRAMPS/CRAMPS.ShuttleXpress.ini
+++ b/configs/ARM/BeagleBone/CRAMPS/CRAMPS.ShuttleXpress.ini
@@ -1,7 +1,7 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=1 num_stepgens=4 num_pwmgens=6
-PRUBIN=rtlib/xenomai/pru_generic.bin
+PRUBIN=xenomai/pru_generic.bin
 
 
 [EMC]

--- a/configs/ARM/BeagleBone/Probotix/Comet_Metric.ini
+++ b/configs/ARM/BeagleBone/Probotix/Comet_Metric.ini
@@ -5,7 +5,7 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=1 num_stepgens=5
-PRUBIN=rtlib/xenomai/pru_generic.bin
+PRUBIN=xenomai/pru_generic.bin
 
 [EMC]
 MACHINE = Comet (metric)

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.ShuttleXpress.ini
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.ShuttleXpress.ini
@@ -1,7 +1,7 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=1 num_stepgens=4
-PRUBIN=rtlib/xenomai/pru_generic.bin
+PRUBIN=xenomai/pru_generic.bin
 
 [EMC]
 


### PR DESCRIPTION
Some example configuration files still used the older path values
for PRUBIN, which only work with run-in-place.  Updated so package
based installs will work properly as well.

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>