### PR TITLE
Machinekit re-branding - bugfix

### DIFF
--- a/debian/machinekit.postinst
+++ b/debian/machinekit.postinst
@@ -43,22 +43,22 @@ else
     fi
 fi
 
-if [ ! -d "$HOME/machinekit" ]; then
-    ## if already linuxcnc dir linlk to it
-    if [ -d "$HOME/linuxcnc" ]; then
-	ln -s $HOME/linuxcnc $HOME/machinekit
+if [ ! -d "~/$SUDO_USER/machinekit" ]; then
+    ## if already linuxcnc dir link to it
+    if [ -d "~/$SUDO_USER/linuxcnc" ]; then
+	ln -s ~/$SUDO_USER/linuxcnc $HOME/machinekit
 	echo "Creating machinekit directory link"
     else
-        mkdir -p $HOME/machinekit
+        mkdir -p ~/$SUDO_USER/machinekit
 	echo "Creating machinekit directory"
-        chown -R $USER:$USER  $HOME/machinekit.
+        chown -R $SUDO_USER:$SUDO_USER ~/$SUDO_USER/machinekit.
     fi
 fi
 
-if [ ! -f "$HOME/.machinekitrc" ]; then
+if [ ! -f "~/$SUDO_USER/.machinekitrc" ]; then
     ## if already .linuxcncrc file link to it
-    if [ -f "$HOME/.linuxcncrc" ]; then
-	ln -s $HOME/.linuxcncrc $HOME/.machinekitrc
+    if [ -f "~/$SUDO_USER/.linuxcncrc" ]; then
+	ln -s ~/$SUDO_USER/.linuxcncrc ~/$SUDO_USER/.machinekitrc
 	echo "Creating .machinekitrc link"
     # else will be created by pickconfig when used
     fi


### PR DESCRIPTION
Correct /machinekit dir or symlink creation
for installation by package

Set home using $SUDO_USER

signed-off-by: Mick <arceye@mgware.co.uk>