### PR TITLE
Use hostnames in service announcement

### DIFF
--- a/lib/python/machinekit/service.py
+++ b/lib/python/machinekit/service.py
@@ -10,7 +10,7 @@ class ZeroconfService:
     """
 
     def __init__(self, name, port, stype="_http._tcp", subtype=None,
-                 domain="", host="", text=""):
+                 domain="", host="", text="", loopback=False):
         self.name = name
         self.stype = stype
         self.domain = domain
@@ -18,21 +18,27 @@ class ZeroconfService:
         self.port = port
         self.text = text
         self.subtype = subtype
+        self.loopback = loopback
+        self.group = None
 
     def publish(self):
         bus = dbus.SystemBus()
         server = dbus.Interface(
-                         bus.get_object(
-                                 avahi.DBUS_NAME,
-                                 avahi.DBUS_PATH_SERVER),
-                        avahi.DBUS_INTERFACE_SERVER)
+            bus.get_object(
+                avahi.DBUS_NAME,
+                avahi.DBUS_PATH_SERVER),
+            avahi.DBUS_INTERFACE_SERVER)
 
         g = dbus.Interface(
-                    bus.get_object(avahi.DBUS_NAME,
-                                   server.EntryGroupNew()),
-                    avahi.DBUS_INTERFACE_ENTRY_GROUP)
+            bus.get_object(avahi.DBUS_NAME,
+                           server.EntryGroupNew()),
+            avahi.DBUS_INTERFACE_ENTRY_GROUP)
 
-        g.AddService(avahi.IF_UNSPEC, avahi.PROTO_UNSPEC, dbus.UInt32(0),
+        iface = avahi.IF_UNSPEC
+        if self.loopback:
+            iface = 0
+
+        g.AddService(iface, avahi.PROTO_UNSPEC, dbus.UInt32(0),
                      self.name, self.stype, self.domain, self.host,
                      dbus.UInt16(self.port), self.text)
 
@@ -54,23 +60,24 @@ class Service:
     """A simple class to publish a Machinekit network service using zeroconf.
     """
 
-    def __init__(self, type, svcUuid, dsn, port, name=None, ip=None,
-                debug=False):
+    def __init__(self, type, svcUuid, dsn, port, name=None, host=None,
+                loopback=False, debug=False):
         self.dsn = dsn
         self.svcUuid = svcUuid
         self.type = type
         self.port = port
         self.name = name
-        self.ip = ip
+        self.host = host
+        self.loopback = loopback
         self.debug = debug
 
         self.stype = '_machinekit._tcp'
-        self.subtype = '_' + self.type + '._sub.' + self.stype
+        self.subtype = '_%s._sub.%s' % (self.type, self.stype)
 
         if name is None:
             pid = os.getpid()
-            self.name = self.type.title() \
-            + ' on ' + self.ip + ' pid ' + str(pid)
+            self.name = '%s on %s pid %i' % \
+                        (self.type.title(), self.host, pid)
 
         me = uuid.uuid1()
         self.statusTxtrec = [str('dsn=' + self.dsn),
@@ -87,7 +94,8 @@ class Service:
         self.statusService = ZeroconfService(self.name, self.port,
                                             stype=self.stype,
                                             subtype=self.subtype,
-                                            text=self.statusTxtrec)
+                                            text=self.statusTxtrec,
+                                            loopback=self.loopback)
 
     def publish(self):
         self.statusService.publish()

--- a/src/machinetalk/haltalk/haltalk.hh
+++ b/src/machinetalk/haltalk/haltalk.hh
@@ -162,7 +162,7 @@ typedef struct htself {
 
     void       *z_halrcmd;
     const char *z_halrcmd_dsn;
-    int        z_halrcomp_port;
+    int        z_halrcmd_port;
     itemmap_t  items;
 
     htbridge_t *bridge;

--- a/src/machinetalk/haltalk/haltalk_main.cc
+++ b/src/machinetalk/haltalk/haltalk_main.cc
@@ -199,8 +199,8 @@ zmq_init(htself_t *self)
     zsocket_set_linger (self->z_halrcmd, 0);
     zsocket_set_identity (self->z_halrcmd, self->cfg->modname);
 
-    self->z_halrcomp_port = zsocket_bind(self->z_halrcmd, self->cfg->command);
-    assert (self->z_halrcomp_port > -1);
+    self->z_halrcmd_port = zsocket_bind(self->z_halrcmd, self->cfg->command);
+    assert (self->z_halrcmd_port > -1);
     self->z_halrcmd_dsn = zsocket_last_endpoint (self->z_halrcmd);
 
     rtapi_print_msg(RTAPI_MSG_DBG, "%s: talking HALComannd on '%s'",

--- a/src/machinetalk/haltalk/haltalk_zeroconf.cc
+++ b/src/machinetalk/haltalk/haltalk_zeroconf.cc
@@ -23,46 +23,71 @@ int
 ht_zeroconf_announce(htself_t *self)
 {
     char name[LINELEN];
+    char hostname[PATH_MAX];
+    char uri[PATH_MAX];
     char puuid[40];
     uuid_unparse(self->process_uuid, puuid);
 
-    snprintf(name,sizeof(name), "HAL Group service on %s pid %d", self->cfg->ipaddr, getpid());
+    if (gethostname(hostname, sizeof(hostname)) < 0) {
+	syslog_async(LOG_ERR, "%s: gethostname() failed ?! %s\n",
+		     self->cfg->progname, strerror(errno));
+	return -1;
+    }
+
+    // use mDNS addressing if running over TCP:
+    // construct a URI of the form 'tcp://<hostname>.local.:<portnumber>'
+
+    if (self->cfg->remote)
+	snprintf(uri,sizeof(uri), "tcp://%s.local.:%d",hostname, self->z_group_port);
+
+    snprintf(name,sizeof(name), "HAL Group service on %s.local pid %d", hostname, getpid());
     self->halgroup_publisher = zeroconf_service_announce(name,
-						      MACHINEKIT_DNSSD_SERVICE_TYPE,
-						      HALGROUP_DNSSD_SUBTYPE,
-						      self->z_group_port,
-						      (char *)self->z_halgroup_dsn,
-						      self->cfg->service_uuid,
-						      puuid,
-						      "halgroup", NULL,
-						      self->av_loop);
+							 MACHINEKIT_DNSSD_SERVICE_TYPE,
+							 HALGROUP_DNSSD_SUBTYPE,
+							 self->z_group_port,
+							 self->cfg->remote ? uri :
+							 (char *)self->z_halgroup_dsn,
+							 self->cfg->service_uuid,
+							 puuid,
+							 "halgroup", NULL,
+							 self->av_loop);
     if (self->halgroup_publisher == NULL) {
 	syslog_async(LOG_ERR, "%s: failed to start zeroconf HAL Group publisher\n",
 		     self->cfg->progname);
 	return -1;
     }
 
-    snprintf(name,sizeof(name), "HAL Rcomp service on %s pid %d", self->cfg->ipaddr, getpid());
+    snprintf(name,sizeof(name), "HAL Rcomp service on %s.local pid %d", hostname, getpid());
+
+    if (self->cfg->remote)
+	snprintf(uri,sizeof(uri), "tcp://%s.local.:%d",hostname, self->z_rcomp_port);
+
     self->halrcomp_publisher = zeroconf_service_announce(name,
-						      MACHINEKIT_DNSSD_SERVICE_TYPE,
-						      HALRCOMP_DNSSD_SUBTYPE,
-						      self->z_rcomp_port,
-						      (char *)self->z_halrcomp_dsn,
-						      self->cfg->service_uuid,
-						      puuid,
-						      "halrcomp", NULL,
-						      self->av_loop);
+							 MACHINEKIT_DNSSD_SERVICE_TYPE,
+							 HALRCOMP_DNSSD_SUBTYPE,
+							 self->z_rcomp_port,
+							 self->cfg->remote ? uri :
+							 (char *)self->z_halrcomp_dsn,
+							 self->cfg->service_uuid,
+							 puuid,
+							 "halrcomp", NULL,
+							 self->av_loop);
     if (self->halrcomp_publisher == NULL) {
 	syslog_async(LOG_ERR, "%s: failed to start zeroconf HAL Rcomp publisher\n",
 		     self->cfg->progname);
 	return -1;
     }
 
-    snprintf(name,sizeof(name),  "HAL Rcommand service on %s pid %d", self->cfg->ipaddr, getpid());
+    snprintf(name,sizeof(name),  "HAL Rcommand service on %s.local pid %d", hostname, getpid());
+
+    if (self->cfg->remote)
+	snprintf(uri,sizeof(uri), "tcp://%s.local.:%d",hostname, self->z_rcomp_port);
+
     self->halrcmd_publisher = zeroconf_service_announce(name,
 							MACHINEKIT_DNSSD_SERVICE_TYPE,
 							HALRCMD_DNSSD_SUBTYPE,
-							self->z_halrcomp_port,
+							self->z_halrcmd_port,
+							self->cfg->remote ? uri :
 							(char *)self->z_halrcmd_dsn,
 							self->cfg->service_uuid,
 							puuid,

--- a/src/machinetalk/webtalk/webtalk_zeroconf.cc
+++ b/src/machinetalk/webtalk/webtalk_zeroconf.cc
@@ -25,12 +25,19 @@ wt_zeroconf_announce(wtself_t *self)
     char name[255];
     char dsn[255];
     char puuid[40];
+    char hostname[PATH_MAX];
+
     uuid_unparse(self->process_uuid, puuid);
 
-    snprintf(name,sizeof(name), "Machinekit on %s", self->cfg->ipaddr);
-    snprintf(dsn,sizeof(dsn), "http%s://%s:%d%s",
+    if (gethostname(hostname, sizeof(hostname)) < 0) {
+	syslog_async(LOG_ERR, "%s: gethostname() failed ?! %s\n",
+		     self->cfg->progname, strerror(errno));
+	return -1;
+    }
+    snprintf(name,sizeof(name), "Machinekit on %s.local", hostname);
+    snprintf(dsn, sizeof(dsn), "http%s://%s.local.:%d%s",
 	     self->cfg->use_ssl ? "s" : "",
-	     self->cfg->ipaddr,
+	     hostname,
 	     self->cfg->info.port,
 	     self->cfg->index_html);
 


### PR DESCRIPTION
This patch fixes a problematic behaviour of machinetalk announcing local ip addresses. Using the local hostname the address can be resolved correctly (IPv4 or IPv6). This approach is similar to what network printers do.