### PR TITLE
Machinetalk service fixes

### DIFF
--- a/lib/python/machinekit/service.py
+++ b/lib/python/machinekit/service.py
@@ -76,14 +76,14 @@ class Service:
 
         if name is None:
             pid = os.getpid()
-            self.name = '%s on %s pid %i' % \
+            self.name = '%s service on %s pid %i' % \
                         (self.type.title(), self.host, pid)
 
         me = uuid.uuid1()
         self.statusTxtrec = [str('dsn=' + self.dsn),
                              str('uuid=' + self.svcUuid),
-                             str('service=' + self.type),
-                             str('instance=' + str(me))]
+                             str('instance=' + str(me)),
+                             str('service=' + self.type)]
 
         if self.debug:
             print(('service: ' + 'dsname = ' + self.dsn +

--- a/lib/python/machinekit/service.py
+++ b/lib/python/machinekit/service.py
@@ -38,13 +38,13 @@ class ZeroconfService:
         if self.loopback:
             iface = 0
 
-        g.AddService(iface, avahi.PROTO_UNSPEC, dbus.UInt32(0),
+        g.AddService(iface, avahi.PROTO_INET, dbus.UInt32(0),
                      self.name, self.stype, self.domain, self.host,
                      dbus.UInt16(self.port), self.text)
 
         if self.subtype:
-            g.AddServiceSubtype(avahi.IF_UNSPEC,
-                                avahi.PROTO_UNSPEC,
+            g.AddServiceSubtype(iface,
+                                avahi.PROTO_INET,
                                 dbus.UInt32(0),
                                 self.name, self.stype, self.domain,
                                 self.subtype)

--- a/src/machinetalk/haltalk/haltalk_zeroconf.cc
+++ b/src/machinetalk/haltalk/haltalk_zeroconf.cc
@@ -81,7 +81,7 @@ ht_zeroconf_announce(htself_t *self)
     snprintf(name,sizeof(name),  "HAL Rcommand service on %s.local pid %d", hostname, getpid());
 
     if (self->cfg->remote)
-	snprintf(uri,sizeof(uri), "tcp://%s.local.:%d",hostname, self->z_rcomp_port);
+	snprintf(uri,sizeof(uri), "tcp://%s.local.:%d",hostname, self->z_halrcmd_port);
 
     self->halrcmd_publisher = zeroconf_service_announce(name,
 							MACHINEKIT_DNSSD_SERVICE_TYPE,
@@ -94,7 +94,7 @@ ht_zeroconf_announce(htself_t *self)
 							"halrcmd", NULL,
 							self->av_loop);
     if (self->halrcmd_publisher == NULL) {
-	syslog_async(LOG_ERR, "%s: failed to start zeroconf HAL Rcomp publisher\n",
+	syslog_async(LOG_ERR, "%s: failed to start zeroconf HAL Rcommand publisher\n",
 		     self->cfg->progname);
 	return -1;
     }


### PR DESCRIPTION
- fixes a problem introduced by https://github.com/machinekit/machinekit/commit/d0f446c2471d6174648a8f03d148f0ca633c0f7e
- keeps naming of service announcments consistent
- explicitely specifying protocol and interface for announcements