### PR TITLE
Bugfix - instantiable components

### DIFF
--- a/src/hal/i_components/bitslice.icomp
+++ b/src/hal/i_components/bitslice.icomp
@@ -7,9 +7,6 @@ instanceparam int maxpincount = 32;
 
 instanceparam int pincount = 16;
 
-instanceparam string iprefix = "";
-
-
 author "Andy Pugh";
 license "GPL2+";
 function _ nofp;

--- a/src/hal/i_components/gantry.icomp
+++ b/src/hal/i_components/gantry.icomp
@@ -55,8 +55,6 @@ instanceparam int maxpincount = 7;
 
 instanceparam int pincount = 7;
 
-instanceparam string iprefix = "gantry7";
-
 description """
 Drives multiple physical motors (joints) from a single axis input
 .LP

--- a/src/hal/i_components/lgantry.icomp
+++ b/src/hal/i_components/lgantry.icomp
@@ -58,8 +58,6 @@ instanceparam int maxpincount = 7;
 
 instanceparam int pincount = 7;
 
-instanceparam string iprefix = "lgantry7";
-
 description """
 Drives multiple physical motors (joints) from a single axis input
 .LP

--- a/src/hal/i_components/lincurve.icomp
+++ b/src/hal/i_components/lincurve.icomp
@@ -32,8 +32,6 @@ instanceparam int maxpincount = 16;
 
 instanceparam int pincount = 4;
 
-instanceparam string iprefix = "lincurve4";
-
 author "Andy Pugh";
 license "GPL";
 

--- a/src/hal/i_components/lutn.icomp
+++ b/src/hal/i_components/lutn.icomp
@@ -8,8 +8,6 @@ instanceparam int maxpincount = 5;
 
 instanceparam int pincount = 2;
 
-instanceparam string iprefix = "lut2";
-
 instanceparam int functn = 0;
 
 option extra_inst_setup;

--- a/src/hal/i_components/multiswitch.icomp
+++ b/src/hal/i_components/multiswitch.icomp
@@ -34,9 +34,6 @@ instanceparam int maxpincount = 32;
 
 instanceparam int pincount = 6;
 
-instanceparam string iprefix = "mswitch6";
-
-
 function _ ;
 option extra_inst_setup yes;
 //option count_function yes;


### PR DESCRIPTION
6 components have predefined iprefix names, this will override the
name set in newisnt, unless iprefix=  is specified

Predefined iprefixes removed, the parameter can still be used if required,
but in most instances, setting the name via

'newinst [component-name] [new-instance-name] [args ....]'

will work better and in a more easily understood way.

Signed-off-by: Mick <arceye@mgware.co.uk>