### PR TITLE
Change PRU binary designation for DECAMUX support

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.ini
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.ini
@@ -2,7 +2,7 @@
 DRIVER=hal_pru_generic
 #CONFIG=pru=1 num_stepgens=5 num_pwmgens=3 disabled=1
 CONFIG=pru=1 num_stepgens=9 num_pwmgens=3 disabled=0
-PRUBIN=xenomai/pru_generic.bin
+PRUBIN=xenomai/pru_decamux.bin
 
 [PEPPER]
 # depending on this setting, changes are permanently stored in PEPPER's EEPROM


### PR DESCRIPTION
A further addition to #580, just changes the .ini to designate the correct PRU binary when using a DECAMUX with two PEPPERs.