### PR TITLE
python/machinekit/hal: renamed new_sig to newsig

### DIFF
--- a/nosetests/test_netcmd.py
+++ b/nosetests/test_netcmd.py
@@ -29,7 +29,7 @@ def test_component_creation():
     c2.ready()
 
 def test_net_existing_signal_with_bad_type():
-    hal.new_sig("f", hal.HAL_FLOAT)
+    hal.newsig("f", hal.HAL_FLOAT)
     try:
         hal.net("f", "c1.s32out")
         raise "should not happen"
@@ -54,13 +54,13 @@ def test_net_pin2pin():
 
 
 def test_net_existing_signal():
-    hal.new_sig("s32", hal.HAL_S32)
+    hal.newsig("s32", hal.HAL_S32)
 
     assert hal.pins["c1.s32out"].linked == False
     hal.net("s32", "c1.s32out")
     assert hal.pins["c1.s32out"].linked == True
 
-    hal.new_sig("s32too", hal.HAL_S32)
+    hal.newsig("s32too", hal.HAL_S32)
     try:
         hal.net("s32too", "c1.s32out")
         raise "should not happen"
@@ -69,28 +69,28 @@ def test_net_existing_signal():
 
     del hal.signals["s32"]
 
-def test_new_sig():
-    floatsig1 = hal.new_sig("floatsig1", hal.HAL_FLOAT)
+def test_newsig():
+    floatsig1 = hal.newsig("floatsig1", hal.HAL_FLOAT)
     try:
-        hal.new_sig("floatsig1", hal.HAL_FLOAT)
+        hal.newsig("floatsig1", hal.HAL_FLOAT)
         # RuntimeError: Failed to create signal floatsig1: HAL: ERROR: duplicate signal 'floatsig1'
         raise "should not happen"
     except RuntimeError:
         pass
     try:
-        hal.new_sig(32423 *32432, hal.HAL_FLOAT)
+        hal.newsig(32423 *32432, hal.HAL_FLOAT)
         raise "should not happen"
     except TypeError:
         pass
 
     try:
-        hal.new_sig(None, hal.HAL_FLOAT)
+        hal.newsig(None, hal.HAL_FLOAT)
         raise "should not happen"
     except TypeError:
         pass
 
     try:
-        hal.new_sig("badtype", 1234)
+        hal.newsig("badtype", 1234)
         raise "should not happen"
     except TypeError:
         pass

--- a/src/hal/cython/machinekit/hal_signal.pyx
+++ b/src/hal/cython/machinekit/hal_signal.pyx
@@ -177,6 +177,6 @@ cdef _new_sig(char *name, int type):
         raise TypeError("new_sig: %s - invalid type %d " % (name, type))
     return Signal(name, type)
 
-def new_sig(name,type):
+def newsig(name,type):
     _new_sig(name,type)
     return signals[name] # add to sigdict


### PR DESCRIPTION
this PR renames the `new_sig` function of the new HAL Python API to `newsig` to keep naming consistent with `halcmd` and other functions like `newthread` or `newpin`