### PR TITLE
emc/task/emctaskmain.cc: fix setuid() warn unused.

### DIFF
--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -348,7 +348,10 @@ int emcSystemCmd(char *s)
 	// convert string to argc/argv
 	argvize(s, buffer, argv, EMC_SYSTEM_CMD_LEN);
 	// drop any setuid privileges
-	setuid(getuid());
+	if (setuid(getuid()) == -1) {
+	rcs_print("dropping setuid privileges failed: %s\n", strerror(errno));
+	exit(-1);
+	}
 	execvp(argv[0], argv);
 	// if we get here, we didn't exec
 	if (emc_debug & EMC_DEBUG_TASK_ISSUE) {


### PR DESCRIPTION
Just saw, that https://github.com/zultron/machinekit/commit/a5cbb53db4e6dcdb1be95f3d3e5773dd6e0edf60 adresses this, but my pr also prints the strerror.