### PR TITLE
DECAMUX support

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.hal
@@ -1,6 +1,6 @@
 # #######################################
 #
-# HAL file for BeagleBone + BeBoPr++ cape with Pepper (5 steppers)
+# HAL file for BeagleBone + BeBoPr++ cape with DECAMUX and two PEPPERs (10 steppers)
 #
 # Derived from example BeBoPr-Bridge.hal
 #
@@ -23,11 +23,11 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # load low-level drivers
-loadrt hal_bb_gpio output_pins=107,126,224,226 input_pins=108,109,110,114,117,118
+loadrt hal_bb_gpio output_pins=107,224,226 input_pins=108,109,110,114,117,118
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
 loadrt pid num_chan=2
 loadrt limit1 count=2
-loadrt pepper count=1
+loadrt pepper count=2
 
 
 # Python user-mode HAL module to read ADC value and generate a thermostat output for PWM
@@ -49,7 +49,7 @@ addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
 addf [PRUCONF](DRIVER).update             servo-thread
 addf bb_gpio.write                        base-thread
-addf pepper.update			  base-thread
+addf pepper.update			  base-thread      
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
@@ -64,7 +64,7 @@ addf pepper.update			  base-thread
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
-net emcmot.00.enable <= axis.0.amp-enable-out
+net emcmot.00.enable <= axis.0.amp-enable-out 
 net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
 
 
@@ -103,7 +103,7 @@ setp [PRUCONF](DRIVER).stepgen.00.dirpin           0x4D
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
-net emcmot.01.enable <= axis.1.amp-enable-out
+net emcmot.01.enable <= axis.1.amp-enable-out 
 net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
 
 
@@ -142,7 +142,7 @@ setp [PRUCONF](DRIVER).stepgen.01.dirpin           0x4F
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
-net emcmot.02.enable <= axis.2.amp-enable-out
+net emcmot.02.enable <= axis.2.amp-enable-out 
 net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
 
 
@@ -181,7 +181,7 @@ setp [PRUCONF](DRIVER).stepgen.02.dirpin           0x51
 newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
-net emcmot.03.enable <= axis.3.amp-enable-out
+net emcmot.03.enable <= axis.3.amp-enable-out 
 net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
 
 
@@ -220,7 +220,7 @@ setp [PRUCONF](DRIVER).stepgen.03.dirpin           0x23
 newsig emcmot.04.enable bit
 sets emcmot.04.enable FALSE
 
-net emcmot.04.enable <= axis.4.amp-enable-out
+net emcmot.04.enable <= axis.4.amp-enable-out 
 net emcmot.04.enable => [PRUCONF](DRIVER).stepgen.04.enable
 
 
@@ -251,6 +251,201 @@ setp [PRUCONF](DRIVER).stepgen.04.steppin          0x24
 setp [PRUCONF](DRIVER).stepgen.04.dirpin           0x25
 
 
+# ################
+# U [5] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.05.enable bit
+sets emcmot.05.enable FALSE
+
+net emcmot.05.enable <= axis.5.amp-enable-out 
+net emcmot.05.enable => [PRUCONF](DRIVER).stepgen.05.enable
+
+
+# position command and feedback
+net emcmot.05.pos-cmd <= axis.5.motor-pos-cmd
+net emcmot.05.pos-cmd => [PRUCONF](DRIVER).stepgen.05.position-cmd
+
+net motor.05.pos-fb <= [PRUCONF](DRIVER).stepgen.05.position-fb
+net motor.05.pos-fb => axis.5.motor-pos-fb
+
+
+# timing parameters
+setp [PRUCONF](DRIVER).stepgen.05.dirsetup        [AXIS_5]DIRSETUP
+setp [PRUCONF](DRIVER).stepgen.05.dirhold         [AXIS_5]DIRHOLD
+
+setp [PRUCONF](DRIVER).stepgen.05.steplen         [AXIS_5]STEPLEN
+setp [PRUCONF](DRIVER).stepgen.05.stepspace       [AXIS_5]STEPSPACE
+
+setp [PRUCONF](DRIVER).stepgen.05.position-scale  [AXIS_5]SCALE
+
+setp [PRUCONF](DRIVER).stepgen.05.maxvel          [AXIS_5]STEPGEN_MAX_VEL
+setp [PRUCONF](DRIVER).stepgen.05.maxaccel        [AXIS_5]STEPGEN_MAX_ACC
+
+#setp [PRUCONF](DRIVER).stepgen.05.step_type       0
+# P8.12 GPIO1_12
+setp [PRUCONF](DRIVER).stepgen.05.steppin          0x8C
+# P8.11 GPIO1_13
+setp [PRUCONF](DRIVER).stepgen.05.dirpin           0x8D
+
+
+# ################
+# V [6] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.06.enable bit
+sets emcmot.06.enable FALSE
+
+net emcmot.06.enable <= axis.6.amp-enable-out 
+net emcmot.06.enable => [PRUCONF](DRIVER).stepgen.06.enable
+
+
+# position command and feedback
+net emcmot.06.pos-cmd <= axis.6.motor-pos-cmd
+net emcmot.06.pos-cmd => [PRUCONF](DRIVER).stepgen.06.position-cmd
+
+net motor.06.pos-fb <= [PRUCONF](DRIVER).stepgen.06.position-fb
+net motor.06.pos-fb => axis.6.motor-pos-fb
+
+
+# timing parameters
+setp [PRUCONF](DRIVER).stepgen.06.dirsetup        [AXIS_6]DIRSETUP
+setp [PRUCONF](DRIVER).stepgen.06.dirhold         [AXIS_6]DIRHOLD
+
+setp [PRUCONF](DRIVER).stepgen.06.steplen         [AXIS_6]STEPLEN
+setp [PRUCONF](DRIVER).stepgen.06.stepspace       [AXIS_6]STEPSPACE
+
+setp [PRUCONF](DRIVER).stepgen.06.position-scale  [AXIS_6]SCALE
+
+setp [PRUCONF](DRIVER).stepgen.06.maxvel          [AXIS_6]STEPGEN_MAX_VEL
+setp [PRUCONF](DRIVER).stepgen.06.maxaccel        [AXIS_6]STEPGEN_MAX_ACC
+
+#setp [PRUCONF](DRIVER).stepgen.06.step_type       0
+# P8.16 GPIO1_14
+setp [PRUCONF](DRIVER).stepgen.06.steppin          0x8E
+# P8.15 GPIO1_15
+setp [PRUCONF](DRIVER).stepgen.06.dirpin           0x8F
+
+
+# ################
+# W [7] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.07.enable bit
+sets emcmot.07.enable FALSE
+
+net emcmot.07.enable <= axis.7.amp-enable-out 
+net emcmot.07.enable => [PRUCONF](DRIVER).stepgen.07.enable
+
+
+# position command and feedback
+net emcmot.07.pos-cmd <= axis.7.motor-pos-cmd
+net emcmot.07.pos-cmd => [PRUCONF](DRIVER).stepgen.07.position-cmd
+
+net motor.07.pos-fb <= [PRUCONF](DRIVER).stepgen.07.position-fb
+net motor.07.pos-fb => axis.7.motor-pos-fb
+
+
+# timing parameters
+setp [PRUCONF](DRIVER).stepgen.07.dirsetup        [AXIS_7]DIRSETUP
+setp [PRUCONF](DRIVER).stepgen.07.dirhold         [AXIS_7]DIRHOLD
+
+setp [PRUCONF](DRIVER).stepgen.07.steplen         [AXIS_7]STEPLEN
+setp [PRUCONF](DRIVER).stepgen.07.stepspace       [AXIS_7]STEPSPACE
+
+setp [PRUCONF](DRIVER).stepgen.07.position-scale  [AXIS_7]SCALE
+
+setp [PRUCONF](DRIVER).stepgen.07.maxvel          [AXIS_7]STEPGEN_MAX_VEL
+setp [PRUCONF](DRIVER).stepgen.07.maxaccel        [AXIS_7]STEPGEN_MAX_ACC
+
+#setp [PRUCONF](DRIVER).stepgen.07.step_type       0
+# P9.15 GPIO1_16
+setp [PRUCONF](DRIVER).stepgen.07.steppin          0x90
+# P9.23 GPIO1_17
+setp [PRUCONF](DRIVER).stepgen.07.dirpin           0x91
+
+
+# ################
+# C [8] Axis (Extruder 3)
+# ################
+
+# axis enable chain
+newsig emcmot.08.enable bit
+sets emcmot.08.enable FALSE
+
+net emcmot.08.enable <= axis.8.amp-enable-out 
+net emcmot.08.enable => [PRUCONF](DRIVER).stepgen.08.enable
+
+
+# position command and feedback
+net emcmot.08.pos-cmd <= axis.8.motor-pos-cmd
+net emcmot.08.pos-cmd => [PRUCONF](DRIVER).stepgen.08.position-cmd
+
+net motor.08.pos-fb <= [PRUCONF](DRIVER).stepgen.08.position-fb
+net motor.08.pos-fb => axis.8.motor-pos-fb
+
+
+# timing parameters
+setp [PRUCONF](DRIVER).stepgen.08.dirsetup        [AXIS_8]DIRSETUP
+setp [PRUCONF](DRIVER).stepgen.08.dirhold         [AXIS_8]DIRHOLD
+
+setp [PRUCONF](DRIVER).stepgen.08.steplen         [AXIS_8]STEPLEN
+setp [PRUCONF](DRIVER).stepgen.08.stepspace       [AXIS_8]STEPSPACE
+
+setp [PRUCONF](DRIVER).stepgen.08.position-scale  [AXIS_8]SCALE
+
+setp [PRUCONF](DRIVER).stepgen.08.maxvel          [AXIS_8]STEPGEN_MAX_VEL
+setp [PRUCONF](DRIVER).stepgen.08.maxaccel        [AXIS_8]STEPGEN_MAX_ACC
+
+#setp [PRUCONF](DRIVER).stepgen.08.step_type       0
+# P9.22 GPIO0_2
+setp [PRUCONF](DRIVER).stepgen.08.steppin          0x62
+# P9.21 GPIO0_3
+setp [PRUCONF](DRIVER).stepgen.08.dirpin           0x63
+
+
+## ################
+## D [9] Axis (Extruder 4)
+## ################
+#
+## axis enable chain
+#newsig emcmot.09.enable bit
+#sets emcmot.09.enable FALSE
+#
+#net emcmot.09.enable <= axis.9.amp-enable-out 
+#net emcmot.09.enable => [PRUCONF](DRIVER).stepgen.09.enable
+#
+#
+## position command and feedback
+#net emcmot.09.pos-cmd <= axis.9.motor-pos-cmd
+#net emcmot.09.pos-cmd => [PRUCONF](DRIVER).stepgen.09.position-cmd
+#
+#net motor.09.pos-fb <= [PRUCONF](DRIVER).stepgen.09.position-fb
+#net motor.09.pos-fb => axis.9.motor-pos-fb
+#
+#
+## timing parameters
+#setp [PRUCONF](DRIVER).stepgen.09.dirsetup        [AXIS_9]DIRSETUP
+#setp [PRUCONF](DRIVER).stepgen.09.dirhold         [AXIS_9]DIRHOLD
+#
+#setp [PRUCONF](DRIVER).stepgen.09.steplen         [AXIS_9]STEPLEN
+#setp [PRUCONF](DRIVER).stepgen.09.stepspace       [AXIS_9]STEPSPACE
+#
+#setp [PRUCONF](DRIVER).stepgen.09.position-scale  [AXIS_9]SCALE
+#
+#setp [PRUCONF](DRIVER).stepgen.09.maxvel          [AXIS_9]STEPGEN_MAX_VEL
+#setp [PRUCONF](DRIVER).stepgen.09.maxaccel        [AXIS_9]STEPGEN_MAX_ACC
+#
+##setp [PRUCONF](DRIVER).stepgen.09.step_type       0
+## P9.18 GPIO0_4
+#setp [PRUCONF](DRIVER).stepgen.09.steppin          0x64
+## P9.17 GPIO0_5
+#setp [PRUCONF](DRIVER).stepgen.09.dirpin           0x65
+#
+
 # ##################################################
 # Standard I/O - EStop, Enables, Limit Switches, Etc
 # ##################################################
@@ -269,7 +464,7 @@ net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
 # Link pepper component as last item in io_enable chain
 #
 net estop-loop => pepper.io-ena.in
-net io-enable pepper.io-ena.out => bb_gpio.p8.out-07
+net io-enable pepper.io-ena.out => bb_gpio.p8.out-07 
 setp bb_gpio.p8.out-07.invert 1
 
 # feed stepper enables to pepper component
@@ -296,30 +491,55 @@ setp pepper.axis.1.micro-step [AXIS_1]MICRO_STEP
 setp pepper.axis.2.micro-step [AXIS_2]MICRO_STEP
 setp pepper.axis.3.micro-step [AXIS_3]MICRO_STEP
 setp pepper.axis.4.micro-step [AXIS_4]MICRO_STEP
+setp pepper.axis.5.micro-step [AXIS_5]MICRO_STEP
+setp pepper.axis.6.micro-step [AXIS_6]MICRO_STEP
+setp pepper.axis.7.micro-step [AXIS_7]MICRO_STEP
+setp pepper.axis.8.micro-step [AXIS_8]MICRO_STEP
+#setp pepper.axis.9.micro-step [AXIS_9]MICRO_STEP
 
 setp pepper.axis.0.idle-current [AXIS_0]IDLE_CURRENT
 setp pepper.axis.1.idle-current [AXIS_1]IDLE_CURRENT
 setp pepper.axis.2.idle-current [AXIS_2]IDLE_CURRENT
 setp pepper.axis.3.idle-current [AXIS_3]IDLE_CURRENT
 setp pepper.axis.4.idle-current [AXIS_4]IDLE_CURRENT
+setp pepper.axis.5.idle-current [AXIS_5]IDLE_CURRENT
+setp pepper.axis.6.idle-current [AXIS_6]IDLE_CURRENT
+setp pepper.axis.7.idle-current [AXIS_7]IDLE_CURRENT
+setp pepper.axis.8.idle-current [AXIS_8]IDLE_CURRENT
+#setp pepper.axis.9.idle-current [AXIS_9]IDLE_CURRENT
 
 setp pepper.axis.0.active-current [AXIS_0]ACTIVE_CURRENT
 setp pepper.axis.1.active-current [AXIS_1]ACTIVE_CURRENT
 setp pepper.axis.2.active-current [AXIS_2]ACTIVE_CURRENT
 setp pepper.axis.3.active-current [AXIS_3]ACTIVE_CURRENT
 setp pepper.axis.4.active-current [AXIS_4]ACTIVE_CURRENT
+setp pepper.axis.5.active-current [AXIS_5]ACTIVE_CURRENT
+setp pepper.axis.6.active-current [AXIS_6]ACTIVE_CURRENT
+setp pepper.axis.7.active-current [AXIS_7]ACTIVE_CURRENT
+setp pepper.axis.8.active-current [AXIS_8]ACTIVE_CURRENT
+#setp pepper.axis.9.active-current [AXIS_9]ACTIVE_CURRENT
 
 setp pepper.axis.0.idle-decay [AXIS_0]IDLE_DECAY
 setp pepper.axis.1.idle-decay [AXIS_1]IDLE_DECAY
 setp pepper.axis.2.idle-decay [AXIS_2]IDLE_DECAY
 setp pepper.axis.3.idle-decay [AXIS_3]IDLE_DECAY
 setp pepper.axis.4.idle-decay [AXIS_4]IDLE_DECAY
+setp pepper.axis.5.idle-decay [AXIS_5]IDLE_DECAY
+setp pepper.axis.6.idle-decay [AXIS_6]IDLE_DECAY
+setp pepper.axis.7.idle-decay [AXIS_7]IDLE_DECAY
+setp pepper.axis.8.idle-decay [AXIS_8]IDLE_DECAY
+#setp pepper.axis.9.idle-decay [AXIS_9]IDLE_DECAY
 
 setp pepper.axis.0.active-decay [AXIS_0]ACTIVE_DECAY
 setp pepper.axis.1.active-decay [AXIS_1]ACTIVE_DECAY
 setp pepper.axis.2.active-decay [AXIS_2]ACTIVE_DECAY
 setp pepper.axis.3.active-decay [AXIS_3]ACTIVE_DECAY
 setp pepper.axis.4.active-decay [AXIS_4]ACTIVE_DECAY
+setp pepper.axis.5.active-decay [AXIS_5]ACTIVE_DECAY
+setp pepper.axis.6.active-decay [AXIS_6]ACTIVE_DECAY
+setp pepper.axis.7.active-decay [AXIS_7]ACTIVE_DECAY
+setp pepper.axis.8.active-decay [AXIS_8]ACTIVE_DECAY
+#setp pepper.axis.9.active-decay [AXIS_9]ACTIVE_DECAY
 
 # ##################################################
 # PWM and Temperature Signals
@@ -335,20 +555,25 @@ newsig bed.temp.meas float
 
 setp hal_pru_generic.pwmgen.00.pwm_period       10000000
 
-# J2 E0 Heater PRU1.out1
+# J2 E0 Heater T10 GPIO0.23 P8.13
 setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
 setp hal_pru_generic.pwmgen.00.out.00.enable    1
 setp hal_pru_generic.pwmgen.00.out.00.value     0.0
 
-# J3 E1 Heater PRU1.out0
+# J3 E1 Heater U10 GPIO0.22 P8.19
 setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
 setp hal_pru_generic.pwmgen.00.out.01.enable    1
 setp hal_pru_generic.pwmgen.00.out.01.value     0.0
 
-# J4 Bed Heater GPIO2.16
+# J4 Bed Heater U14 GPIO1.18 P9.14
 setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
 setp hal_pru_generic.pwmgen.00.out.02.enable    1
 setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+
+## DECAMUX clock signal U18 GPIO1.28 P9.12
+#setp hal_pru_generic.pwmgen.00.out.03.pin       0x5C
+#setp hal_pru_generic.pwmgen.00.out.03.enable    1
+#setp hal_pru_generic.pwmgen.00.out.03.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -384,23 +609,23 @@ setp limit1.1.min 0
 
 # PID Parameters for adjusting temperature control
 # Extruder
-#setp pid.0.FF0      0
-#setp pid.0.FF1      0
-#setp pid.0.FF2      0
+#setp pid.0.FF0      0  
+#setp pid.0.FF1      0  
+#setp pid.0.FF2      0  
 setp pid.0.Pgain  0.30
 setp pid.0.Igain  0.00001
 setp pid.0.Dgain  0.9375
 setp pid.0.maxerrorI 1.0
-setp pid.0.bias    0.5
+setp pid.0.bias    0.5  
 setp pid.0.enable   1
 
 # Bed
-#setp pid.1.FF0      0
-#setp pid.1.FF1      0
-#setp pid.1.FF2      0
+#setp pid.1.FF0      0  
+#setp pid.1.FF1      0  
+#setp pid.1.FF2      0  
 setp pid.1.Pgain  1
 setp pid.1.Igain  0.0
 setp pid.1.Dgain  0.0
 setp pid.1.maxerrorI 1.0
-setp pid.1.bias    0.5
+setp pid.1.bias    0.5  
 setp pid.1.enable   1

--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.ini
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.ini
@@ -1,0 +1,566 @@
+[PRUCONF]
+DRIVER=hal_pru_generic
+#CONFIG=pru=1 num_stepgens=5 num_pwmgens=3 disabled=1
+CONFIG=pru=1 num_stepgens=9 num_pwmgens=3 disabled=0
+PRUBIN=xenomai/pru_generic.bin
+
+[PEPPER]
+# depending on this setting, changes are permanently stored in PEPPER's EEPROM
+VOLATILE=1
+
+[EMC]
+
+# Name of machine, for use with display, etc.
+MACHINE =               BeBoPr++Pepper
+
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+#DEBUG =                0x00000003
+#DEBUG =                0x00000007
+DEBUG = 0
+
+[DISPLAY]
+
+# Name of display program, e.g., tkemc
+#DISPLAY = tkemc
+#DISPLAY = gscreen
+DISPLAY = axis
+
+# Touchy currently won't work without some hardware buttons/jog-wheel
+#DISPLAY = touchy
+
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.200
+
+# Path to help file
+HELP_FILE =             tklinucnc.txt
+
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.5
+
+# Prefix to be used
+PROGRAM_PREFIX = ../../../../nc_files/
+
+# Introductory graphic
+INTRO_GRAPHIC =         machinekit.gif
+INTRO_TIME =            5
+
+# Increments for the JOG section
+INCREMENTS = 10 1 0.1 0.01
+
+
+PYVCP = BeBoPr.panel.xml
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+
+
+[TASK]
+
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.010
+
+
+
+
+[RS274NGC]
+
+# File containing interpreter variables
+PARAMETER_FILE =        ./pru-stepper.var
+
+
+
+
+[EMCMOT]
+
+EMCMOT =                motmod
+
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+
+# Interval between tries to emcmot, in seconds
+COMM_WAIT =             0.010
+
+# Fast task period, in nanoseconds
+BASE_PERIOD =           100000
+
+# Servo task period, in nanoseconds
+SERVO_PERIOD =          1000000
+
+
+
+
+[HAL]
+
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+
+HALFILE =		BeBoPr++Pepper-DecaMux.hal
+
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =               save neta
+
+POSTGUI_HALFILE =       ./BeBoPr.postgui.hal
+
+
+[TRAJ]
+
+AXES =                  9
+COORDINATES =           X Y Z A B C U V W	#X Y Z A B on Pepper #1, U V W C on Pepper #2 (D unavailable)
+MAX_ANGULAR_VELOCITY = 45.00
+DEFAULT_ANGULAR_VELOCITY = 4.50
+LINEAR_UNITS =          mm
+ANGULAR_UNITS =         degree
+CYCLE_TIME =            0.010
+DEFAULT_VELOCITY = 20.00
+MAX_LINEAR_VELOCITY = 200.00
+
+
+
+
+
+[AXIS_0]
+
+# 
+# Step timing is 40 us steplen + 40 us stepspace
+# That gives 80 us step period = 12.5 KHz step freq
+#
+# Bah, even software stepping can handle that, hm2 doesnt buy you much with
+# such slow steppers.
+#
+# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
+#
+# This gives a maxvel of 12.5/1 = 12.5 ips
+#
+
+
+TYPE =              LINEAR
+MAX_VELOCITY =       200.0
+MAX_ACCELERATION =   3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    240.0
+STEPGEN_MAX_ACC =    3600.0
+
+BACKLASH =           0.000
+
+# scale is 200 steps/rev * 5 revs/inch
+SCALE =  -80
+
+MIN_LIMIT =             -1.0
+MAX_LIMIT =             220.0
+
+FERROR =     1.0
+MIN_FERROR = 0.25
+
+HOME =                  0.000
+HOME_OFFSET =           0.00
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              1000
+STEPSPACE  =              1000
+
+###############
+#
+#  CURRENT: peak current in 0.1 A units (e.g. 15 is 1.5A)
+#  DECAY: 0 = slow, 1 = fast, 2 = mixed
+#  MICRO_STEP: 1, 2, 4, 8, 16, 32
+#
+MICRO_STEP     = 8
+ACTIVE_CURRENT = 10
+ACTIVE_DECAY   = 1
+IDLE_CURRENT   = 2
+IDLE_DECAY     = 2
+
+
+[AXIS_1]
+
+TYPE =              LINEAR
+MAX_VELOCITY =       200.0
+MAX_ACCELERATION =   3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    240.0
+STEPGEN_MAX_ACC =    3600.0
+
+BACKLASH =           0.000
+
+SCALE =  80.0
+
+MIN_LIMIT =             -1.0
+MAX_LIMIT =             250.0
+
+FERROR =     1.0
+MIN_FERROR = 0.25
+
+HOME =                  0.000
+HOME_OFFSET =           0.00
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              1000
+STEPSPACE  =              1000
+
+MICRO_STEP     = 8
+ACTIVE_CURRENT = 10
+ACTIVE_DECAY   = 1
+IDLE_CURRENT   = 2
+IDLE_DECAY     = 2
+
+
+[AXIS_2]
+
+TYPE =              LINEAR
+MAX_VELOCITY =      5.0
+MAX_ACCELERATION =  100.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    6.0
+STEPGEN_MAX_ACC =    125.0
+
+BACKLASH =           0.000
+
+SCALE = 1511.81102362
+
+MIN_LIMIT =             -10.0
+MAX_LIMIT =             200.0
+
+FERROR =     1.0
+MIN_FERROR = 0.25
+
+HOME =                  0.000
+HOME_OFFSET =           0.00
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              1000
+STEPSPACE  =              1000
+
+MICRO_STEP     = 8
+ACTIVE_CURRENT = 10
+ACTIVE_DECAY   = 1
+IDLE_CURRENT   = 2
+IDLE_DECAY     = 2
+
+
+[AXIS_3]
+
+TYPE = ANGULAR
+MAX_VELOCITY = 31.8993189453
+MAX_ACCELERATION = 3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL = 37.0
+STEPGEN_MAX_ACC = 3750.0
+
+BACKLASH =           0.000
+
+SCALE = -744.530002058
+#SCALE = -732.32
+
+MIN_LIMIT = -9999.0
+MAX_LIMIT = 999999999.0
+
+FERROR = 1.0
+MIN_FERROR = .25
+
+HOME = 0.0
+HOME_OFFSET = 0.0
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              1000
+STEPSPACE  =              1000
+
+MICRO_STEP     = 8
+ACTIVE_CURRENT = 10
+ACTIVE_DECAY   = 1
+IDLE_CURRENT   = 2
+IDLE_DECAY     = 2
+
+
+[AXIS_4]
+
+TYPE = ANGULAR
+MAX_VELOCITY = 31.8993189453
+MAX_ACCELERATION = 3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL = 37.0
+STEPGEN_MAX_ACC = 3750.0
+
+BACKLASH =           0.000
+
+SCALE = -744.530002058
+#SCALE = -732.32
+
+MIN_LIMIT = -9999.0
+MAX_LIMIT = 999999999.0
+
+FERROR = 1.0
+MIN_FERROR = .25
+
+HOME = 0.0
+HOME_OFFSET = 0.0
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              1000
+STEPSPACE  =              1000
+
+MICRO_STEP     = 8
+ACTIVE_CURRENT = 10
+ACTIVE_DECAY   = 1
+IDLE_CURRENT   = 2
+IDLE_DECAY     = 2
+
+
+
+
+[AXIS_5]
+
+TYPE =              LINEAR
+MAX_VELOCITY =       200.0
+MAX_ACCELERATION =   3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    240.0
+STEPGEN_MAX_ACC =    3600.0
+
+BACKLASH =           0.000
+
+
+SCALE =  -80
+
+MIN_LIMIT =             -1.0
+MAX_LIMIT =             220.0
+
+FERROR =     1.0
+MIN_FERROR = 0.25
+
+HOME =                  0.000
+HOME_OFFSET =           0.00
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              1000
+STEPSPACE  =              1000
+
+MICRO_STEP     = 8
+ACTIVE_CURRENT = 10
+ACTIVE_DECAY   = 1
+IDLE_CURRENT   = 2
+IDLE_DECAY     = 2
+
+
+[AXIS_6]
+
+TYPE =              LINEAR
+MAX_VELOCITY =       200.0
+MAX_ACCELERATION =   3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    240.0
+STEPGEN_MAX_ACC =    3600.0
+
+BACKLASH =           0.000
+
+SCALE =  80.0
+
+MIN_LIMIT =             -1.0
+MAX_LIMIT =             250.0
+
+FERROR =     1.0
+MIN_FERROR = 0.25
+
+HOME =                  0.000
+HOME_OFFSET =           0.00
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              1000
+STEPSPACE  =              1000
+
+MICRO_STEP     = 8
+ACTIVE_CURRENT = 10
+ACTIVE_DECAY   = 1
+IDLE_CURRENT   = 2
+IDLE_DECAY     = 2
+
+
+[AXIS_7]
+
+TYPE =              LINEAR
+MAX_VELOCITY =      5.0
+MAX_ACCELERATION =  100.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    6.0
+STEPGEN_MAX_ACC =    125.0
+
+BACKLASH =           0.000
+
+SCALE = 1511.81102362
+
+MIN_LIMIT =             -10.0
+MAX_LIMIT =             200.0
+
+FERROR =     1.0
+MIN_FERROR = 0.25
+
+HOME =                  0.000
+HOME_OFFSET =           0.00
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              1000
+STEPSPACE  =              1000
+
+MICRO_STEP     = 8
+ACTIVE_CURRENT = 10
+ACTIVE_DECAY   = 1
+IDLE_CURRENT   = 2
+IDLE_DECAY     = 2
+
+
+[AXIS_8]
+
+TYPE = ANGULAR
+MAX_VELOCITY = 31.8993189453
+MAX_ACCELERATION = 3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL = 37.0
+STEPGEN_MAX_ACC = 3750.0
+
+BACKLASH =           0.000
+
+SCALE = -744.530002058
+#SCALE = -732.32
+
+MIN_LIMIT = -9999.0
+MAX_LIMIT = 999999999.0
+
+FERROR = 1.0
+MIN_FERROR = .25
+
+HOME = 0.0
+HOME_OFFSET = 0.0
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              1000
+STEPSPACE  =              1000
+
+MICRO_STEP     = 8
+ACTIVE_CURRENT = 10
+ACTIVE_DECAY   = 1
+IDLE_CURRENT   = 2
+IDLE_DECAY     = 2
+
+
+[AXIS_9]
+
+TYPE = ANGULAR
+MAX_VELOCITY = 31.8993189453
+MAX_ACCELERATION = 3000.0
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL = 37.0
+STEPGEN_MAX_ACC = 3750.0
+
+BACKLASH =           0.000
+
+SCALE = -744.530002058
+#SCALE = -732.32
+
+MIN_LIMIT = -9999.0
+MAX_LIMIT = 999999999.0
+
+FERROR = 1.0
+MIN_FERROR = .25
+
+HOME = 0.0
+HOME_OFFSET = 0.0
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              1000
+STEPSPACE  =              1000
+
+MICRO_STEP     = 8
+ACTIVE_CURRENT = 10
+ACTIVE_DECAY   = 1
+IDLE_CURRENT   = 2
+IDLE_DECAY     = 2
+
+
+[EMCIO]
+
+# Name of IO controller program, e.g., io
+EMCIO =                 io
+
+# cycle time, in seconds
+CYCLE_TIME =            0.100
+
+# tool table file
+TOOL_TABLE =            ./tool.tbl
+

--- a/src/hal/drivers/hal_pru_generic/pru_generic.p
+++ b/src/hal/drivers/hal_pru_generic/pru_generic.p
@@ -198,7 +198,16 @@ START:
     MOV     GState.State_Reg1, GPIO1 + GPIO_CLEARDATAOUT
     MOV     GState.State_Reg2, GPIO2 + GPIO_CLEARDATAOUT
     MOV     GState.State_Reg3, GPIO3 + GPIO_CLEARDATAOUT
+#define DECA_MUX T
+#ifdef DECA_MUX
+    ZERO    &GState.State_Reg4, 12
+    // setup masks for PEPPER signals in GPIO0 & GPIO1
+    MOV     GState.State_Reg6.w0, 0x003c            // bits 2,3,4 & 5 for GPIO0 mask (w0)
+    MOV     GState.State_Reg6.w2, 0x03f0            // bits 12,13,14,15,16 & 17 for GPIO1 mask (w1)
+    XOUT    10, GState.State_Reg0, 28
+#else
     XOUT    10, GState.State_Reg0, 16
+#endif
     ZERO    &GState.State_Reg0, 16
 
     LDI     GState.TaskTable, #TASKTABLE                // Base address of jump tables

--- a/src/hal/drivers/hal_pru_generic/pru_wait.p
+++ b/src/hal/drivers/hal_pru_generic/pru_wait.p
@@ -50,24 +50,93 @@
 MODE_WAIT:
 .enter WAIT_SCOPE
 
+#define DECAMUX T
+
 .struct wait_state
     .u32    GPIO0_Clr_Addr
     .u32    GPIO1_Clr_Addr
     .u32    GPIO2_Clr_Addr
     .u32    GPIO3_Clr_Addr
+#ifdef DECAMUX   
+   // GPIO0 values align to b0, GPIO1 to b1 !
+   .u16     PEPPER1_GPIO0
+   .u16     PEPPER1_GPIO1
+   .u16     PEPPER2_GPIO0
+   .u16     PEPPER2_GPIO1
+   .u16     GPIO0_Mask
+   .u16     GPIO1_Mask
+.ends
+
+.struct pepper1_shadow
+   .u32     GPIO01
+.ends
+
+.struct pepper2_shadow
+   .u32     GPIO01
+.ends
+
+.struct pepper_masks
+   .u32     Masks
+#endif
+
 .ends
 
 .assign wait_state, GState.State_Reg0, *, State
 
-    // FIXME:
-    // This scheme requires the GPIO addresses to be stored as local data
-    // in the wait task.  A better solution would be to use the Register
-    // Transfer instructions and pull the data from a scratchpad
 
-    // Read channel state data
-//    LBBO    STATE_REG, GTask.addr, 8, SIZE(State)
-    XIN     10, State, 16
+    XIN     10, State, SIZE( State)          // Pull the GPIO addresses from first scratchpad
 
+#ifdef DECA_MUX
+
+.assign pepper1_shadow, State.PEPPER1_GPIO0, *, State_PEPPER1
+.assign pepper2_shadow, State.PEPPER2_GPIO0, *, State_PEPPER2
+.assign pepper_masks, State.GPIO0_Mask, *, State_GPIO01
+
+    // Put PEPPER2 signals on GPIO0 & GPIO1 outputs before generating strobe
+    // Note that here we will only change PEPPER signals on GPIO0 & GPIO1 !
+
+    AND     r3, State.PEPPER2_GPIO0, State.GPIO0_Mask // determine bits to be set
+    XOR     r2, r3.w0, State.GPIO0_Mask      // determine bits to be cleared
+    SBBO    r2, State.GPIO0_CLR_ADDR, 0, 8   // Write both CLR & SET registers
+
+    XOR     r1.b3, r0, r0                    // clear leading byte for SBBO
+    AND     r3, State.PEPPER2_GPIO1, State.GPIO1_Mask // determine bits to be set
+    XOR     r2, r3, State.GPIO1_Mask            // determine bits to be cleared 
+    SBBO    r1.b3, State.GPIO1_CLR_ADDR, 0, 8   // Write both CLR & SET registers
+
+    // Negate DECAMUX clock (GPIO1.28) after having set PEPPER #2 data.
+    // This generates a falling edge on the DM_CLK signal that on its
+    // turn creates the enable for the latch on the DECAMUX that stores
+    // the signals for the second PEPPER.
+
+// FIXME: move to later moment giving more data setup time ???
+
+    MOV     r2, (1 << 28)                     // GPIO1.28
+    SBBO    r2, State.GPIO1_CLR_ADDR, 0, 4    // Write CLR register
+
+    // Calculate new state for PEPPER #1 stepper signals
+    // Since we are switching between PEPPER1 and PEPPER2 we need
+    // to reconstruct the entire output pattern !
+
+    OR      State.PEPPER1_GPIO0, State.PEPPER1_GPIO0, GState.GPIO0_SET.w0
+    OR      State.PEPPER1_GPIO1, State.PEPPER1_GPIO1, GState.GPIO1_SET.w1
+    AND     State_PEPPER1.GPIO01, State_PEPPER1.GPIO01, State_GPIO01.Masks
+    AND     r2.w0, State.PEPPER1_GPIO0, GState.GPIO0_CLR.w0
+    AND     r2.w2, State.PEPPER1_GPIO1, GState.GPIO1_CLR.w1
+    XOR     State_PEPPER1.GPIO01, State_PEPPER1.GPIO01, r2
+
+    // Add PEPPER1 stepper signals to SET and CLR masks for GPIO0 & GPIO1
+
+    OR      GState.GPIO0_SET.w0, GState.GPIO0_SET.w0, State.PEPPER1_GPIO0 // merge bits to be set
+    OR      GState.GPIO1_SET.w1, GState.GPIO1_SET.w1, State.PEPPER1_GPIO1 //
+    XOR     r2, State_PEPPER1.GPIO01, State_GPIO01.Masks                  // find bits to clear
+    OR      GState.GPIO0_CLR.w0, GState.GPIO0_CLR.w0, r2.w0               // merge bits to be cleared
+    OR      GState.GPIO1_CLR.w1, GState.GPIO1_CLR.w1, r2.w2               //
+      
+    XOUT    10, State_PEPPER1.GPIO01, SIZE( State_PEPPER1)  // update GPIO0 & GPIO1 state on scratchpad
+
+#endif
+   
     // Debugging:
     // Task_DataY indicates we had a real-time error, or the timer tick
     // occurred before we began waiting for it!
@@ -99,11 +168,46 @@ WAITLOOP:
     // The timer just ticked...
     // ...write out the pre-computed output bits:
     MOV     r30, GState.PRU_Out
+
+#ifdef DECAMUX   
+
+    SBBO    GState.GPIO0_CLR, State.GPIO0_CLR_ADDR, 0, 8    // Writes both CLR and SET registers
+    SBBO    GState.GPIO1_CLR, State.GPIO1_CLR_ADDR, 0, 8    // Writes both CLR and SET registers
+//    SBBO    GState.GPIO2_CLR, State.GPIO2_CLR_ADDR, 0, 8    // Writes both CLR and SET registers
+//    SBBO    GState.GPIO3_CLR, State.GPIO3_CLR_ADDR, 0, 8    // Writes both CLR and SET registers
+
+   
+    // Assert DECAMUX clock (GPIO1.28) after having set PEPPER #1 data
+    // This generates a rising edge on the DM_CLK signal that in its
+    // turn creates the enable for the latch on the DECAMUX that stores
+    // the signals for the first PEPPER.
+    SET     GState.GPIO1_SET, #28             // assert GPIO1.28 (DM_CLK)
+    SBBO    GState.GPIO1_SET, State.GPIO1_CLR_ADDR, 4, 4    // Write SET register
+
+// Quick hack for BeBoPr with two PEPPER drivers for 10 axes:
+// Use output definitions from GPIO2 and GPIO3 for second PEPPER
+// i.e. these map to GPIO0 and GPIO1 respectively.
+
+    // Calculate new state for PEPPER #2 stepper signals
+
+    OR      State.PEPPER2_GPIO0, State.PEPPER2_GPIO0, GState.GPIO2_SET.w0
+    OR      State.PEPPER2_GPIO1, State.PEPPER2_GPIO1, GState.GPIO3_SET.w1
+    AND     State_PEPPER2.GPIO01, State_PEPPER2.GPIO01, State_GPIO01.Masks
+    AND     r2.w0, State.PEPPER2_GPIO0, GState.GPIO2_CLR.w0
+    AND     r2.w2, State.PEPPER2_GPIO1, GState.GPIO3_CLR.w1
+    XOR     State_PEPPER2.GPIO01, State_PEPPER2.GPIO01, r2
+
+    XOUT    10, State_PEPPER2.GPIO01, SIZE( State_PEPPER2)  // update GPIO0 & GPIO1 state on scratchpad
+
+#else
+
     SBBO    GState.GPIO0_CLR, State.GPIO0_CLR_ADDR, 0, 8    // Writes both CLR and SET registers
     SBBO    GState.GPIO1_CLR, State.GPIO1_CLR_ADDR, 0, 8    // Writes both CLR and SET registers
     SBBO    GState.GPIO2_CLR, State.GPIO2_CLR_ADDR, 0, 8    // Writes both CLR and SET registers
     SBBO    GState.GPIO3_CLR, State.GPIO3_CLR_ADDR, 0, 8    // Writes both CLR and SET registers
 
+#endif
+   
     // Clear the GPIO set/clear registers
     ZERO    &GState.GPIO0_Clr, OFFSET(GState.PRU_Out) - OFFSET(GState.GPIO0_Clr)
 


### PR DESCRIPTION
Merges changes to the PRU code, PEPPER driver and BeBoPr++ configs from [Bas's proof-of-concept code](https://github.com/modmaker/machinekit/tree/feature/poc-decamux) to allow support for using 10 axes using a DECAMUX.

This has been tested with a lone PEPPER (default 5 axis config), with a single PEPPER through a DECAMUX (default 5 axis config) and two PEPPERs through a DECAMUX (added 9 axis config). Other configs have not been tested due to lack of hardware. The PEPPER module was modified to require a variable "count" while loading, so existing configs will need to add "count=1" when loading.

Note that while the BeBoPr++ will generally work with default overlays, for DECAMUX support it will not. The overlay "cape-bebopr-brdg" must be disabled in uEnv.txt, and before running AXIS the file configs\ARM\BeagleBone\BeBoPr++\dtc.sh must be run to generate the correct overlays.

Many thanks to Bas for writing this code; I've merely provided this code merge.