### PR TITLE
Misc fixes

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -135,7 +135,7 @@ do_xenomai_kernel() {
     echo "debian/control:  Added Xenomai kernel threads ${KVER}" >&2
     echo "                 with Build-Depends:" >&2
     echo "    libxenomai-dev" >&2
-    rules_enable_threads xenomai_kernel
+    rules_enable_threads xenomai-kernel
     XENOMAI_KERNEL_HEADERS+=" ${KVER}"
     HAVE_FLAVOR=true
 }
@@ -159,7 +159,7 @@ do_rtai_kernel() {
     echo "debian/control:  Added RTAI kernel threads ${KVER}" >&2
     echo "                 with Build-Depends:" >&2
     echo "    librtai-dev" >&2
-    rules_enable_threads rtai_kernel
+    rules_enable_threads rtai-kernel
     RTAI_KERNEL_HEADERS+=" ${KVER}"
     HAVE_FLAVOR=true
 }

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1283,14 +1283,14 @@ AC_ARG_WITH(rt-preempt,
 AC_ARG_WITH(xenomai,
     [AS_HELP_STRING([--with-xenomai],
         [build Xenomai userland threads])],
-    [xenomai_from_cmdline=yes
+    [xenomai_from_cmdline=$withval
      test $withval = yes && all_flavors_default=no],
     [with_xenomai=check])
 
 AC_ARG_WITH(xenomai-kernel,
     [AS_HELP_STRING([--with-xenomai-kernel],
         [build Xenomai kernel-space realtime threads (deprecated)])],
-    [xenomai_from_cmdline=yes
+    [xenomai_kernel_from_cmdline=$withval
      test $withval = yes && all_flavors_default=no],
     [with_xenomai_kernel=check])
 # XENOMAI_THREADS_RTS:  locate the 'xeno-config' executable
@@ -1485,8 +1485,11 @@ test -z "$XENOMAI_THREADS_RTS" && with_xenomai=no
 if test $with_xenomai = yes; then
     BUILD_THREAD_FLAVORS="$BUILD_THREAD_FLAVORS xenomai"
     with_userland_rt_threads=yes
+elif test "$xenomai_from_cmdline" = yes; then
+    AC_MSG_ERROR([Requested '--with-xenomai', but unable to configure])
 fi
 AC_MSG_RESULT($with_xenomai)
+
 
 AC_MSG_CHECKING(whether to build Xenomai kernel threads)
 if test "$with_xenomai_kernel" = check; then
@@ -1500,6 +1503,8 @@ test -z "$xenomai_kernels" && with_xenomai_kernel=no
 test -z "$XENOMAI_THREADS_RTS" && with_xenomai_kernel=no
 if test $with_xenomai_kernel = yes; then
      BUILD_THREAD_FLAVORS="$BUILD_THREAD_FLAVORS xenomai-kernel"
+elif test "$xenomai_kernel_from_cmdline" = yes; then
+    AC_MSG_ERROR([Requested '--with-xenomai-kernel', but unable to configure])
 fi
 AC_MSG_RESULT($with_xenomai_kernel)
 

--- a/src/hal/lib/hal_lib.c
+++ b/src/hal/lib/hal_lib.c
@@ -251,7 +251,7 @@ void hal_print_msg(int level, const char *fmt, ...)
     va_list args;
     va_start(args, fmt);
 
-    vsnprintf(_hal_errmsg, HALPRINTBUFFERLEN, fmt, args);
+    rtapi_vsnprintf(_hal_errmsg, HALPRINTBUFFERLEN, fmt, args);
     rtapi_print_msg(level, _hal_errmsg);
     va_end(args);
 }
@@ -263,7 +263,8 @@ void hal_print_error(const char *fmt, ...)
     const char *prefix = "HAL error: ";
     strncpy(_hal_errmsg, prefix, sizeof(_hal_errmsg));
 
-    vsnprintf(_hal_errmsg + strlen(_hal_errmsg), HALPRINTBUFFERLEN, fmt, args);
+    rtapi_vsnprintf(_hal_errmsg + strlen(_hal_errmsg), HALPRINTBUFFERLEN,
+		    fmt, args);
     rtapi_print_msg(RTAPI_MSG_ERR, _hal_errmsg);
     va_end(args);
 }


### PR DESCRIPTION
A few random fixes that prepare for Xenomai-3 and newer kernels, but don't really belong in such a PR.

- Packaging:  Fix kthreads specification
- `configure.ac`:  Fail if `--with-xenomai[-kernel]` requested but unconfigurable
- `hal_lib`:  Convert a couple of `vsnprintf` statements to `rtapi_vsnprintf`
