### PR TITLE
Xenomai 3, RTAI 4.1, Linux >=3.10 updates

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1088,10 +1088,10 @@ check_rtai_kernel_source() {
 
 
     # look for rt_daemonize (older RTAI) or rtai_irq_handler (at least
-    # RTAI 4.0.0+) function definition
+    # RTAI 4.0) or rtai_syscall_hook (RTAI 4.1) function definition
     AC_MSG_CHECKING(if $ksrc_dir is an RTAI kernel)
     if test -f "$ksrc_dir/Module.symvers" && \
-            grep -q '\(rt_daemonize\|rtai_irq_handler\)' \
+            grep -q '\(rt_daemonize\|rtai_irq_handler\|rtai_syscall_hook\)' \
             "$ksrc_dir/Module.symvers"; then
         AC_MSG_RESULT([yes])
         return 0
@@ -1603,6 +1603,17 @@ if test $with_rtai_kernel = yes; then
     BUILD_THREAD_FLAVORS="$BUILD_THREAD_FLAVORS rtai-kernel"
 fi
 AC_MSG_RESULT($with_rtai_kernel)
+if test $with_rtai_kernel = yes; then
+    AC_MSG_CHECKING(RTAI version)
+    if grep -q rt_free_timers $RTAI_KERNEL_THREADS_EXTRA_SYMBOLS; then
+        RTAI_VERSION=401
+	AC_MSG_RESULT(4.1 or greater)
+    else
+        RTAI_VERSION=400
+	AC_MSG_RESULT(4.0 or earlier)
+    fi
+fi
+
 ##############################################################################
 # Subsection 2.6                                                             #
 # Hardware driver detection                                                  #
@@ -1887,6 +1898,9 @@ AC_SUBST([RTAI_KERNEL_THREADS_KERNEL_MATH_CFLAGS])
 AC_SUBST([RTAI_KERNEL_THREADS_RTDIR],[$RTAI_KERNEL_THREADS_RTDIR])
 AC_SUBST([RTAI_KERNEL_THREADS_EXTRA_KMODS],
 	"_cfg_flavor_extra_kmods(rtai-kernel)")
+if test -n "$RTAI_VERSION"; then
+    AC_DEFINE_UNQUOTED([RTAI_VERSION],$RTAI_VERSION,"RTAI version")
+fi
 
 
 # while we are at it, drop a git scent mark

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1396,11 +1396,22 @@ if test "$with_xenomai" != no -o "$with_xenomai_kernel" != no; then
         # the variable; then --ldflags should return something
         # containing the string '-lnative'
 	AC_MSG_CHECKING([usability of xenomai utility, $XENOMAI_THREADS_RTS])
-	if test -x $XENOMAI_THREADS_RTS -a \
-	    -n "$($XENOMAI_THREADS_RTS --skin=native --ldflags 2>/dev/null | \
-	        grep .lnative)"; then
-	    XENOMAI_THREADS_RTS="$XENOMAI_THREADS_RTS --skin=native"
-	    AC_MSG_RESULT(yes)
+	if test -x $XENOMAI_THREADS_RTS; then
+	    # Check for Xenomai v.2 or v.3
+	    case $(xeno-config --version) in
+	        2.*)
+		    XENOMAI_SKIN=native
+		    XENOMAI_V2=true
+		    AC_MSG_RESULT(yes (v2))
+		    ;;
+		3.*)
+		    XENOMAI_SKIN=alchemy
+		    XENOMAI_V2=false
+		    with_xenomai_kernel=no  # No more xenomai kthreads in v3
+		    AC_MSG_RESULT(yes (v3))
+		    ;;
+	    esac
+	    XENOMAI_THREADS_RTS="$XENOMAI_THREADS_RTS --skin=$XENOMAI_SKIN"
 	else
 	    XENOMAI_THREADS_RTS=''
 	    AC_MSG_RESULT(no)
@@ -1424,35 +1435,25 @@ if test "$with_xenomai" != no -o "$with_xenomai_kernel" != no; then
 	XENOMAI_KERNEL_THREADS_RTS="$XENOMAI_THREADS_RTS"
     fi
 fi
-# XENOMAI_THREADS_RTFLAGS:  test runtime library & get flags
+
 if test -n "$XENOMAI_THREADS_RTS"; then
-    AC_MSG_CHECKING(Xenomai runtime library)
-    CFLAGS_hold=$CFLAGS
-    CFLAGS="$CFLAGS "`$XENOMAI_THREADS_RTS --cflags`
-    LIBS_hold=$LIBS
-    LIBS="$LIBS "`$XENOMAI_THREADS_RTS --ldflags`
-    AC_LINK_IFELSE([AC_LANG_PROGRAM(
-    [[
-	#include <native/task.h>
-	#include <native/timer.h>
-	RT_TASK demo_task;
-	RTIME now;
-    ]],
-    [[
-	rt_task_create(&demo_task, "trivial", 0, 99, 0);
-	rt_task_set_periodic(NULL, TM_NOW, 1000000000);
-	rt_timer_read();
-    ]])],
-    [AC_MSG_RESULT(works)],
-    [
-	AC_MSG_RESULT(failed)
-	with_xenomai=no
-	with_xenomai_kernel=no
-    ])
-    LIBS=$LIBS_hold
-    CFLAGS=$CFLAGS_hold
+    # XENOMAI_THREADS_RTFLAGS:  test runtime library & get flags
+    LIBS_hold="$LIBS"
+    CFLAGS_hold="$CFLAGS"
+    CPPFLAGS_hold="$CPPFLAGS"
+    LIBS="$LIBS $($XENOMAI_THREADS_RTS --ldflags)"
+    CFLAGS="$CFLAGS $($XENOMAI_THREADS_RTS --cflags)"
+    CPPFLAGS="$CPPFLAGS $($XENOMAI_THREADS_RTS --cflags)"
+    AC_CHECK_LIB($XENOMAI_SKIN, rt_task_create,,
+        with_xenomai=no; with_xenomai_kernel=no)
+    AC_CHECK_HEADER($XENOMAI_SKIN/task.h,,
+        with_xenomai=no; with_xenomai_kernel=no)
+    LIBS="$LIBS_hold"
+    CFLAGS="$CFLAGS_hold"
+    CPPFLAGS="$CPPFLAGS_hold"
+fi
 
-
+if test "$with_xenomai" != no -o "$with_xenomai_kernel" != no; then
     flags="$($XENOMAI_THREADS_RTS --cflags)"
     # Xenomai docs recommend turning off CONFIG_CC_STACKPROTECTOR
     # on all arches but x86_64; this causes missing symbols without
@@ -1474,7 +1475,7 @@ if test -n "$XENOMAI_THREADS_RTS"; then
     fi
     XENOMAI_KERNEL_THREADS_KERNEL_MATH_CFLAGS="$flags"
     # ldflags
-    flags="$($XENOMAI_THREADS_RTS --ldflags) -lrtdm"
+    flags="$($XENOMAI_THREADS_RTS --ldflags)"
     XENOMAI_THREADS_LDFLAGS="$XENOMAI_THREADS_LDFLAGS $flags"
     XENOMAI_KERNEL_THREADS_LDFLAGS="$XENOMAI_KERNEL_THREADS_LDFLAGS $flags"
 fi
@@ -1507,37 +1508,6 @@ elif test "$xenomai_kernel_from_cmdline" = yes; then
     AC_MSG_ERROR([Requested '--with-xenomai-kernel', but unable to configure])
 fi
 AC_MSG_RESULT($with_xenomai_kernel)
-
-# check whether the gcc-multilib problem exists
-# see http://gcc.gnu.org/ml/gcc/2012-02/msg00314.html
-if test $with_xenomai_kernel = yes -a -x /usr/bin/lsb_release &&
-    test "$(lsb_release -cs)" = precise; then
-    CFLAGS_save="$CFLAGS"
-    CFLAGS="-nostdinc -I/usr/include"
-    MULTILIB_HACK="/usr/include/$(gcc -print-multiarch)"
-    AC_MSG_CHECKING(for the precise multilib bug)
-    AC_COMPILE_IFELSE(
-        [ AC_LANG_PROGRAM([[#include "math.h"]],[]) ],
-	[
-	    PRECISE_MULTILIB_BUG=""
-	    AC_MSG_RESULT(not found)
-	],
-	[
-	    export C_INCLUDE_PATH=$MULTILIB_HACK
-	    AC_COMPILE_IFELSE(
-		[
-		    AC_LANG_PROGRAM([[#include "math.h"]],[])
-		],
-		[
-		    PRECISE_MULTILIB_BUG="C_INCLUDE_PATH=$MULTILIB_HACK"
-		    AC_MSG_RESULT(found)
-		],
-		AC_MSG_ERROR([unexpected result checking "math.h"]))
-	    unset C_INCLUDE_PATH
-	]
-    )
-    CFLAGS="$CFLAGS_save"
-fi
 
 
 ##############################################################################
@@ -1855,6 +1825,13 @@ AC_SUBST([RT_PREEMPT_THREADS_LDFLAGS])
 AC_SUBST([RT_PREEMPT_THREADS_RTDIR],[])
 AC_SUBST([RT_PREEMPT_THREADS_RTS],[])
 AC_SUBST([RT_PREEMPT_THREADS_EXTRA_KMODS],[])
+
+# Xenomai general settings
+if test "$XENOMAI_V2" = true; then
+    AC_DEFINE([XENOMAI_V2],[],[Xenomai v.2])
+fi
+AC_DEFINE_UNQUOTED([XENOMAI_SKIN],$XENOMAI_SKIN,
+	[Xenomai skin ('native' for v2, 'alchemy' for v3)])
 
 # Xenomai userland settings
 if test "$with_xenomai" = yes; then

--- a/src/hal/lib/hal_procfs.c
+++ b/src/hal/lib/hal_procfs.c
@@ -13,8 +13,35 @@
 #endif
 
 #ifdef CONFIG_PROC_FS
+#include <linux/version.h>
 #include <linux/proc_fs.h>
 #include <linux/string.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
+#else
+// proc_dir_entry is private in Linux 3.10+, so re-define it here
+struct proc_dir_entry {
+  unsigned int low_ino;
+  umode_t mode;
+  nlink_t nlink;
+  kuid_t uid;
+  kgid_t gid;
+  loff_t size;
+  const struct inode_operations *proc_iops;
+  const struct file_operations *proc_fops;
+  struct proc_dir_entry *next, *parent, *subdir;
+  void *data;
+  atomic_t count;         /* use count */
+  atomic_t in_use;        /* number of callers into module in progress; */
+  /* negative -> it's going away RSN */
+  struct completion *pde_unload_completion;
+  struct list_head pde_openers;   /* who did ->open, but not ->release */
+  spinlock_t pde_unload_lock; /* proc_fops checks and pde_users bumps */
+  u8 namelen;
+  char name[];
+};
+#endif
+
 extern struct proc_dir_entry *rtapi_dir;
 static struct proc_dir_entry *hal_dir = 0;
 static struct proc_dir_entry *hal_rtapicmd = 0;
@@ -103,15 +130,32 @@ void hal_proc_clean(void) {
     hal_dir = hal_rtapicmd = 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
+#else
+static const struct file_operations proc_file_fops = {
+ .write = proc_write_rtapicmd,
+};
+#endif
+
 int hal_proc_init(void) {
     if(!rtapi_dir) return 0;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     hal_dir = create_proc_entry("hal", S_IFDIR, rtapi_dir);
+#else
+    hal_dir = proc_create("hal", S_IFDIR, rtapi_dir, NULL);
+#endif
     if(!hal_dir) { hal_proc_clean(); return -1; }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     hal_rtapicmd = create_proc_entry("rtapicmd", 0666, hal_dir);
+#else
+    hal_rtapicmd = proc_create("rtapicmd", 0666, hal_dir, &proc_file_fops);
+#endif
     if(!hal_rtapicmd) { hal_proc_clean(); return -1; }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     hal_rtapicmd->data = NULL;
     hal_rtapicmd->read_proc = NULL;
     hal_rtapicmd->write_proc = proc_write_rtapicmd;
+#endif
     return 0;
 }
 #else

--- a/src/rtapi/procfs_macros.h
+++ b/src/rtapi/procfs_macros.h
@@ -1,77 +1,69 @@
-//    Copyright 2003 John Kasunich
-//
-//    This program is free software; you can redistribute it and/or modify
-//    it under the terms of the GNU General Public License as published by
-//    the Free Software Foundation; either version 2 of the License, or
-//    (at your option) any later version.
-//
-//    This program is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//    GNU General Public License for more details.
-//
-//    You should have received a copy of the GNU General Public License
-//    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-#ifndef PROCFS_MACROS_H
-#define PROCFS_MACROS_H
-/***********************************************************************
-*                        PROC_FS MACROS                                *
-************************************************************************/
-#ifdef CONFIG_PROC_FS
+/*
+ * Copyright (C) 1999-2014 Paolo Mantegazza <mantegazza@aero.polimi.it>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#ifndef _RTAI_PROC_FS_H
+#define _RTAI_PROC_FS_H
+
+extern struct proc_dir_entry *rtai_proc_root;
+
+#include <linux/seq_file.h>
 #include <linux/proc_fs.h>
 
-/* proc print macros - Contributed by: Erwin Rol (erwin@muffin.org)
-   and shamelessly ripped from rtai_proc_fs.h, part of the RTAI
-   project.  See http://www.rtai.org for more details.
+#define PROC_READ_FUN(read_fun_name)			\
+    int read_fun_name(struct seq_file *pf, void *v)
 
-   macro that holds the local variables that
-   we use in the PROC_PRINT_* macros. We have
-   this macro so we can add variables with out
-   changing the users of this macro, of course
-   only when the names don't colide!
-*/
+#define PROC_READ_WRITE_OPEN_OPS(rtai_proc_fops,		\
+				 read_fun_name, write_fun_name)	\
+    								\
+    static int read_fun_name##_open(struct inode *inode,	\
+				    struct file *file) {	\
+	return single_open(file, read_fun_name, NULL);		\
+    }								\
+    								\
+    static const struct file_operations rtai_proc_fops = {	\
+	.owner = THIS_MODULE,					\
+	.open = read_fun_name##_open,				\
+	.read = seq_read,					\
+	.write = write_fun_name,				\
+	.llseek = seq_lseek,					\
+	.release = single_release				\
+    };
 
-#define PROC_PRINT_VARS                                 \
-    off_t pos = 0;                                      \
-    off_t begin = 0;                                    \
-    int len = 0			/* no ";" */
+#define PROC_READ_OPEN_OPS(rtai_proc_fops, read_fun_name)		\
+    PROC_READ_WRITE_OPEN_OPS(rtai_proc_fops, read_fun_name, NULL)
 
-/* macro that prints in the procfs read buffer.
-   this macro expects the function arguments to be
-   named as follows.
-   static int FOO(char *page, char **start,
-                off_t off, int count, int *eof, void *data)  */
+static inline void *CREATE_PROC_ENTRY(const char *name, umode_t mode,
+				      void *parent,
+				      const struct file_operations *proc_fops)
+{
+    return !parent ? proc_mkdir(name, NULL) :
+	proc_create(name, mode, parent, proc_fops);
+}
 
-#define PROC_PRINT(fmt,args...)                         \
-    len += sprintf(page + len , fmt, ##args);           \
-    pos += len;                                         \
-    if(pos < off) {                                     \
-        len = 0;                                        \
-        begin = pos;                                    \
-    }                                                   \
-    if(pos > off + count)                               \
-        goto done;
+#define SET_PROC_READ_ENTRY(entry, read_fun)  do { } while(0)
 
-/* macro to leave the read function from another
-   place than at the end.   */
-#define PROC_PRINT_RETURN                              \
-    *eof = 1;                                          \
-    goto done			// no ";"
+#define PROC_PRINT_VARS 
 
-/* macro that should only used once at the end of the
-   read function, to return from another place in the
-   read function use the PROC_PRINT_RETURN macro.   */
-#define PROC_PRINT_DONE                                 \
-        *eof = 1;                                       \
-    done:                                               \
-        *start = page + (off - begin);                  \
-        len -= (off - begin);                           \
-        if(len > count)                                 \
-            len = count;                                \
-        if(len < 0)                                     \
-            len = 0;                                    \
-        return len		// no ";"
+#define PROC_PRINT(fmt, args...)  \
+	do { seq_printf(pf, fmt, ##args); } while(0)
 
-#endif /* CONFIG_PROC_FS */
-#endif /* PROCFS_MACROS_H */
+#define PROC_PRINT_RETURN do { goto done; } while(0)
+
+#define PROC_PRINT_DONE do { return 0; } while(0)
+
+#endif  /* !_RTAI_PROC_FS_H */

--- a/src/rtapi/rtai-kernel.c
+++ b/src/rtapi/rtai-kernel.c
@@ -20,7 +20,11 @@ extern rtapi_exception_handler_t rt_exception_handler;
 #ifdef RTAPI
 void _rtapi_module_timer_stop(void) {
     stop_rt_timer();
+#if RTAI_VERSION <= 400
     rt_free_timer();
+#else
+    rt_free_timers();
+#endif
 }
 
 
@@ -119,8 +123,13 @@ int _rtapi_task_new_hook(task_data *task, int task_id) {
     if (retval) return retval;
 
     /* request to handle traps in the new task */
+#if RTAI_VERSION <= 400
     for(v=0; v<HAL_NR_FAULTS; v++)
         rt_set_task_trap_handler(ostask_array[task_id], v, _rtapi_trap_handler);
+#else
+    for(v=0; v<IPIPE_NR_FAULTS; v++)
+        rt_set_task_trap_handler(ostask_array[task_id], v, _rtapi_trap_handler);
+#endif
 
     return 0;
 }

--- a/src/rtapi/rtapi_kdetect.h
+++ b/src/rtapi/rtapi_kdetect.h
@@ -61,7 +61,11 @@
 
 // dlopen() these shared libraries
 #define LIBXENOMAI "libxenomai.so"
+#ifdef XENOMAI_V2
 #define LIBNATIVE "libnative.so"
+#else
+#define LIBNATIVE "libalchemy.so"
+#endif
 // and dig for LIBNATIVE_SYM
 #define LIBNATIVE_SYM "rt_task_create"
 

--- a/src/rtapi/rtapi_proc.h
+++ b/src/rtapi/rtapi_proc.h
@@ -104,17 +104,16 @@ void rtapi_proc_read_status_hook(char *page, char **start, off_t off,
 				 int count, int *eof, void *data);
 #endif
 
-static int proc_read_status(char *page, char **start, off_t off,
-    int count, int *eof, void *data)
+PROC_READ_FUN(proc_read_status)
 {
     PROC_PRINT_VARS;
     PROC_PRINT("******* RTAPI STATUS ********\n");
     PROC_PRINT("   RT Modules = %i\n", rtapi_data->rt_module_count);
     PROC_PRINT("   UL Modules = %i\n", rtapi_data->ul_module_count);
     PROC_PRINT("        Tasks = %i/%i\n", rtapi_data->task_count,
-	RTAPI_MAX_TASKS);
+	       RTAPI_MAX_TASKS);
     PROC_PRINT("Shared memory = %i/%i\n", rtapi_data->shmem_count,
-	RTAPI_MAX_SHMEMS);
+	       RTAPI_MAX_SHMEMS);
     PROC_PRINT("default RT task CPU = %i\n", rtapi_data->rt_cpu);
     if (rtapi_data->timer_running) {
 	PROC_PRINT(" Timer status = Running\n");
@@ -122,15 +121,12 @@ static int proc_read_status(char *page, char **start, off_t off,
     } else {
 	PROC_PRINT(" Timer status = Stopped\n");
     }
-#ifdef HAVE_RTAPI_READ_STATUS_HOOK
-    rtapi_proc_read_status_hook(page, start, off, count, eof, data);
-#endif
     PROC_PRINT("\n");
     PROC_PRINT_DONE;
 }
+PROC_READ_OPEN_OPS(status_file_fops, proc_read_status);
 
-static int proc_read_modules(char *page, char **start, off_t off,
-    int count, int *eof, void *data)
+PROC_READ_FUN(proc_read_modules)
 {
     int n;
     char *state_str;
@@ -157,9 +153,9 @@ static int proc_read_modules(char *page, char **start, off_t off,
     PROC_PRINT("\n");
     PROC_PRINT_DONE;
 }
+PROC_READ_OPEN_OPS(modules_file_fops, proc_read_modules);
 
-static int proc_read_tasks(char *page, char **start, off_t off,
-    int count, int *eof, void *data)
+PROC_READ_FUN(proc_read_tasks)
 {
     int n;
     char *state_str;
@@ -198,9 +194,9 @@ static int proc_read_tasks(char *page, char **start, off_t off,
     PROC_PRINT("\n");
     PROC_PRINT_DONE;
 }
+PROC_READ_OPEN_OPS(tasks_file_fops, proc_read_tasks);
 
-static int proc_read_shmem(char *page, char **start, off_t off,
-    int count, int *eof, void *data)
+PROC_READ_FUN(proc_read_shmem)
 {
     int n;
 
@@ -211,44 +207,45 @@ static int proc_read_shmem(char *page, char **start, off_t off,
     for (n = 1; n <= RTAPI_MAX_SHMEMS; n++) {
 	if (shmem_array[n].key != 0) {
 	    PROC_PRINT("%02d  %2d/%-2d  %-10d  %-10lu\n",
-		n, shmem_array[n].rtusers, shmem_array[n].ulusers,
-		shmem_array[n].key, shmem_array[n].size);
+		       n, shmem_array[n].rtusers, shmem_array[n].ulusers,
+		       shmem_array[n].key, shmem_array[n].size);
 	}
     }
     PROC_PRINT("\n");
     PROC_PRINT_DONE;
 }
+PROC_READ_OPEN_OPS(shmem_file_fops, proc_read_shmem);
 
-static int proc_read_debug(char *page, char **start, off_t off,
-    int count, int *eof, void *data)
+PROC_READ_FUN(proc_read_debug)
 {
     PROC_PRINT_VARS;
     PROC_PRINT("******* RTAPI MESSAGES ******\n");
     PROC_PRINT("  Message Level  = RT:%i User:%i\n", 
 	       global_data->rt_msg_level,global_data->user_msg_level);
     PROC_PRINT("RT ERROR messages = %s\n",
-	global_data->rt_msg_level >= RTAPI_MSG_ERR ? "ON" : "OFF");
+	       global_data->rt_msg_level >= RTAPI_MSG_ERR ? "ON" : "OFF");
     PROC_PRINT("WARNING messages = %s\n",
-	global_data->rt_msg_level >= RTAPI_MSG_WARN ? "ON" : "OFF");
+	       global_data->rt_msg_level >= RTAPI_MSG_WARN ? "ON" : "OFF");
     PROC_PRINT("   INFO messages = %s\n",
-	global_data->rt_msg_level >= RTAPI_MSG_INFO ? "ON" : "OFF");
+	       global_data->rt_msg_level >= RTAPI_MSG_INFO ? "ON" : "OFF");
     PROC_PRINT("  DEBUG messages = %s\n",
-	global_data->rt_msg_level >= RTAPI_MSG_DBG ? "ON" : "OFF");
+	       global_data->rt_msg_level >= RTAPI_MSG_DBG ? "ON" : "OFF");
 
     PROC_PRINT("User  ERROR messages = %s\n",
-	global_data->user_msg_level >= RTAPI_MSG_ERR ? "ON" : "OFF");
+	       global_data->user_msg_level >= RTAPI_MSG_ERR ? "ON" : "OFF");
     PROC_PRINT("WARNING messages = %s\n",
-	global_data->user_msg_level >= RTAPI_MSG_WARN ? "ON" : "OFF");
+	       global_data->user_msg_level >= RTAPI_MSG_WARN ? "ON" : "OFF");
     PROC_PRINT("   INFO messages = %s\n",
-	global_data->user_msg_level >= RTAPI_MSG_INFO ? "ON" : "OFF");
+	       global_data->user_msg_level >= RTAPI_MSG_INFO ? "ON" : "OFF");
     PROC_PRINT("  DEBUG messages = %s\n",
-	global_data->user_msg_level >= RTAPI_MSG_DBG ? "ON" : "OFF");
+	       global_data->user_msg_level >= RTAPI_MSG_DBG ? "ON" : "OFF");
     PROC_PRINT("\n");
     PROC_PRINT_DONE;
 }
 
-static int proc_write_debug(struct file *file,
-    const char *buffer, unsigned long count, void *data)
+static ssize_t proc_write_debug(struct file *file,
+				const char __user *buffer, size_t count,
+				loff_t *data)
 {
     char c;
     int msg_level;
@@ -274,14 +271,15 @@ static int proc_write_debug(struct file *file,
        really only used the first byte */
     return count;
 }
+PROC_READ_WRITE_OPEN_OPS(debug_file_fops, proc_read_debug, proc_write_debug)
 
-static int proc_read_instance(char *page, char **start, off_t off,
-    int count, int *eof, void *data)
+PROC_READ_FUN(proc_read_instance)
 {
     PROC_PRINT_VARS;
     PROC_PRINT("%i\n", rtapi_instance);
     PROC_PRINT_DONE;
 }
+PROC_READ_OPEN_OPS(instance_file_fops, proc_read_instance);
 
 /** proc_init() initializes the /proc filesystem entries,
     creating the directory and files, and linking them
@@ -290,126 +288,36 @@ static int proc_read_instance(char *page, char **start, off_t off,
     RTAPI implementation.
 */
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-#else
-static const struct file_operations status_file_fops = {
-     .read = proc_read_status,
-};
-
-static const struct file_operations modules_file_fops = {
-     .read = proc_read_modules,
-};
-
-static const struct file_operations tasks_file_fops = {
-     .read = proc_read_tasks,
-};
-
-static const struct file_operations shmem_file_fops = {
-     .read = proc_read_shmem,
-};
-
-static const struct file_operations debug_file_fops = {
-     .read  = proc_read_debug,
-     .write = proc_write_debug,
-};
-
-static const struct file_operations instance_file_fops = {
-     .read  = proc_read_instance,
-};
-#endif
-
 static int proc_init(void)
 {
     /* create the rtapi directory "/proc/rtapi" */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    rtapi_dir = create_proc_entry("rtapi", S_IFDIR, NULL);
-#else
-    rtapi_dir = proc_create("rtapi", S_IFDIR, NULL, NULL);
-#endif
-    if (rtapi_dir == 0) {
+    rtapi_dir = CREATE_PROC_ENTRY("rtapi",S_IFDIR,NULL,NULL);
+    if (rtapi_dir == 0)
 	return -1;
-    }
 
     /* create read only file "/proc/rtapi/status" */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    status_file = create_proc_entry("status", S_IRUGO, rtapi_dir);
-#else
-    status_file = proc_create("status", S_IRUGO, rtapi_dir, &status_file_fops);
-#endif
-    if (status_file == NULL) {
-	return -1;
-    }
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    status_file->read_proc = proc_read_status;
-#endif
+    status_file = \
+	CREATE_PROC_ENTRY("status",S_IRUGO,rtapi_dir,&status_file_fops);
 
     /* create read only file "/proc/rtapi/modules" */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    modules_file = create_proc_entry("modules", S_IRUGO, rtapi_dir);
-#else
-    modules_file = proc_create("modules", S_IRUGO, rtapi_dir, &modules_file_fops);
-#endif
-    if (modules_file == NULL) {
-	return -1;
-    }
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    modules_file->read_proc = proc_read_modules;
-#endif
+    modules_file = \
+	CREATE_PROC_ENTRY("modules",S_IRUGO,rtapi_dir,&modules_file_fops);
 
     /* create read only file "/proc/rtapi/tasks" */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    tasks_file = create_proc_entry("tasks", S_IRUGO, rtapi_dir);
-#else
-    tasks_file = proc_create("tasks", S_IRUGO, rtapi_dir, &tasks_file_fops);
-#endif
-    if (tasks_file == NULL) {
-	return -1;
-    }
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    tasks_file->read_proc = proc_read_tasks;
-#endif
+    tasks_file = \
+	CREATE_PROC_ENTRY("tasks",S_IRUGO,rtapi_dir,&tasks_file_fops);
 
     /* create read only file "/proc/rtapi/shmem" */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    shmem_file = create_proc_entry("shmem", S_IRUGO, rtapi_dir);
-#else
-    shmem_file = proc_create("shmem", S_IRUGO, rtapi_dir, &shmem_file_fops);
-#endif
-    if (shmem_file == NULL) {
-	return -1;
-    }
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    shmem_file->read_proc = proc_read_shmem;
-#endif
+    shmem_file = \
+	CREATE_PROC_ENTRY("shmem",S_IRUGO,rtapi_dir,&shmem_file_fops);
 
     /* create read/write file "/proc/rtapi/debug" */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    debug_file = create_proc_entry("debug", S_IRUGO | S_IWUGO, rtapi_dir);
-#else
-    debug_file = proc_create("debug", S_IRUGO | S_IWUGO, rtapi_dir, &debug_file_fops);
-#endif
-    if (debug_file == NULL) {
-	return -1;
-    }
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    debug_file->data = NULL;
-    debug_file->read_proc = proc_read_debug;
-    debug_file->write_proc = proc_write_debug;
-#endif
+    debug_file = \
+	CREATE_PROC_ENTRY("debug",S_IRUGO|S_IWUGO,rtapi_dir,&debug_file_fops);
 
-    /* create read/write file "/proc/rtapi/instance" */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    instance_file = create_proc_entry("instance", S_IRUGO, rtapi_dir);
-#else
-    instance_file = proc_create("instance", S_IRUGO, rtapi_dir, &instance_file_fops);
-#endif
-    if (instance_file == NULL) {
-	return -1;
-    }
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
-    instance_file->data = NULL;
-    instance_file->read_proc = proc_read_instance;
-#endif
+    /* create read only file "/proc/rtapi/instance" */
+    instance_file = \
+	CREATE_PROC_ENTRY("instance",S_IRUGO,rtapi_dir,&instance_file_fops);
 
     return 0;
 }

--- a/src/rtapi/rtapi_proc.h
+++ b/src/rtapi/rtapi_proc.h
@@ -290,58 +290,126 @@ static int proc_read_instance(char *page, char **start, off_t off,
     RTAPI implementation.
 */
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
+#else
+static const struct file_operations status_file_fops = {
+     .read = proc_read_status,
+};
+
+static const struct file_operations modules_file_fops = {
+     .read = proc_read_modules,
+};
+
+static const struct file_operations tasks_file_fops = {
+     .read = proc_read_tasks,
+};
+
+static const struct file_operations shmem_file_fops = {
+     .read = proc_read_shmem,
+};
+
+static const struct file_operations debug_file_fops = {
+     .read  = proc_read_debug,
+     .write = proc_write_debug,
+};
+
+static const struct file_operations instance_file_fops = {
+     .read  = proc_read_instance,
+};
+#endif
+
 static int proc_init(void)
 {
     /* create the rtapi directory "/proc/rtapi" */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     rtapi_dir = create_proc_entry("rtapi", S_IFDIR, NULL);
+#else
+    rtapi_dir = proc_create("rtapi", S_IFDIR, NULL, NULL);
+#endif
     if (rtapi_dir == 0) {
 	return -1;
     }
 
     /* create read only file "/proc/rtapi/status" */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     status_file = create_proc_entry("status", S_IRUGO, rtapi_dir);
+#else
+    status_file = proc_create("status", S_IRUGO, rtapi_dir, &status_file_fops);
+#endif
     if (status_file == NULL) {
 	return -1;
     }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     status_file->read_proc = proc_read_status;
+#endif
 
     /* create read only file "/proc/rtapi/modules" */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     modules_file = create_proc_entry("modules", S_IRUGO, rtapi_dir);
+#else
+    modules_file = proc_create("modules", S_IRUGO, rtapi_dir, &modules_file_fops);
+#endif
     if (modules_file == NULL) {
 	return -1;
     }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     modules_file->read_proc = proc_read_modules;
+#endif
 
     /* create read only file "/proc/rtapi/tasks" */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     tasks_file = create_proc_entry("tasks", S_IRUGO, rtapi_dir);
+#else
+    tasks_file = proc_create("tasks", S_IRUGO, rtapi_dir, &tasks_file_fops);
+#endif
     if (tasks_file == NULL) {
 	return -1;
     }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     tasks_file->read_proc = proc_read_tasks;
+#endif
 
     /* create read only file "/proc/rtapi/shmem" */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     shmem_file = create_proc_entry("shmem", S_IRUGO, rtapi_dir);
+#else
+    shmem_file = proc_create("shmem", S_IRUGO, rtapi_dir, &shmem_file_fops);
+#endif
     if (shmem_file == NULL) {
 	return -1;
     }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     shmem_file->read_proc = proc_read_shmem;
+#endif
 
     /* create read/write file "/proc/rtapi/debug" */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     debug_file = create_proc_entry("debug", S_IRUGO | S_IWUGO, rtapi_dir);
+#else
+    debug_file = proc_create("debug", S_IRUGO | S_IWUGO, rtapi_dir, &debug_file_fops);
+#endif
     if (debug_file == NULL) {
 	return -1;
     }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     debug_file->data = NULL;
     debug_file->read_proc = proc_read_debug;
     debug_file->write_proc = proc_write_debug;
+#endif
 
     /* create read/write file "/proc/rtapi/instance" */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     instance_file = create_proc_entry("instance", S_IRUGO, rtapi_dir);
+#else
+    instance_file = proc_create("instance", S_IRUGO, rtapi_dir, &instance_file_fops);
+#endif
     if (instance_file == NULL) {
 	return -1;
     }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
     instance_file->data = NULL;
     instance_file->read_proc = proc_read_instance;
+#endif
 
     return 0;
 }

--- a/src/rtapi/xenomai-common.h
+++ b/src/rtapi/xenomai-common.h
@@ -1,0 +1,1 @@
+#define XENOMAI_INCLUDE(header) <XENOMAI_SKIN/header>

--- a/src/rtapi/xenomai-kernel.c
+++ b/src/rtapi/xenomai-kernel.c
@@ -20,20 +20,19 @@
 #include "config.h"
 #include "rtapi.h"
 #include "rtapi_common.h"
+#include "xenomai-common.h"
 
-#include <nucleus/types.h>		/* XNOBJECT_NAME_LEN, RTIME */
-#include <native/heap.h>		// RT_HEAP, H_SHARED, rt_heap_*
-#include <native/task.h>		// RT_TASK, rt_task_*()
+#include XENOMAI_INCLUDE(heap.h)	// RT_HEAP, H_SHARED, rt_heap_*
+#include XENOMAI_INCLUDE(task.h)	// RT_TASK, rt_task_*()
 
 #ifdef RTAPI	/* In kernel land, this is equiv. to MODULE */
 #include <linux/slab.h>			// kfree
-#include <native/types.h>		// TM_INFINITE
-#include <native/timer.h>		// rt_timer_*()
+#include XENOMAI_INCLUDE(timer.h)	// rt_timer_*()
 #include "procfs_macros.h"		// PROC_PRINT()
 
 #else /* ULAPI */
-#include <errno.h>		/* errno */
-#include <unistd.h>             // getpid()
+#include <errno.h>			/* errno */
+#include <unistd.h>			// getpid()
 
 #endif
 
@@ -124,8 +123,7 @@ long long int _rtapi_get_time_hook(void) {
    doesn't take a week every time you call it.
 */
 long long int _rtapi_get_clocks_hook(void) {
-    // Gilles says: do this - it's portable
-    return rt_timer_tsc();
+    return rt_timer_read();
 }
 
 void _rtapi_clock_set_period_hook(long int nsecs, RTIME *counts, 
@@ -136,8 +134,8 @@ void _rtapi_clock_set_period_hook(long int nsecs, RTIME *counts,
 
 void _rtapi_delay_hook(long int nsec) 
 {
-    long long int release = rt_timer_tsc() + nsec;
-    while (rt_timer_tsc() < release);
+    long long int release = rt_timer_read() + nsec;
+    while (rt_timer_read() < release);
 }
 #endif /* RTAPI */
 

--- a/src/rtapi/xenomai-kernel.h
+++ b/src/rtapi/xenomai-kernel.h
@@ -23,7 +23,8 @@
 
 #define FLAVOR_FLAGS XENOMAI_KERNEL_FLAVOR_FLAGS // see rtapi_compat.h
 
-#include <native/task.h>	/* RT_TASK, rt_task_*() */
+#include "xenomai-common.h"
+#include XENOMAI_INCLUDE(task.h)	/* RT_TASK, rt_task_*() */
 
 /* rtapi_common.c */
 

--- a/src/rtapi/xenomai.c
+++ b/src/rtapi/xenomai.c
@@ -24,18 +24,18 @@
 #include "config.h"
 #include "rtapi.h"
 #include "rtapi_common.h"
+#include "xenomai-common.h"
 
-#include <sys/mman.h>		/* munlockall() */
-#include <nucleus/types.h>	/* XNOBJECT_NAME_LEN */
-#include <native/task.h>	/* RT_TASK, rt_task_*() */
-#include <native/timer.h>	/* rt_timer_*() */
-#include <signal.h>		/* sigaction/SIGXCPU handling */
+#include <sys/mman.h>			/* munlockall() */
+#include XENOMAI_INCLUDE(task.h)	/* RT_TASK, rt_task_*() */
+#include XENOMAI_INCLUDE(timer.h)	/* rt_timer_*() */
+#include <signal.h>			/* sigaction/SIGXCPU handling */
 #include <sys/types.h>
-#include <unistd.h>             // getpid()
+#include <unistd.h>		        // getpid()
+#include <sched.h>			// cpu sets
 
 #ifdef RTAPI
-#include <native/mutex.h>
-#include <rtdk.h>
+#include XENOMAI_INCLUDE(mutex.h)
 #include <stdlib.h>		// abort()
 
 /*  RTAPI task functions  */
@@ -92,12 +92,19 @@ int _rtapi_task_update_stats_hook(void)
 
     rtapi_threadstatus_t *ts = &global_data->thread_status[task_id];
 
+#ifdef XENOMAI_V2
     ts->flavor.xeno.modeswitches = rtinfo.modeswitches;
     ts->flavor.xeno.ctxswitches = rtinfo.ctxswitches;
     ts->flavor.xeno.pagefaults = rtinfo.pagefaults;
     ts->flavor.xeno.exectime = rtinfo.exectime;
-    ts->flavor.xeno.modeswitches = rtinfo.modeswitches;
     ts->flavor.xeno.status = rtinfo.status;
+#else
+    ts->flavor.xeno.modeswitches = rtinfo.stat.msw;
+    ts->flavor.xeno.ctxswitches = rtinfo.stat.csw;
+    ts->flavor.xeno.pagefaults = rtinfo.stat.pf;
+    ts->flavor.xeno.exectime = rtinfo.stat.xtime;
+    ts->flavor.xeno.status = rtinfo.stat.status;
+#endif
 
     ts->num_updates++;
 
@@ -270,16 +277,16 @@ void _rtapi_task_wrapper(void * task_id_hack) {
 
 int _rtapi_task_start_hook(task_data *task, int task_id) {
     int which_cpu = 0;
+    int uses_fpu = 0;
     int retval;
 
-#if !defined(BROKEN_XENOMAU_CPU_AFFINITY)
+#ifdef XENOMAI_V2
     // seems to work for me
     // not sure T_CPU(n) is possible - see:
     // http://www.xenomai.org/pipermail/xenomai-help/2010-09/msg00081.html
 
     if (task->cpu > -1)  // explicitly set by threads, motmod
 	which_cpu = T_CPU(task->cpu);
-#endif
 
     // http://www.xenomai.org/documentation/trunk/html/api/group__task.html#ga03387550693c21d0223f739570ccd992
     // Passing T_FPU|T_CPU(1) in the mode parameter thus creates a
@@ -287,16 +294,26 @@ int _rtapi_task_start_hook(task_data *task, int task_id) {
     // the task will start out dormant; execution begins with rt_task_start()
 
     // since this is a usermode RT task, it will be FP anyway
+    if (task->uses_fp)
+	uses_fpu = T_FPU;
+#endif
+
     if ((retval = rt_task_create (&ostask_array[task_id], task->name, 
 				  task->stacksize, task->prio, 
-				  (task->uses_fp ? T_FPU : 0) |
-				  which_cpu | T_JOINABLE)
+				  uses_fpu | which_cpu | T_JOINABLE)
 	 ) != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 			"rt_task_create failed: %d %s\n",
 			retval, strerror(-retval));
 	return -ENOMEM;
     }
+
+#ifndef XENOMAI_V2
+    // Xenomai-3 CPU affinity
+    cpu_set_t cpus;
+    CPU_SET(task->cpu, &cpus);
+    rt_task_set_affinity (&ostask_array[task_id], &cpus);
+#endif
 
     if ((retval = rt_task_start( &ostask_array[task_id],
 				 _rtapi_task_wrapper, (void *)(long)task_id))) {
@@ -445,8 +462,8 @@ int _rtapi_task_self_hook(void) {
 #ifdef RTAPI
 void _rtapi_delay_hook(long int nsec)
 {
-    long long int release = rt_timer_tsc() + nsec;
-    while (rt_timer_tsc() < release);
+    long long int release = rt_timer_read() + nsec;
+    while (rt_timer_read() < release);
 }
 #endif
 
@@ -463,6 +480,5 @@ long long int _rtapi_get_time_hook(void) {
    doesn't take a week every time you call it.
 */
 long long int _rtapi_get_clocks_hook(void) {
-    // Gilles says: do this - it's portable
-    return rt_timer_tsc();
+    return rt_timer_read();
 }


### PR DESCRIPTION
This adds support for newer RT kernels and run-time without breaking compatibility with current deps (Xenomai-2, RTAI-4.0, Linux-3.8.13).

Linux updates include @koppi's patch from PR #618.

See commit log for details.