### PR TITLE
fix #634

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2930,11 +2930,11 @@ if test "$BUILD_PYTHON" = "yes"; then
     if test "$PYTHON_TCL_VERSION" != "$TCL_VERSION"; then
 	AC_MSG_RESULT([TCL mismatch: $TCL_VERSION vs $PYTHON_TCL_VERSION])
 	AC_MSG_ERROR([Python requires use of Tcl $PYTHON_TCL_VERSION and Tk $PYTHON_TK_VERSION.
-Install this version and specify --with-tclConfig and --with-tkConfig if necessary])
+Install this version and specify --with-tcl and --with-tk if necessary])
     fi
     if test "$PYTHON_TK_VERSION" != "$TK_VERSION"; then
 	AC_MSG_RESULT([Tk mismatch: $TK_VERSION vs $PYTHON_TK_VERSION])
-	AC_MSG_ERROR(["Python requires use of Tk $TK_VERSION.  Install this version and specify --with-tkConfig if necessary"])
+	AC_MSG_ERROR(["Python requires use of Tk $TK_VERSION.  Install this version and specify --with-tk if necessary"])
     fi
     AC_MSG_RESULT([$PYTHON_TK_VERSION])
 

--- a/src/m4/tcl.m4
+++ b/src/m4/tcl.m4
@@ -33,7 +33,7 @@ AC_DEFUN([SC_PATH_TCLCONFIG], [
 	# we reset no_tcl in case something fails here
 	no_tcl=true
 	AC_ARG_WITH(tcl,
-	    AC_HELP_STRING([--with-tcl],
+	    AC_HELP_STRING([--with-tcl=DIR],
 		[directory containing tcl configuration (tclConfig.sh)]),
 	    with_tclconfig="${withval}")
 	AC_MSG_CHECKING([for Tcl configuration])
@@ -165,7 +165,7 @@ AC_DEFUN([SC_PATH_TKCONFIG], [
 	# we reset no_tk in case something fails here
 	no_tk=true
 	AC_ARG_WITH(tk,
-	    AC_HELP_STRING([--with-tk],
+	    AC_HELP_STRING([--with-tk=DIR],
 		[directory containing tk configuration (tkConfig.sh)]),
 	    with_tkconfig="${withval}")
 	AC_MSG_CHECKING([for Tk configuration])


### PR DESCRIPTION
…stent

configure.ac was generating error messages referring to nonexistent
"--with-tclConfig" and "--with-tkConfig" options.
tcl.m4 was generating help messages missing required =DIR