### PR TITLE
Don't remove `machinekit.ini` during `make clean`

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -136,7 +136,7 @@ ifneq ($(wildcard src/configure src/Makefile.inc),)
 	    src/configure \
 	    src/machinekitcfg.py-tmp \
 	    tcl/linuxcnc.tcl
-	rm -rf src/autom4te.cache
+	rm -rf src/autom4te.cache etc
 endif
 
 #	# Remove package artifacts

--- a/src/Makefile
+++ b/src/Makefile
@@ -705,7 +705,8 @@ clean: depclean modclean
 	for flav in $(BUILD_THREAD_FLAVORS); do \
 	    rm -rf ../lib/$$flav; \
 	done
-	-rm -rf ../rtlib ../libexec ../etc
+	-rm -rf ../rtlib ../libexec
+	rm -f ../etc/linuxcnc/rtapi.ini
 	-rm -f $(COPY_CONFIGS)
 	-rm -f $(RTLIBDIR)/*.$(MODULE_EXT)
 	-rm -f hal/components/conv_*.comp


### PR DESCRIPTION
GNU coding standards say `make clean` shouldn't remove anything
generated by `./configure`.

This is a fixup for #600.  Fixes #621