### PR TITLE
python/machinekit/rtapi: renamed use_fp parameter 

### DIFF
--- a/nosetests/test_ring.py
+++ b/nosetests/test_ring.py
@@ -32,7 +32,7 @@ def test_rtapi_connect():
 
 def test_loadrt_ringwrite():
     rt.loadrt("ringwrite","ring=ring1")
-    rt.newthread("servo-thread",1000000,use_fp=True)
+    rt.newthread("servo-thread",1000000,fp=True)
     hal.addf("ringwrite","servo-thread")
     hal.start_threads()
     time.sleep(1) # let rt thread write a bit to ring

--- a/nosetests/test_ringdemo.py
+++ b/nosetests/test_ringdemo.py
@@ -27,8 +27,8 @@ def test_runthread():
     cpe = hal.Pin("charge-pump.enable")
     cpe.set(0)
 
-    rt.newthread("fast",1000000, use_fp=True)
-    rt.newthread("slow",100000000, use_fp=True)
+    rt.newthread("fast",1000000, fp=True)
+    rt.newthread("slow",100000000, fp=True)
     hal.addf("ringread","fast")
     hal.addf("ringwrite","slow")
     hal.addf("charge-pump","slow")

--- a/nosetests/test_rtapi.py
+++ b/nosetests/test_rtapi.py
@@ -21,7 +21,7 @@ def test_rtapi_connect():
 def test_loadrt_or2():
     global rt
     rt.loadrt("or2")
-    rt.newthread("servo-thread",1000000,use_fp=True)
+    rt.newthread("servo-thread",1000000,fp=True)
     hal.addf("or2.0","servo-thread")
     hal.start_threads()
     time.sleep(0.2)

--- a/nosetests/unittest_or2.py
+++ b/nosetests/unittest_or2.py
@@ -16,7 +16,7 @@ class TestOr2(TestCase):
         self.uuid = self.cfg.get("MACHINEKIT", "MKUUID")
         self.rt = rtapi.RTAPIcommand(uuid=self.uuid)
         self.rt.loadrt("or2")
-        self.rt.newthread("servo-thread",1000000,use_fp=True)
+        self.rt.newthread("servo-thread",1000000,fp=True)
         hal.addf("or2.0","servo-thread")
         hal.start_threads()
 

--- a/src/hal/cython/machinekit/rtapi.pyx
+++ b/src/hal/cython/machinekit/rtapi.pyx
@@ -170,9 +170,9 @@ class RTAPIcommand:
         if r:
             raise RuntimeError("cant connect to rtapi: %s" % strerror(-r))
 
-    def newthread(self,char *name, int period, instance=0,use_fp=0,cpu=-1):
+    def newthread(self,char *name, int period, instance=0,fp=0,cpu=-1):
         cdef char *c_name = name
-        r = rtapi_newthread(instance, c_name, period, cpu, use_fp)
+        r = rtapi_newthread(instance, c_name, period, cpu, fp)
         if r:
             raise RuntimeError("rtapi_newthread failed:  %s" % strerror(-r))
 


### PR DESCRIPTION
to fp to keep the Python API consistent

halcmd's newthread function is called like `newthread name period fp` whereas the Cython function `newthread` had the paramter `use_fp`. To keep the API consistent I renamed the paramter to `fp`