### PR TITLE
Fix ~/machinekit dir creation problem

### DIFF
--- a/debian/machinekit.postinst
+++ b/debian/machinekit.postinst
@@ -23,7 +23,8 @@ invoke-rc.d rsyslog restart
 
 # The rebranding from linuxcnc to machinekit is taken care of in src/configure for RIPs
 # /usr builds to package need it in postinst script
-# The first bit should not be needed, just belt and braces :)
+# This  bit should not be needed, just belt and braces :)
+# Checking for / creating ~/machinekit dir now in linuxcnc script
 
 if [ -f "/usr/bin/linuxcnc" ]; then
     if [ ! -f "/usr/bin/machinekit" ]; then
@@ -43,26 +44,6 @@ else
     fi
 fi
 
-if [ ! -d "~/$SUDO_USER/machinekit" ]; then
-    ## if already linuxcnc dir link to it
-    if [ -d "~/$SUDO_USER/linuxcnc" ]; then
-	ln -s ~/$SUDO_USER/linuxcnc $HOME/machinekit
-	echo "Creating machinekit directory link"
-    else
-        mkdir -p ~/$SUDO_USER/machinekit
-	echo "Creating machinekit directory"
-        chown -R $SUDO_USER:$SUDO_USER ~/$SUDO_USER/machinekit.
-    fi
-fi
-
-if [ ! -f "~/$SUDO_USER/.machinekitrc" ]; then
-    ## if already .linuxcncrc file link to it
-    if [ -f "~/$SUDO_USER/.linuxcncrc" ]; then
-	ln -s ~/$SUDO_USER/.linuxcncrc ~/$SUDO_USER/.machinekitrc
-	echo "Creating .machinekitrc link"
-    # else will be created by pickconfig when used
-    fi
-fi
 
 
 

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -49,6 +49,28 @@ if [ -z "$MACHINEKIT_INI" ]; then
 fi
 export MACHINEKIT_INI
 
+if [ ! -d "$HOME/machinekit" ]; then
+    ## if already linuxcnc dir link to it
+    if [ -d "$HOME/linuxcnc" ]; then
+	ln -s $HOME/linuxcnc $HOME/machinekit
+	echo "Creating machinekit directory link"
+    else
+        mkdir -p $HOME/machinekit
+	echo "Creating machinekit directory"
+        chown -R $USER:$USER $HOME/machinekit.
+    fi
+fi
+
+if [ ! -f "$HOME/.machinekitrc" ]; then
+    ## if already .linuxcncrc file link to it
+    if [ -f "$HOME/.linuxcncrc" ]; then
+	ln -s $HOME/.linuxcncrc $HOME/.machinekitrc
+	echo "Creating .machinekitrc link"
+    # else will be created by pickconfig when used
+    fi
+fi
+
+
 #put the LINUXCNC_BIN_DIR in PATH
 PATH=$LINUXCNC_BIN_DIR:$PATH
 #ditto scripts if not RIP


### PR DESCRIPTION
The creation of the ~/machinekit dir, or the creation of a symlink
to the pre-existing ~/linuxcnc dir, is now left until the linuxcnc
script is run

This not only ensures that the $HOME env var points to the actual users
home dir and not root, when sudo is used to install,
but caters for multiple and or additional users on one machine, creating new dirs /
symlinks on the fly as required

Resolves issue #564 and issue #541

Signed-off-by: Mick <arceye@mgware.co.uk>