### PR TITLE
machinetalk/mkwrapper: fix for file service not working on some interfaces

### DIFF
--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -89,7 +89,7 @@ class FileService(threading.Thread):
             self.directory = self.ini.find('DISPLAY', 'PROGRAM_PREFIX') or os.getcwd()
             self.directory = os.path.expanduser(self.directory)
         except linuxcnc.error as detail:
-            printError(detail)
+            printError(str(detail))
             sys.exit(1)
 
         self.filePort = getFreePort()
@@ -341,7 +341,7 @@ class LinuxCNCWrapper():
                 self.command.program_open(filePath)
 
         except linuxcnc.error as detail:
-            printError(detail)
+            printError(str(detail))
             sys.exit(1)
 
         if self.pingInterval > 0:
@@ -1839,7 +1839,7 @@ class LinuxCNCWrapper():
                         self.ping_error()
 
             except linuxcnc.error as detail:
-                printError("error", detail)
+                printError(str(detail))
                 self.stop()
 
             if (self.pingCount == self.pingRatio):

--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -118,7 +118,7 @@ class FileService(threading.Thread):
         self.handler.banner = "welcome to the GCode file service"
 
         # Instantiate FTP server class and listen on some address
-        self.address = (self.host, self.filePort)
+        self.address = ('', self.filePort)
         self.server = FTPServer(self.address, self.handler)
 
         # set a limit for connections


### PR DESCRIPTION
Binds the file service to all iterfaces as it should be done. Additionally fixes a problem with wrong usage of the printError function.