### PR TITLE
configure.ac:  accommodate ShabbyX-style rtai-config

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1561,7 +1561,14 @@ if test "$with_rtai_kernel" != no; then
         # a configured kernel source directory with .config file
 	AC_MSG_CHECKING([usability of RTAI utility, $RTAI_KERNEL_THREADS_RTS])
 	if test -x $RTAI_KERNEL_THREADS_RTS -a \
-	    -f $($RTAI_KERNEL_THREADS_RTS --linux-dir 2>/dev/null)/.config; then
+	     -f $($RTAI_KERNEL_THREADS_RTS -o --linux-dir 2>/dev/null)/.config
+	then
+	    # ShabbyX-style `rtai-config`
+	    RTAI_KERNEL_THREADS_RTS="$RTAI_KERNEL_THREADS_RTS -o"
+	    AC_MSG_RESULT(yes)
+	elif test -x $RTAI_KERNEL_THREADS_RTS -a \
+	     -f $($RTAI_KERNEL_THREADS_RTS --linux-dir 2>/dev/null)/.config
+	then
 	    AC_MSG_RESULT(yes)
 	else
 	    RTAI_KERNEL_THREADS_RTS=''


### PR DESCRIPTION
The ShabbyX RTAI fork has a stub `rtai-config` script that detects (possibly multiple) installed RTAI versions and provides a way to select between them.

This patch checks for that style script if it exists, and otherwise assumes the old behavior.

A little bait for Maintainers:  once this is merged, I have a full set of Jessie packages to push out for testing!