### PR TITLE
improve rtapi_app + halcmd loadrt/unloadrt error message reporting

### DIFF
--- a/src/hal/cython/Submakefile
+++ b/src/hal/cython/Submakefile
@@ -25,6 +25,7 @@ $(HALNGMKDIR)/hal.c: $(wildcard $(HALNGMKDIR)/*.pyx $(HALNGMKDIR)/*.pxd)
 
 TARGETS += ../lib/python/machinekit/hal.so
 ../lib/python/machinekit/hal.so:	../lib/liblinuxcnchal.so.0 \
+	../lib/libmtalk.so.0 \
 	 $(patsubst %.c,objects/%.o,$(HALSO_SRCS)) \
 	 $(patsubst %.cc,objects/%.o,$(HALSO_CXXSRCS))
 	$(ECHO) Linking $($@)
@@ -43,7 +44,6 @@ RTAPISO_CXXSRCS := \
 USERSRCS += $(RTAPISO_CSRCS) $(RTAPISO_CXXSRCS)
 $(call TOOBJSDEPS, $(RTAPISO_CSRCS)) : EXTRAFLAGS=-fPIC -Ihal/utils -I.
 $(call TOOBJSDEPS, $(RTAPISO_CXXSRCS)) : EXTRAFLAGS=-fPIC -Ihal/utils -I.
-
 
 TARGETS += ../lib/python/machinekit/rtapi.so
 

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -67,6 +67,7 @@ static int propose_completion(char *all, char *fragment, int start);
 
 static const char *inifile;
 static FILE *inifp;
+const char *logpath = "/var/log/linuxcnc.log";
 
 /***********************************************************************
 *                   LOCAL FUNCTION DEFINITIONS                         *

--- a/src/hal/utils/halcmd_rtapiapp.cc
+++ b/src/hal/utils/halcmd_rtapiapp.cc
@@ -6,6 +6,7 @@
 #include "ll-zeroconf.hh"
 #include "mk-zeroconf.hh"
 #include "mk-zeroconf-types.h"
+#include "pbutil.hh"
 #include <avahi-common/malloc.h>
 
 
@@ -35,10 +36,11 @@ int rtapi_rpc(void *socket, pb::Container &tx, pb::Container &rx)
 				    zframe_size (reply)) ? 0 : -1;
     //    assert(retval == 0);
     zframe_destroy(&reply);
-
-    errormsg = "";
-    for (int i = 0; i < rx.note_size(); i++)
-	errormsg += rx.note(i) + "\n";
+    if (rx.note_size())
+	errormsg = pbconcat(rx.note(), "\n");
+    //errormsg = rx.note(0); // simplify - one line only
+    else
+	errormsg = "";
     return retval;
 }
 

--- a/src/machinetalk/include/pbutil.hh
+++ b/src/machinetalk/include/pbutil.hh
@@ -16,7 +16,11 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#ifndef _PBUTIL_HH_INCLUDED
+#define _PBUTIL_HH_INCLUDED
+
 #include <machinetalk/generated/message.pb.h>
+#include <string>
 
 // for repeated string field creation (Container.note, Container.argv)
 typedef ::google::protobuf::RepeatedPtrField< ::std::string> pbstringarray_t;
@@ -34,3 +38,8 @@ int send_pbcontainer(const std::string &dest, pb::Container &c, void *socket);
 #define MAX_NOTESIZE 4096
 int
 note_printf(pb::Container &c, const char *fmt, ...);
+
+// fold a RepeatedPtrField into a std::string, separated by delim
+std::string pbconcat(const pbstringarray_t &args, const std::string &delim = " ");
+
+#endif // _PBUTIL_HH_INCLUDED

--- a/src/machinetalk/lib/pbutil.cc
+++ b/src/machinetalk/lib/pbutil.cc
@@ -96,3 +96,14 @@ note_printf(pb::Container &c, const char *fmt, ...)
     }
     return n;
 }
+
+std::string pbconcat(const pbstringarray_t &args, const std::string &delim)
+{
+    std::string s;
+    for (int i = 0; i < args.size(); i++) {
+	s += args.Get(i);
+	if (i < args.size()-1)
+	    s += delim;
+    }
+    return s;
+}

--- a/src/rtapi/rtapi_compat.c
+++ b/src/rtapi/rtapi_compat.c
@@ -36,6 +36,9 @@
 #include <stdlib.h>		/* exit() */
 #include <grp.h>                // getgroups
 
+#include <elf.h>                // get_rpath()
+#include <link.h>
+
 // really in nucleus/heap.h but we rather get away with minimum include files
 #ifndef XNHEAP_DEV_NAME
 #define XNHEAP_DEV_NAME  "/dev/rtheap"
@@ -487,4 +490,24 @@ int procfs_cmd(const char *path, const char *format, ...)
 	return retval;
     } else
 	return -ENOENT;
+}
+
+
+const char *rtapi_get_rpath(void)
+{
+  const ElfW(Dyn) *dyn = _DYNAMIC;
+  const ElfW(Dyn) *rpath = NULL;
+  const char *strtab = NULL;
+  for (; dyn->d_tag != DT_NULL; ++dyn) {
+    if (dyn->d_tag == DT_RPATH) {
+      rpath = dyn;
+    } else if (dyn->d_tag == DT_STRTAB) {
+      strtab = (const char *)dyn->d_un.d_val;
+    }
+  }
+
+  if (strtab != NULL && rpath != NULL) {
+      return strdup(strtab + rpath->d_un.d_val);
+  }
+  return NULL;
 }

--- a/src/rtapi/rtapi_compat.h
+++ b/src/rtapi/rtapi_compat.h
@@ -162,6 +162,14 @@ extern int module_path(char *result, const char *basename);
 
 extern int get_rtapi_config(char *result, const char *param, int n);
 
+// diagnostics: retrieve the rpath this binary was linked with
+//
+// returns malloc'd memory - caller MUST free returned string if non-null
+// example:  cc -g -Wall -Wl,-rpath,/usr/local/lib -Wl,-rpath,/usr/lib foo.c -o foo
+// rtapi_get_rpath() will return "/usr/local/lib:/usr/lib"
+
+extern const char *rtapi_get_rpath(void);
+
 SUPPORT_END_DECLS
 
 #endif // MODULE


### PR DESCRIPTION
this was appalling to start with, time to fix.

The halcmd output now looks like so:

mah@nwheezy:~/machinekit-prepare/src$ halcmd -f -k
halcmd: loadrt or2
<stdin>:1: Realtime module 'or2' loaded

  # halcmd now reports where it tried to look for the module:

halcmd: loadrt doesnotexist
<stdin>:3: insmod failed, returned -1:
do_load_cmd: dlopen: doesnotexist.so: cannot open shared object file: No such file or directory
rpath=/home/mah/machinekit-prepare/rtlib/posix:/home/mah/machinekit-prepare/lib
See /var/log/linuxcnc.log for more information.

 # and doesnt suggest to look at 'dmesg' which isnt helpful for 90+% of users


