### PR TITLE
configure.ac:  account for Debian multi-arch

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -604,8 +604,8 @@ AC_ARG_WITH(platform-pc,
 	esac
     ],
     [
-        case $host in
-	    (i?86-* | x86_64-*)
+        case $host_cpu in
+	    (i?86 | x86_64)
 	        TARGET_PLATFORM_PC=unk
 		;;
 	    (*)
@@ -633,8 +633,8 @@ AC_ARG_WITH(platform-beaglebone,
 	esac
     ],
     [
-        case $host in
-	    (armv7l-*)
+        case $host_cpu in
+	    (arm*)
 	        TARGET_PLATFORM_BEAGLEBONE=unk
 		;;
 	    (*)
@@ -662,8 +662,8 @@ AC_ARG_WITH(platform-raspberry,
 	esac
     ],
     [
-        case $host in
-	    (armv7l-*)
+        case $host_cpu in
+	    (arm*)
 	        TARGET_PLATFORM_RASPBERRY=unk
 		;;
 	    (*)
@@ -691,8 +691,8 @@ AC_ARG_WITH(platform-zedboard,
 	esac
     ],
     [
-        case $host in
-	    (armv7l-*)
+        case $host_cpu in
+	    (arm*)
 	        TARGET_PLATFORM_ZEDBOARD=unk
 		;;
 	    (*)


### PR DESCRIPTION
**MAINTAINERS**:  Please check the `d7-bb-pkg` build logs for the following lines before merging:
```
checking platform-pc... disabled for this architecture
checking platform-beaglebone... default enabled for this architecture
checking platform-raspberry... default enabled for this architecture
checking platform-zedboard... default enabled for this architecture
```

Thanks, @strahlex for pointing this out.

(Original commit message follows)
*****
When running `./configure` without `--host` and `--build`, the
`AC_CANONICAL_*` macros run `config.guess` to determine host and build
architectures.

Commit ccf3bc98b from #594 sets `--host` and `--build` to Debian
multi-arch names from variables defined in
`/usr/share/dpkg/architecture.mk` during package builds.

This exemplifies the difference:

    # ./config.guess
    armv7l-unknown-linux-gnueabihf
    # dpkg-architecture -qDEB_BUILD_MULTIARCH
    arm-linux-gnueabihf

This patch is a quick fix for platform detection errors in package
builds, and probably needs something more general in the future.