### PR TITLE
Halmutex macro

### DIFF
--- a/src/hal/lib/hal_instance.c
+++ b/src/hal/lib/hal_instance.c
@@ -16,10 +16,12 @@ int hal_inst_create(const char *name, const int comp_id, const int size,
     CHECK_STR(name);
 
     {
-	hal_inst_t *inst  __attribute__((cleanup(halpr_autorelease_mutex)));
+
+	WITH_HAL_MUTEX();
+
+	hal_inst_t *inst;
 	hal_comp_t *comp;
 	void *m = NULL;
-	rtapi_mutex_get(&(hal_data->mutex));
 
 	// comp must exist
 	if ((comp = halpr_find_comp_by_id(comp_id)) == 0) {
@@ -78,8 +80,9 @@ int hal_inst_delete(const char *name)
     CHECK_STR(name);
 
     {
-	hal_inst_t *inst  __attribute__((cleanup(halpr_autorelease_mutex)));
-	rtapi_mutex_get(&(hal_data->mutex));
+	WITH_HAL_MUTEX();
+
+	hal_inst_t *inst;
 
 	// inst must exist
 	if ((inst = halpr_find_inst_by_name(name)) == NULL) {

--- a/src/hal/lib/hal_priv.h
+++ b/src/hal/lib/hal_priv.h
@@ -632,6 +632,26 @@ hal_funct_t *halpr_find_funct_by_owner_id(const int owner_id, hal_funct_t * star
 // NB: make sure the mutex is actually held in the using code when leaving scope!
 void halpr_autorelease_mutex(void *variable);
 
+
+// scope protection macro for simplified usage
+// use like so:
+// { // begin criticial region
+//    WITH_HAL_MUTEX();
+//    .. in criticial region
+//    any scope exit will release the HAL mutex
+// }
+#ifndef __PASTE
+#define __PASTE(a,b)	a##b
+#endif
+#define _WITH_HAL_MUTEX(unique)						\
+    int __PASTE(__scope_protector_,unique)				\
+	 __attribute__((cleanup(halpr_autorelease_mutex)));		\
+	 rtapi_mutex_get(&(hal_data->mutex));
+
+#define WITH_HAL_MUTEX() _WITH_HAL_MUTEX(__LINE__)
+
+
+
 /** The 'shmalloc_xx()' functions allocate blocks of shared memory.
     Each function allocates a block that is 'size' bytes long.
     If 'size' is 3 or more, the block is aligned on a 4 byte


### PR DESCRIPTION
Intended to simplify critical region coding. 

The full story is at: https://github.com/mhaberler/asciidoc-sandbox/wiki/Locking-and-using-scoped-locks-with-the-HAL-C-API (needs to go to the yet-unwritten HAL manual )