### PR TITLE
BeagleBone configs: Fix for HAL name length

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.hal
@@ -553,27 +553,27 @@ newsig bed.temp.set  float
 newsig bed.temp.meas float
 
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater T10 GPIO0.23 P8.13
-setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.enable    1
+setp hpg.pwmgen.00.out.00.value     0.0
 
 # J3 E1 Heater U10 GPIO0.22 P8.19
-setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
-setp hal_pru_generic.pwmgen.00.out.01.enable    1
-setp hal_pru_generic.pwmgen.00.out.01.value     0.0
+setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.enable    1
+setp hpg.pwmgen.00.out.01.value     0.0
 
 # J4 Bed Heater U14 GPIO1.18 P9.14
-setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
-setp hal_pru_generic.pwmgen.00.out.02.enable    1
-setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
 
 ## DECAMUX clock signal U18 GPIO1.28 P9.12
-#setp hal_pru_generic.pwmgen.00.out.03.pin       0x5C
-#setp hal_pru_generic.pwmgen.00.out.03.enable    1
-#setp hal_pru_generic.pwmgen.00.out.03.value     0.0
+#setp hpg.pwmgen.00.out.03.pin       0x5C
+#setp hpg.pwmgen.00.out.03.enable    1
+#setp hpg.pwmgen.00.out.03.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -585,7 +585,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 net e0.heater  => limit1.0.in
 net e0.heaterl <= limit1.0.out
-net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -601,7 +601,7 @@ net bed.temp.set     => pid.1.command
 net bed.heater  <= pid.1.output
 net bed.heater  => limit1.1.in
 net bed.heaterl <= limit1.1.out
-net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.hal
@@ -24,7 +24,7 @@ loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EM
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 loadrt pepper count=2
@@ -39,7 +39,7 @@ loadusr -Wn Therm ./ReadTemp.py -n Therm --num_chan 2 -t 1 1 -a 4 5
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         base-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -47,7 +47,7 @@ addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        base-thread
 addf pepper.update			  base-thread      
 
@@ -65,34 +65,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out 
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.12 GPIO1_12
-setp [PRUCONF](DRIVER).stepgen.00.steppin          0x4C
+setp hpg.stepgen.00.steppin          0x4C
 # P8.11 GPIO1_13
-setp [PRUCONF](DRIVER).stepgen.00.dirpin           0x4D
+setp hpg.stepgen.00.dirpin           0x4D
 
 
 # ################
@@ -104,34 +104,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out 
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.16 GPIO1_14
-setp [PRUCONF](DRIVER).stepgen.01.steppin          0x4E
+setp hpg.stepgen.01.steppin          0x4E
 # P8.15 GPIO1_15
-setp [PRUCONF](DRIVER).stepgen.01.dirpin           0x4F
+setp hpg.stepgen.01.dirpin           0x4F
 
 
 # ################
@@ -143,34 +143,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out 
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P9.15 GPIO1_16
-setp [PRUCONF](DRIVER).stepgen.02.steppin          0x50
+setp hpg.stepgen.02.steppin          0x50
 # P9.23 GPIO1_17
-setp [PRUCONF](DRIVER).stepgen.02.dirpin           0x51
+setp hpg.stepgen.02.dirpin           0x51
 
 
 # ################
@@ -182,34 +182,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out 
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P9.22 GPIO0_2
-setp [PRUCONF](DRIVER).stepgen.03.steppin          0x22
+setp hpg.stepgen.03.steppin          0x22
 # P9.21 GPIO0_3
-setp [PRUCONF](DRIVER).stepgen.03.dirpin           0x23
+setp hpg.stepgen.03.dirpin           0x23
 
 
 # ################
@@ -221,34 +221,34 @@ newsig emcmot.04.enable bit
 sets emcmot.04.enable FALSE
 
 net emcmot.04.enable <= axis.4.amp-enable-out 
-net emcmot.04.enable => [PRUCONF](DRIVER).stepgen.04.enable
+net emcmot.04.enable => hpg.stepgen.04.enable
 
 
 # position command and feedback
 net emcmot.04.pos-cmd <= axis.4.motor-pos-cmd
-net emcmot.04.pos-cmd => [PRUCONF](DRIVER).stepgen.04.position-cmd
+net emcmot.04.pos-cmd => hpg.stepgen.04.position-cmd
 
-net motor.04.pos-fb <= [PRUCONF](DRIVER).stepgen.04.position-fb
+net motor.04.pos-fb <= hpg.stepgen.04.position-fb
 net motor.04.pos-fb => axis.4.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.04.dirsetup        [AXIS_4]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.04.dirhold         [AXIS_4]DIRHOLD
+setp hpg.stepgen.04.dirsetup        [AXIS_4]DIRSETUP
+setp hpg.stepgen.04.dirhold         [AXIS_4]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.04.steplen         [AXIS_4]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.04.stepspace       [AXIS_4]STEPSPACE
+setp hpg.stepgen.04.steplen         [AXIS_4]STEPLEN
+setp hpg.stepgen.04.stepspace       [AXIS_4]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.04.position-scale  [AXIS_4]SCALE
+setp hpg.stepgen.04.position-scale  [AXIS_4]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.04.maxvel          [AXIS_4]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.04.maxaccel        [AXIS_4]STEPGEN_MAX_ACC
+setp hpg.stepgen.04.maxvel          [AXIS_4]STEPGEN_MAX_VEL
+setp hpg.stepgen.04.maxaccel        [AXIS_4]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.04.step_type       0
+#setp hpg.stepgen.04.step_type       0
 # P9.18 GPIO0_4
-setp [PRUCONF](DRIVER).stepgen.04.steppin          0x24
+setp hpg.stepgen.04.steppin          0x24
 # P9.17 GPIO0_5
-setp [PRUCONF](DRIVER).stepgen.04.dirpin           0x25
+setp hpg.stepgen.04.dirpin           0x25
 
 
 # ################
@@ -260,34 +260,34 @@ newsig emcmot.05.enable bit
 sets emcmot.05.enable FALSE
 
 net emcmot.05.enable <= axis.5.amp-enable-out 
-net emcmot.05.enable => [PRUCONF](DRIVER).stepgen.05.enable
+net emcmot.05.enable => hpg.stepgen.05.enable
 
 
 # position command and feedback
 net emcmot.05.pos-cmd <= axis.5.motor-pos-cmd
-net emcmot.05.pos-cmd => [PRUCONF](DRIVER).stepgen.05.position-cmd
+net emcmot.05.pos-cmd => hpg.stepgen.05.position-cmd
 
-net motor.05.pos-fb <= [PRUCONF](DRIVER).stepgen.05.position-fb
+net motor.05.pos-fb <= hpg.stepgen.05.position-fb
 net motor.05.pos-fb => axis.5.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.05.dirsetup        [AXIS_5]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.05.dirhold         [AXIS_5]DIRHOLD
+setp hpg.stepgen.05.dirsetup        [AXIS_5]DIRSETUP
+setp hpg.stepgen.05.dirhold         [AXIS_5]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.05.steplen         [AXIS_5]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.05.stepspace       [AXIS_5]STEPSPACE
+setp hpg.stepgen.05.steplen         [AXIS_5]STEPLEN
+setp hpg.stepgen.05.stepspace       [AXIS_5]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.05.position-scale  [AXIS_5]SCALE
+setp hpg.stepgen.05.position-scale  [AXIS_5]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.05.maxvel          [AXIS_5]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.05.maxaccel        [AXIS_5]STEPGEN_MAX_ACC
+setp hpg.stepgen.05.maxvel          [AXIS_5]STEPGEN_MAX_VEL
+setp hpg.stepgen.05.maxaccel        [AXIS_5]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.05.step_type       0
+#setp hpg.stepgen.05.step_type       0
 # P8.12 GPIO1_12
-setp [PRUCONF](DRIVER).stepgen.05.steppin          0x8C
+setp hpg.stepgen.05.steppin          0x8C
 # P8.11 GPIO1_13
-setp [PRUCONF](DRIVER).stepgen.05.dirpin           0x8D
+setp hpg.stepgen.05.dirpin           0x8D
 
 
 # ################
@@ -299,34 +299,34 @@ newsig emcmot.06.enable bit
 sets emcmot.06.enable FALSE
 
 net emcmot.06.enable <= axis.6.amp-enable-out 
-net emcmot.06.enable => [PRUCONF](DRIVER).stepgen.06.enable
+net emcmot.06.enable => hpg.stepgen.06.enable
 
 
 # position command and feedback
 net emcmot.06.pos-cmd <= axis.6.motor-pos-cmd
-net emcmot.06.pos-cmd => [PRUCONF](DRIVER).stepgen.06.position-cmd
+net emcmot.06.pos-cmd => hpg.stepgen.06.position-cmd
 
-net motor.06.pos-fb <= [PRUCONF](DRIVER).stepgen.06.position-fb
+net motor.06.pos-fb <= hpg.stepgen.06.position-fb
 net motor.06.pos-fb => axis.6.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.06.dirsetup        [AXIS_6]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.06.dirhold         [AXIS_6]DIRHOLD
+setp hpg.stepgen.06.dirsetup        [AXIS_6]DIRSETUP
+setp hpg.stepgen.06.dirhold         [AXIS_6]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.06.steplen         [AXIS_6]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.06.stepspace       [AXIS_6]STEPSPACE
+setp hpg.stepgen.06.steplen         [AXIS_6]STEPLEN
+setp hpg.stepgen.06.stepspace       [AXIS_6]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.06.position-scale  [AXIS_6]SCALE
+setp hpg.stepgen.06.position-scale  [AXIS_6]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.06.maxvel          [AXIS_6]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.06.maxaccel        [AXIS_6]STEPGEN_MAX_ACC
+setp hpg.stepgen.06.maxvel          [AXIS_6]STEPGEN_MAX_VEL
+setp hpg.stepgen.06.maxaccel        [AXIS_6]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.06.step_type       0
+#setp hpg.stepgen.06.step_type       0
 # P8.16 GPIO1_14
-setp [PRUCONF](DRIVER).stepgen.06.steppin          0x8E
+setp hpg.stepgen.06.steppin          0x8E
 # P8.15 GPIO1_15
-setp [PRUCONF](DRIVER).stepgen.06.dirpin           0x8F
+setp hpg.stepgen.06.dirpin           0x8F
 
 
 # ################
@@ -338,34 +338,34 @@ newsig emcmot.07.enable bit
 sets emcmot.07.enable FALSE
 
 net emcmot.07.enable <= axis.7.amp-enable-out 
-net emcmot.07.enable => [PRUCONF](DRIVER).stepgen.07.enable
+net emcmot.07.enable => hpg.stepgen.07.enable
 
 
 # position command and feedback
 net emcmot.07.pos-cmd <= axis.7.motor-pos-cmd
-net emcmot.07.pos-cmd => [PRUCONF](DRIVER).stepgen.07.position-cmd
+net emcmot.07.pos-cmd => hpg.stepgen.07.position-cmd
 
-net motor.07.pos-fb <= [PRUCONF](DRIVER).stepgen.07.position-fb
+net motor.07.pos-fb <= hpg.stepgen.07.position-fb
 net motor.07.pos-fb => axis.7.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.07.dirsetup        [AXIS_7]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.07.dirhold         [AXIS_7]DIRHOLD
+setp hpg.stepgen.07.dirsetup        [AXIS_7]DIRSETUP
+setp hpg.stepgen.07.dirhold         [AXIS_7]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.07.steplen         [AXIS_7]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.07.stepspace       [AXIS_7]STEPSPACE
+setp hpg.stepgen.07.steplen         [AXIS_7]STEPLEN
+setp hpg.stepgen.07.stepspace       [AXIS_7]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.07.position-scale  [AXIS_7]SCALE
+setp hpg.stepgen.07.position-scale  [AXIS_7]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.07.maxvel          [AXIS_7]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.07.maxaccel        [AXIS_7]STEPGEN_MAX_ACC
+setp hpg.stepgen.07.maxvel          [AXIS_7]STEPGEN_MAX_VEL
+setp hpg.stepgen.07.maxaccel        [AXIS_7]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.07.step_type       0
+#setp hpg.stepgen.07.step_type       0
 # P9.15 GPIO1_16
-setp [PRUCONF](DRIVER).stepgen.07.steppin          0x90
+setp hpg.stepgen.07.steppin          0x90
 # P9.23 GPIO1_17
-setp [PRUCONF](DRIVER).stepgen.07.dirpin           0x91
+setp hpg.stepgen.07.dirpin           0x91
 
 
 # ################
@@ -377,34 +377,34 @@ newsig emcmot.08.enable bit
 sets emcmot.08.enable FALSE
 
 net emcmot.08.enable <= axis.8.amp-enable-out 
-net emcmot.08.enable => [PRUCONF](DRIVER).stepgen.08.enable
+net emcmot.08.enable => hpg.stepgen.08.enable
 
 
 # position command and feedback
 net emcmot.08.pos-cmd <= axis.8.motor-pos-cmd
-net emcmot.08.pos-cmd => [PRUCONF](DRIVER).stepgen.08.position-cmd
+net emcmot.08.pos-cmd => hpg.stepgen.08.position-cmd
 
-net motor.08.pos-fb <= [PRUCONF](DRIVER).stepgen.08.position-fb
+net motor.08.pos-fb <= hpg.stepgen.08.position-fb
 net motor.08.pos-fb => axis.8.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.08.dirsetup        [AXIS_8]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.08.dirhold         [AXIS_8]DIRHOLD
+setp hpg.stepgen.08.dirsetup        [AXIS_8]DIRSETUP
+setp hpg.stepgen.08.dirhold         [AXIS_8]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.08.steplen         [AXIS_8]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.08.stepspace       [AXIS_8]STEPSPACE
+setp hpg.stepgen.08.steplen         [AXIS_8]STEPLEN
+setp hpg.stepgen.08.stepspace       [AXIS_8]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.08.position-scale  [AXIS_8]SCALE
+setp hpg.stepgen.08.position-scale  [AXIS_8]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.08.maxvel          [AXIS_8]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.08.maxaccel        [AXIS_8]STEPGEN_MAX_ACC
+setp hpg.stepgen.08.maxvel          [AXIS_8]STEPGEN_MAX_VEL
+setp hpg.stepgen.08.maxaccel        [AXIS_8]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.08.step_type       0
+#setp hpg.stepgen.08.step_type       0
 # P9.22 GPIO0_2
-setp [PRUCONF](DRIVER).stepgen.08.steppin          0x62
+setp hpg.stepgen.08.steppin          0x62
 # P9.21 GPIO0_3
-setp [PRUCONF](DRIVER).stepgen.08.dirpin           0x63
+setp hpg.stepgen.08.dirpin           0x63
 
 
 ## ################
@@ -416,34 +416,34 @@ setp [PRUCONF](DRIVER).stepgen.08.dirpin           0x63
 #sets emcmot.09.enable FALSE
 #
 #net emcmot.09.enable <= axis.9.amp-enable-out 
-#net emcmot.09.enable => [PRUCONF](DRIVER).stepgen.09.enable
+#net emcmot.09.enable => hpg.stepgen.09.enable
 #
 #
 ## position command and feedback
 #net emcmot.09.pos-cmd <= axis.9.motor-pos-cmd
-#net emcmot.09.pos-cmd => [PRUCONF](DRIVER).stepgen.09.position-cmd
+#net emcmot.09.pos-cmd => hpg.stepgen.09.position-cmd
 #
-#net motor.09.pos-fb <= [PRUCONF](DRIVER).stepgen.09.position-fb
+#net motor.09.pos-fb <= hpg.stepgen.09.position-fb
 #net motor.09.pos-fb => axis.9.motor-pos-fb
 #
 #
 ## timing parameters
-#setp [PRUCONF](DRIVER).stepgen.09.dirsetup        [AXIS_9]DIRSETUP
-#setp [PRUCONF](DRIVER).stepgen.09.dirhold         [AXIS_9]DIRHOLD
+#setp hpg.stepgen.09.dirsetup        [AXIS_9]DIRSETUP
+#setp hpg.stepgen.09.dirhold         [AXIS_9]DIRHOLD
 #
-#setp [PRUCONF](DRIVER).stepgen.09.steplen         [AXIS_9]STEPLEN
-#setp [PRUCONF](DRIVER).stepgen.09.stepspace       [AXIS_9]STEPSPACE
+#setp hpg.stepgen.09.steplen         [AXIS_9]STEPLEN
+#setp hpg.stepgen.09.stepspace       [AXIS_9]STEPSPACE
 #
-#setp [PRUCONF](DRIVER).stepgen.09.position-scale  [AXIS_9]SCALE
+#setp hpg.stepgen.09.position-scale  [AXIS_9]SCALE
 #
-#setp [PRUCONF](DRIVER).stepgen.09.maxvel          [AXIS_9]STEPGEN_MAX_VEL
-#setp [PRUCONF](DRIVER).stepgen.09.maxaccel        [AXIS_9]STEPGEN_MAX_ACC
+#setp hpg.stepgen.09.maxvel          [AXIS_9]STEPGEN_MAX_VEL
+#setp hpg.stepgen.09.maxaccel        [AXIS_9]STEPGEN_MAX_ACC
 #
-##setp [PRUCONF](DRIVER).stepgen.09.step_type       0
+##setp hpg.stepgen.09.step_type       0
 ## P9.18 GPIO0_4
-#setp [PRUCONF](DRIVER).stepgen.09.steppin          0x64
+#setp hpg.stepgen.09.steppin          0x64
 ## P9.17 GPIO0_5
-#setp [PRUCONF](DRIVER).stepgen.09.dirpin           0x65
+#setp hpg.stepgen.09.dirpin           0x65
 #
 
 # ##################################################

--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper.hal
@@ -24,7 +24,7 @@ loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EM
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 loadrt pepper count=1
@@ -39,7 +39,7 @@ loadusr -Wn Therm ./ReadTemp.py -n Therm --num_chan 2 -t 1 1 -a 4 5
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         base-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -47,7 +47,7 @@ addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        base-thread
 addf pepper.update			  base-thread
 
@@ -65,34 +65,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.12 GPIO1_12
-setp [PRUCONF](DRIVER).stepgen.00.steppin          0x4C
+setp hpg.stepgen.00.steppin          0x4C
 # P8.11 GPIO1_13
-setp [PRUCONF](DRIVER).stepgen.00.dirpin           0x4D
+setp hpg.stepgen.00.dirpin           0x4D
 
 
 # ################
@@ -104,34 +104,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.16 GPIO1_14
-setp [PRUCONF](DRIVER).stepgen.01.steppin          0x4E
+setp hpg.stepgen.01.steppin          0x4E
 # P8.15 GPIO1_15
-setp [PRUCONF](DRIVER).stepgen.01.dirpin           0x4F
+setp hpg.stepgen.01.dirpin           0x4F
 
 
 # ################
@@ -143,34 +143,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P9.15 GPIO1_16
-setp [PRUCONF](DRIVER).stepgen.02.steppin          0x50
+setp hpg.stepgen.02.steppin          0x50
 # P9.23 GPIO1_17
-setp [PRUCONF](DRIVER).stepgen.02.dirpin           0x51
+setp hpg.stepgen.02.dirpin           0x51
 
 
 # ################
@@ -182,34 +182,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P9.22 GPIO0_2
-setp [PRUCONF](DRIVER).stepgen.03.steppin          0x22
+setp hpg.stepgen.03.steppin          0x22
 # P9.21 GPIO0_3
-setp [PRUCONF](DRIVER).stepgen.03.dirpin           0x23
+setp hpg.stepgen.03.dirpin           0x23
 
 
 # ################
@@ -221,34 +221,34 @@ newsig emcmot.04.enable bit
 sets emcmot.04.enable FALSE
 
 net emcmot.04.enable <= axis.4.amp-enable-out
-net emcmot.04.enable => [PRUCONF](DRIVER).stepgen.04.enable
+net emcmot.04.enable => hpg.stepgen.04.enable
 
 
 # position command and feedback
 net emcmot.04.pos-cmd <= axis.4.motor-pos-cmd
-net emcmot.04.pos-cmd => [PRUCONF](DRIVER).stepgen.04.position-cmd
+net emcmot.04.pos-cmd => hpg.stepgen.04.position-cmd
 
-net motor.04.pos-fb <= [PRUCONF](DRIVER).stepgen.04.position-fb
+net motor.04.pos-fb <= hpg.stepgen.04.position-fb
 net motor.04.pos-fb => axis.4.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.04.dirsetup        [AXIS_4]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.04.dirhold         [AXIS_4]DIRHOLD
+setp hpg.stepgen.04.dirsetup        [AXIS_4]DIRSETUP
+setp hpg.stepgen.04.dirhold         [AXIS_4]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.04.steplen         [AXIS_4]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.04.stepspace       [AXIS_4]STEPSPACE
+setp hpg.stepgen.04.steplen         [AXIS_4]STEPLEN
+setp hpg.stepgen.04.stepspace       [AXIS_4]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.04.position-scale  [AXIS_4]SCALE
+setp hpg.stepgen.04.position-scale  [AXIS_4]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.04.maxvel          [AXIS_4]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.04.maxaccel        [AXIS_4]STEPGEN_MAX_ACC
+setp hpg.stepgen.04.maxvel          [AXIS_4]STEPGEN_MAX_VEL
+setp hpg.stepgen.04.maxaccel        [AXIS_4]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.04.step_type       0
+#setp hpg.stepgen.04.step_type       0
 # P9.18 GPIO0_4
-setp [PRUCONF](DRIVER).stepgen.04.steppin          0x24
+setp hpg.stepgen.04.steppin          0x24
 # P9.17 GPIO0_5
-setp [PRUCONF](DRIVER).stepgen.04.dirpin           0x25
+setp hpg.stepgen.04.dirpin           0x25
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper.hal
@@ -333,22 +333,22 @@ newsig bed.temp.set  float
 newsig bed.temp.meas float
 
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.enable    1
+setp hpg.pwmgen.00.out.00.value     0.0
 
 # J3 E1 Heater PRU1.out0
-setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
-setp hal_pru_generic.pwmgen.00.out.01.enable    1
-setp hal_pru_generic.pwmgen.00.out.01.value     0.0
+setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.enable    1
+setp hpg.pwmgen.00.out.01.value     0.0
 
 # J4 Bed Heater GPIO2.16
-setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
-setp hal_pru_generic.pwmgen.00.out.02.enable    1
-setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -360,7 +360,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 net e0.heater  => limit1.0.in
 net e0.heaterl <= limit1.0.out
-net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -376,7 +376,7 @@ net bed.temp.set     => pid.1.command
 net bed.heater  <= pid.1.output
 net bed.heater  => limit1.1.in
 net bed.heaterl <= limit1.1.out
-net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/lineardelta.hal
@@ -358,12 +358,12 @@ newsig bed.temp.meas float
 newsig fan.speed.set float
 
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.enable    1
+setp hpg.pwmgen.00.out.00.value     0.0
 
 #signals for comparing set value and actual value of temperature
 #newsig M209_set_temp             float
@@ -395,20 +395,20 @@ net e0_temp_within_range wcomp.0.out => motion.digital-in-00
 # no longer J3 E1 Heater PRU1.out0
 # instead used for FAN control
 # we use scale 255 for compatibility with slicing software
-setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
-setp hal_pru_generic.pwmgen.00.out.01.enable    1
-setp hal_pru_generic.pwmgen.00.out.01.value     0.0
-setp hal_pru_generic.pwmgen.00.out.01.scale     255
+setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.enable    1
+setp hpg.pwmgen.00.out.01.value     0.0
+setp hpg.pwmgen.00.out.01.scale     255
 
 #linking motion.analog-out-00 to fan speed.set.signal
 net fan.speed.set <= motion.analog-out-00
-net fan.speed.set => hal_pru_generic.pwmgen.00.out.01.value
+net fan.speed.set => hpg.pwmgen.00.out.01.value
 
 
 # J4 Bed Heater GPIO2.16
-setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
-setp hal_pru_generic.pwmgen.00.out.02.enable    1
-setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -420,7 +420,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 net e0.heater  => limit1.0.in
 net e0.heaterl <= limit1.0.out
-net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -436,7 +436,7 @@ net bed.temp.set     => pid.1.command
 net bed.heater  <= pid.1.output
 net bed.heater  => limit1.1.in
 net bed.heaterl <= limit1.1.out
-net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/lineardelta.hal
@@ -28,7 +28,7 @@ loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EM
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 loadrt pepper
@@ -47,7 +47,7 @@ loadrt sum2 count=2
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         base-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -55,7 +55,7 @@ addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        base-thread
 addf pepper.update			  base-thread
 
@@ -77,34 +77,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.12 GPIO1_12
-setp [PRUCONF](DRIVER).stepgen.00.steppin          0x4C
+setp hpg.stepgen.00.steppin          0x4C
 # P8.11 GPIO1_13
-setp [PRUCONF](DRIVER).stepgen.00.dirpin           0x4D
+setp hpg.stepgen.00.dirpin           0x4D
 
 # because column C is connected to the X-axis output
 # the BeBoPr++ signal needs to be X-max means P8.9
@@ -120,34 +120,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.16 GPIO1_14
-setp [PRUCONF](DRIVER).stepgen.01.steppin          0x4E
+setp hpg.stepgen.01.steppin          0x4E
 # P8.15 GPIO1_15
-setp [PRUCONF](DRIVER).stepgen.01.dirpin           0x4F
+setp hpg.stepgen.01.dirpin           0x4F
 
 # because column A is connected to the Y-axis output
 # the BeBoPr++ signal needs to be Y-max means P8.14
@@ -163,34 +163,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P9.15 GPIO1_16
-setp [PRUCONF](DRIVER).stepgen.02.steppin          0x50
+setp hpg.stepgen.02.steppin          0x50
 # P9.23 GPIO1_17
-setp [PRUCONF](DRIVER).stepgen.02.dirpin           0x51
+setp hpg.stepgen.02.dirpin           0x51
 
 # because column B is connected to the Z-axis output
 # the BeBoPr++ signal needs to be Z-max means P8.18
@@ -206,34 +206,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P9.22 GPIO0_2
-setp [PRUCONF](DRIVER).stepgen.03.steppin          0x22
+setp hpg.stepgen.03.steppin          0x22
 # P9.21 GPIO0_3
-setp [PRUCONF](DRIVER).stepgen.03.dirpin           0x23
+setp hpg.stepgen.03.dirpin           0x23
 
 
 # ################
@@ -245,34 +245,34 @@ newsig emcmot.04.enable bit
 sets emcmot.04.enable FALSE
 
 net emcmot.04.enable <= axis.4.amp-enable-out
-net emcmot.04.enable => [PRUCONF](DRIVER).stepgen.04.enable
+net emcmot.04.enable => hpg.stepgen.04.enable
 
 
 # position command and feedback
 net emcmot.04.pos-cmd <= axis.4.motor-pos-cmd
-net emcmot.04.pos-cmd => [PRUCONF](DRIVER).stepgen.04.position-cmd
+net emcmot.04.pos-cmd => hpg.stepgen.04.position-cmd
 
-net motor.04.pos-fb <= [PRUCONF](DRIVER).stepgen.04.position-fb
+net motor.04.pos-fb <= hpg.stepgen.04.position-fb
 net motor.04.pos-fb => axis.4.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.04.dirsetup        [AXIS_4]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.04.dirhold         [AXIS_4]DIRHOLD
+setp hpg.stepgen.04.dirsetup        [AXIS_4]DIRSETUP
+setp hpg.stepgen.04.dirhold         [AXIS_4]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.04.steplen         [AXIS_4]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.04.stepspace       [AXIS_4]STEPSPACE
+setp hpg.stepgen.04.steplen         [AXIS_4]STEPLEN
+setp hpg.stepgen.04.stepspace       [AXIS_4]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.04.position-scale  [AXIS_4]SCALE
+setp hpg.stepgen.04.position-scale  [AXIS_4]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.04.maxvel          [AXIS_4]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.04.maxaccel        [AXIS_4]STEPGEN_MAX_ACC
+setp hpg.stepgen.04.maxvel          [AXIS_4]STEPGEN_MAX_VEL
+setp hpg.stepgen.04.maxaccel        [AXIS_4]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.04.step_type       0
+#setp hpg.stepgen.04.step_type       0
 # P9.18 GPIO0_4
-setp [PRUCONF](DRIVER).stepgen.04.steppin          0x24
+setp hpg.stepgen.04.steppin          0x24
 # P9.17 GPIO0_5
-setp [PRUCONF](DRIVER).stepgen.04.dirpin           0x25
+setp hpg.stepgen.04.dirpin           0x25
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/BeBoPr++.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/BeBoPr++.hal
@@ -250,22 +250,22 @@ newsig bed.temp.set  float
 newsig bed.temp.meas float
 
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.enable    1
+setp hpg.pwmgen.00.out.00.value     0.0
 
 # J3 E1 Heater PRU1.out0
-setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
-setp hal_pru_generic.pwmgen.00.out.01.enable    1
-setp hal_pru_generic.pwmgen.00.out.01.value     0.0
+setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.enable    1
+setp hpg.pwmgen.00.out.01.value     0.0
 
 # J4 Bed Heater GPIO2.16
-setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
-setp hal_pru_generic.pwmgen.00.out.02.enable    1
-setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -277,7 +277,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 net e0.heater  => limit1.0.in
 net e0.heaterl <= limit1.0.out
-net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -293,7 +293,7 @@ net bed.temp.set     => pid.1.command
 net bed.heater  <= pid.1.output
 net bed.heater  => limit1.1.in
 net bed.heaterl <= limit1.1.out
-net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/BeBoPr++.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/BeBoPr++.hal
@@ -25,7 +25,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 
@@ -39,7 +39,7 @@ loadusr -Wn Therm ./ReadTemp.py -n Therm --num_chan 2 -t 1 1 -a 4 5
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -47,7 +47,7 @@ addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 
@@ -65,34 +65,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.12 GPIO44
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         0x4C
 # P8.11 GPIO45
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          0x4D
 
 # ################
 # Y [1] Axis
@@ -103,34 +103,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.16 GPIO46
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         0x4E
 # P8.15 GPIO47
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          0x4F
 
 
 # ################
@@ -142,34 +142,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P9.15 GPIO48
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         0x50
 # P9.23 GPIO49
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          0x51
 
 
 # ################
@@ -181,34 +181,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P9.22 GPIO2
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0x22
+setp hpg.stepgen.03.steppin         0x22
 # P9.21 GPIO3
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x23
+setp hpg.stepgen.03.dirpin          0x23
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/TAKE-5.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/TAKE-5.hal
@@ -25,7 +25,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 
@@ -39,7 +39,7 @@ loadusr -Wn Therm ./ReadTemp.py -n Therm --num_chan 2 -t 1 1 -a 4 5
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -47,7 +47,7 @@ addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 
@@ -65,34 +65,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.12 GPIO44
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         0x4C
 # P8.11 GPIO45
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          0x4D
 
 
 # ################
@@ -104,34 +104,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.16 GPIO46
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         0x4E
 # P8.15 GPIO47
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          0x4F
 
 
 # ################
@@ -143,34 +143,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P9.15 GPIO48
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         0x50
 # P9.23 GPIO49
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          0x51
 
 
 # ################
@@ -182,34 +182,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P9.22 GPIO2
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0x22
+setp hpg.stepgen.03.steppin         0x22
 # P9.21 GPIO3
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x23
+setp hpg.stepgen.03.dirpin          0x23
 
 # ################
 # B [4] Axis (2nd Extruder)
@@ -220,34 +220,34 @@ newsig emcmot.04.enable bit
 sets emcmot.04.enable FALSE
 
 net emcmot.04.enable <= axis.4.amp-enable-out
-net emcmot.04.enable => [PRUCONF](DRIVER).stepgen.04.enable
+net emcmot.04.enable => hpg.stepgen.04.enable
 
 
 # position command and feedback
 net emcmot.04.pos-cmd <= axis.4.motor-pos-cmd
-net emcmot.04.pos-cmd => [PRUCONF](DRIVER).stepgen.04.position-cmd
+net emcmot.04.pos-cmd => hpg.stepgen.04.position-cmd
 
-net motor.04.pos-fb <= [PRUCONF](DRIVER).stepgen.04.position-fb
+net motor.04.pos-fb <= hpg.stepgen.04.position-fb
 net motor.04.pos-fb => axis.4.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.04.dirsetup        [AXIS_4]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.04.dirhold         [AXIS_4]DIRHOLD
+setp hpg.stepgen.04.dirsetup        [AXIS_4]DIRSETUP
+setp hpg.stepgen.04.dirhold         [AXIS_4]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.04.steplen         [AXIS_4]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.04.stepspace       [AXIS_4]STEPSPACE
+setp hpg.stepgen.04.steplen         [AXIS_4]STEPLEN
+setp hpg.stepgen.04.stepspace       [AXIS_4]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.04.position-scale  [AXIS_4]SCALE
+setp hpg.stepgen.04.position-scale  [AXIS_4]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.04.maxvel          [AXIS_4]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.04.maxaccel        [AXIS_4]STEPGEN_MAX_ACC
+setp hpg.stepgen.04.maxvel          [AXIS_4]STEPGEN_MAX_VEL
+setp hpg.stepgen.04.maxaccel        [AXIS_4]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.04.step_type       0
+#setp hpg.stepgen.04.step_type       0
 # P9.18 GPIO0_4
-setp [PRUCONF](DRIVER).stepgen.04.steppin         0x24
+setp hpg.stepgen.04.steppin         0x24
 # P9.17 GPIO0_5
-setp [PRUCONF](DRIVER).stepgen.04.dirpin          0x25
+setp hpg.stepgen.04.dirpin          0x25
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/TAKE-5.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/TAKE-5.hal
@@ -292,22 +292,22 @@ newsig bed.temp.set  float
 newsig bed.temp.meas float
 
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.enable    1
+setp hpg.pwmgen.00.out.00.value     0.0
 
 # J3 E1 Heater PRU1.out0
-setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
-setp hal_pru_generic.pwmgen.00.out.01.enable    1
-setp hal_pru_generic.pwmgen.00.out.01.value     0.0
+setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.enable    1
+setp hpg.pwmgen.00.out.01.value     0.0
 
 # J4 Bed Heater GPIO2.16
-setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
-setp hal_pru_generic.pwmgen.00.out.02.enable    1
-setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -319,7 +319,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 net e0.heater  => limit1.0.in
 net e0.heaterl <= limit1.0.out
-net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -335,7 +335,7 @@ net bed.temp.set     => pid.1.command
 net bed.heater  <= pid.1.output
 net bed.heater  => limit1.1.in
 net bed.heaterl <= limit1.1.out
-net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.hal
@@ -28,7 +28,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 
@@ -47,7 +47,7 @@ loadrt sum2 count=2
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -55,7 +55,7 @@ addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 addf wcomp.0                              servo-thread
@@ -77,34 +77,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.43 PRU1.out2
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         0x4C
 # P8.44 PRU1.out4
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          0x4D
 
 # because column C is connected to the X-axis output
 # the bebopr-bridge signal needs to be X-max means P8.9
@@ -120,34 +120,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.42 PRU1.out5
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         0x4E
 # P8.39 PRU1.out6
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          0x4F
 
 
 # because column A is connected to the Y-axis output
@@ -164,34 +164,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P8.27 PRU1.out8
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         0x50
 # P8.29 PRU1.out9
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          0x51
 
 # because column B is connected to the Z-axis output
 # the bebopr-bridge signal needs to be Z-max means P8.18
@@ -207,34 +207,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P8.30 GPIO2.25
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0x22
+setp hpg.stepgen.03.steppin         0x22
 # P8.21 GPIO1.30
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x23
+setp hpg.stepgen.03.dirpin          0x23
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.hal
@@ -276,12 +276,12 @@ newsig bed.temp.set  float
 newsig bed.temp.meas float
 newsig fan.speed.set float
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.enable    1
+setp hpg.pwmgen.00.out.00.value     0.0
 
 #signals for comparing set value and actual value of temperature
 #newsig M209_set_temp             float
@@ -313,20 +313,20 @@ net e0_temp_within_range wcomp.0.out => motion.digital-in-00
 # no longer J3 E1 Heater PRU1.out0
 # instead used for FAN control
 # we use scale 255 for compatibility with slicing software
-setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
-setp hal_pru_generic.pwmgen.00.out.01.enable    1
-setp hal_pru_generic.pwmgen.00.out.01.value     0.0
-setp hal_pru_generic.pwmgen.00.out.01.scale     255
+setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.enable    1
+setp hpg.pwmgen.00.out.01.value     0.0
+setp hpg.pwmgen.00.out.01.scale     255
 
 #linking motion.analog-out-00 to fan speed.set.signal
 net fan.speed.set <= motion.analog-out-00
-net fan.speed.set => hal_pru_generic.pwmgen.00.out.01.value
+net fan.speed.set => hpg.pwmgen.00.out.01.value
 
 
 # J4 Bed Heater GPIO2.16
-setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
-setp hal_pru_generic.pwmgen.00.out.02.enable    1
-setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -338,7 +338,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 net e0.heater  => limit1.0.in
 net e0.heaterl <= limit1.0.out
-net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -354,7 +354,7 @@ net bed.temp.set     => pid.1.command
 net bed.heater  <= pid.1.output
 net bed.heater  => limit1.1.in
 net bed.heaterl <= limit1.1.out
-net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
@@ -251,22 +251,22 @@ newsig bed.temp.set  float
 newsig bed.temp.meas float
 
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.enable    1
+setp hpg.pwmgen.00.out.00.value     0.0
 
 # J3 E1 Heater PRU1.out0
-setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
-setp hal_pru_generic.pwmgen.00.out.01.enable    1
-setp hal_pru_generic.pwmgen.00.out.01.value     0.0
+setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.enable    1
+setp hpg.pwmgen.00.out.01.value     0.0
 
 # J4 Bed Heater GPIO2.16
-setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
-setp hal_pru_generic.pwmgen.00.out.02.enable    1
-setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -278,7 +278,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 net e0.heater  => limit1.0.in
 net e0.heaterl <= limit1.0.out
-net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -294,7 +294,7 @@ net bed.temp.set     => pid.1.command
 net bed.heater  <= pid.1.output
 net bed.heater  => limit1.1.in
 net bed.heaterl <= limit1.1.out
-net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
@@ -25,7 +25,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 
@@ -39,7 +39,7 @@ loadusr -Wn Therm ./ReadTemp.py -n Therm --num_chan 2 -t 1 1 -a 4 5
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -47,7 +47,7 @@ addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 
@@ -65,34 +65,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.43 PRU1.out2
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         0x4C
 # P8.44 PRU1.out4
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          0x4D
 
 
 # ################
@@ -104,34 +104,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.42 PRU1.out5
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         0x4E
 # P8.39 PRU1.out6
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          0x4F
 
 
 # ################
@@ -143,34 +143,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P8.27 PRU1.out8
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         0x50
 # P8.29 PRU1.out9
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          0x51
 
 
 # ################
@@ -182,34 +182,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P8.30 GPIO2.25
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0x22
+setp hpg.stepgen.03.steppin         0x22
 # P8.21 GPIO1.30
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x23
+setp hpg.stepgen.03.dirpin          0x23
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
@@ -29,7 +29,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 
@@ -48,7 +48,7 @@ loadrt sum2 count=2
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -56,7 +56,7 @@ addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 addf wcomp.0                              servo-thread
@@ -78,34 +78,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.43 PRU1.out2
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         0x4C
 # P8.44 PRU1.out4
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          0x4D
 
 # because column C is connected to the X-axis output
 # the bebopr-bridge signal needs to be X-max means P8.9
@@ -121,34 +121,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.42 PRU1.out5
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         0x4E
 # P8.39 PRU1.out6
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          0x4F
 
 
 # because column A is connected to the Y-axis output
@@ -165,34 +165,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P8.27 PRU1.out8
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         0x50
 # P8.29 PRU1.out9
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          0x51
 
 # because column B is connected to the Z-axis output
 # the bebopr-bridge signal needs to be Z-max means P8.18
@@ -208,34 +208,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P8.30 GPIO2.25
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0x22
+setp hpg.stepgen.03.steppin         0x22
 # P8.21 GPIO1.30
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x23
+setp hpg.stepgen.03.dirpin          0x23
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
@@ -277,12 +277,12 @@ newsig bed.temp.set  float
 newsig bed.temp.meas float
 newsig fan.speed.set float
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.enable    1
+setp hpg.pwmgen.00.out.00.value     0.0
 
 #signals for comparing set value and actual value of temperature
 #newsig M209_set_temp             float
@@ -314,20 +314,20 @@ net e0_temp_within_range wcomp.0.out => motion.digital-in-00
 # no longer J3 E1 Heater PRU1.out0
 # instead used for FAN control
 # we use scale 255 for compatibility with slicing software
-setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
-setp hal_pru_generic.pwmgen.00.out.01.enable    1
-setp hal_pru_generic.pwmgen.00.out.01.value     0.0
-setp hal_pru_generic.pwmgen.00.out.01.scale     255
+setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.enable    1
+setp hpg.pwmgen.00.out.01.value     0.0
+setp hpg.pwmgen.00.out.01.scale     255
 
 #linking motion.analog-out-00 to fan speed.set.signal
 net fan.speed.set <= motion.analog-out-00
-net fan.speed.set => hal_pru_generic.pwmgen.00.out.01.value
+net fan.speed.set => hpg.pwmgen.00.out.01.value
 
 
 # J4 Bed Heater GPIO2.16
-setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
-setp hal_pru_generic.pwmgen.00.out.02.enable    1
-setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -339,7 +339,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 net e0.heater  => limit1.0.in
 net e0.heaterl <= limit1.0.out
-net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -355,7 +355,7 @@ net bed.temp.set     => pid.1.command
 net bed.heater  <= pid.1.output
 net bed.heater  => limit1.1.in
 net bed.heaterl <= limit1.1.out
-net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.hal
@@ -30,7 +30,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 
@@ -58,7 +58,7 @@ loadrt lineardeltajointscartesian count=1
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -67,7 +67,7 @@ addf pid.1.do-pid-calcs                   servo-thread
 #addf pid.2.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 addf wcomp.0                              servo-thread
@@ -111,34 +111,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.43 PRU1.out2
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         0x4C
 # P8.44 PRU1.out4
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          0x4D
 
 # because column C is connected to the X-axis output
 # the bebopr-bridge signal needs to be X-max means P8.9
@@ -154,34 +154,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.42 PRU1.out5
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         0x4E
 # P8.39 PRU1.out6
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          0x4F
 
 
 # because column A is connected to the Y-axis output
@@ -198,34 +198,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P8.27 PRU1.out8
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         0x50
 # P8.29 PRU1.out9
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          0x51
 
 # because column B is connected to the Z-axis output
 # the bebopr-bridge signal needs to be Z-max means P8.18
@@ -241,7 +241,7 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 #here i pass the value of the analog output from M67 E1 Q.. or M68 E1 Q.. to the multiplicator
 net line-width  motion.analog-out-02 => mult2.0.in0
@@ -339,7 +339,7 @@ net extruder-speed mux4.0.out sum2.2.in0 ddt.0.in
 net extruder-accel ddt.0.out lincurve.0.in
 # get adjusted speed for adding to current speed during accelleration
 net speed-adjustment lincurve.0.out sum2.2.in1
-net extruder-speed-adjusted sum2.2.out [PRUCONF](DRIVER).stepgen.03.velocity-cmd
+net extruder-speed-adjusted sum2.2.out hpg.stepgen.03.velocity-cmd
 
 #########
 ###todo
@@ -347,24 +347,24 @@ net extruder-speed-adjusted sum2.2.out [PRUCONF](DRIVER).stepgen.03.velocity-cmd
 #########
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-setp [PRUCONF](DRIVER).stepgen.03.control-type    1
+setp hpg.stepgen.03.control-type    1
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P8.30 GPIO2.25
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0x22
+setp hpg.stepgen.03.steppin         0x22
 # P8.21 GPIO1.30
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x23
+setp hpg.stepgen.03.dirpin          0x23
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.hal
@@ -406,12 +406,12 @@ newsig bed.temp.set  float
 newsig bed.temp.meas float
 newsig fan.speed.set float
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.enable    1
+setp hpg.pwmgen.00.out.00.value     0.0
 
 #signals for comparing set value and actual value of temperature
 #newsig M209_set_temp             float
@@ -445,20 +445,20 @@ net e0_temp_within_range wcomp.0.out => motion.digital-in-00
 # no longer J3 E1 Heater PRU1.out0
 # instead used for FAN control
 # we use scalse 255 for campatibility with slicing software
-setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
-setp hal_pru_generic.pwmgen.00.out.01.enable    1
-setp hal_pru_generic.pwmgen.00.out.01.value     0.0
-setp hal_pru_generic.pwmgen.00.out.01.scale     255
+setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.enable    1
+setp hpg.pwmgen.00.out.01.value     0.0
+setp hpg.pwmgen.00.out.01.scale     255
 
 #linking motion.analog-out-00 to fan speed.set.signal
 net fan.speed.set <= motion.analog-out-00
-net fan.speed.set => hal_pru_generic.pwmgen.00.out.01.value
+net fan.speed.set => hpg.pwmgen.00.out.01.value
 
 
 # J4 Bed Heater GPIO2.16
-setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
-setp hal_pru_generic.pwmgen.00.out.02.enable    1
-setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -470,7 +470,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 net e0.heater  => limit1.0.in
 net e0.heaterl <= limit1.0.out
-net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -486,7 +486,7 @@ net bed.temp.set     => pid.1.command
 net bed.heater  <= pid.1.output
 net bed.heater  => limit1.1.in
 net bed.heaterl <= limit1.1.out
-net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/BeBoPr/BeBoPr.hal
+++ b/configs/ARM/BeagleBone/BeBoPr/BeBoPr.hal
@@ -25,7 +25,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=103,105,107,120,128,140,141 input_pins=131,132,133,135,137,138
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 
@@ -39,7 +39,7 @@ loadusr -Wn Therm ./ReadTemp.py -n Therm --num_chan 2 -t 1 1 -a 1 3
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -47,7 +47,7 @@ addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 
@@ -65,34 +65,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.43 PRU1.out2
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0xA2
+setp hpg.stepgen.00.steppin         0xA2
 # P8.44 PRU1.out4
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0xA3
+setp hpg.stepgen.00.dirpin          0xA3
 
 
 # ################
@@ -104,34 +104,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.42 PRU1.out5
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0xA5
+setp hpg.stepgen.01.steppin         0xA5
 # P8.39 PRU1.out6
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0xA6
+setp hpg.stepgen.01.dirpin          0xA6
 
 
 # ################
@@ -143,34 +143,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P8.27 PRU1.out8
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0xA8
+setp hpg.stepgen.02.steppin         0xA8
 # P8.29 PRU1.out9
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0xA9
+setp hpg.stepgen.02.dirpin          0xA9
 
 
 # ################
@@ -182,34 +182,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P8.30 GPIO2.25
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0xAB
+setp hpg.stepgen.03.steppin         0xAB
 # P8.21 GPIO1.30
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0xAC
+setp hpg.stepgen.03.dirpin          0xAC
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/BeBoPr/BeBoPr.hal
+++ b/configs/ARM/BeagleBone/BeBoPr/BeBoPr.hal
@@ -256,22 +256,22 @@ newsig bed.temp.set  float
 newsig bed.temp.meas float
 
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hal_pru_generic.pwmgen.00.out.00.pin       0xA1
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0xA1
+setp hpg.pwmgen.00.out.00.enable    1
+setp hpg.pwmgen.00.out.00.value     0.0
 
 # J3 E1 Heater PRU1.out0
-setp hal_pru_generic.pwmgen.00.out.01.pin       0xA0
-setp hal_pru_generic.pwmgen.00.out.01.enable    1
-setp hal_pru_generic.pwmgen.00.out.01.value     0.0
+setp hpg.pwmgen.00.out.01.pin       0xA0
+setp hpg.pwmgen.00.out.01.enable    1
+setp hpg.pwmgen.00.out.01.value     0.0
 
 # J4 Bed Heater GPIO2.16
-setp hal_pru_generic.pwmgen.00.out.02.pin       0x70
-setp hal_pru_generic.pwmgen.00.out.02.enable    1
-setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+setp hpg.pwmgen.00.out.02.pin       0x70
+setp hpg.pwmgen.00.out.02.enable    1
+setp hpg.pwmgen.00.out.02.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -283,7 +283,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 net e0.heater  => limit1.0.in
 net e0.heaterl <= limit1.0.out
-net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -299,7 +299,7 @@ net bed.temp.set     => pid.1.command
 net bed.heater  <= pid.1.output
 net bed.heater  => limit1.1.in
 net bed.heaterl <= limit1.1.out
-net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/PMDX-432/Shapeoko/Shapeoko.hal
+++ b/configs/ARM/BeagleBone/PMDX-432/Shapeoko/Shapeoko.hal
@@ -43,7 +43,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 # uncertain about P9-17 to 20, these are I2C channels - are these needed if we want to use BB-IO to talk to them?
 loadrt hal_bb_gpio input_pins=107,108,109,110,111,112,115,116,126,211,212,214,215,216,222,223,224,226 output_pins=113,114,117,118,119,127,129,134,136,139,140,141,142,143,144,145,146,213,217,218,221
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 
 
 # Python user-mode HAL module to read ADC value and generate a thermostat output for PWM
@@ -53,12 +53,12 @@ loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CO
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
 # revel in the free time here from not having to run PID
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 
@@ -76,34 +76,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P9.31 GPIO3_14
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0x8E
+setp hpg.stepgen.00.steppin         0x8E
 # P9.29 GPIO3_15
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x8F
+setp hpg.stepgen.00.dirpin          0x8F
 
 
 # ################
@@ -115,34 +115,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P9.30 GPIO3_16
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0x90
+setp hpg.stepgen.01.steppin         0x90
 # P9.28 GPIO3_17
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x91
+setp hpg.stepgen.01.dirpin          0x91
 
 
 # ################
@@ -154,33 +154,33 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P9.42 GPIO3_18 / GPIO0_7
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0x92
+setp hpg.stepgen.02.steppin         0x92
 # P9.27 GPIO3_19
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x93
+setp hpg.stepgen.02.dirpin          0x93
 
 
 # ################
@@ -192,34 +192,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P9.41 GPIO3_20 / GPIO0_20
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0x94
+setp hpg.stepgen.03.steppin         0x94
 # P9.25 GPIO3_21
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x95
+setp hpg.stepgen.03.dirpin          0x95
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/PMDX-432/Shapeoko/Shapeoko.hal
+++ b/configs/ARM/BeagleBone/PMDX-432/Shapeoko/Shapeoko.hal
@@ -253,23 +253,23 @@ net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
 # PWM Signals
 # ##################################################
 
-#setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+#setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 PRU1.out1
-#setp hal_pru_generic.pwmgen.00.out.00.pin       0xA1
-#setp hal_pru_generic.pwmgen.00.out.00.enable    1
-#setp hal_pru_generic.pwmgen.00.out.00.value     0.2
+#setp hpg.pwmgen.00.out.00.pin       0xA1
+#setp hpg.pwmgen.00.out.00.enable    1
+#setp hpg.pwmgen.00.out.00.value     0.2
 
 # J3 PRU1.out0
-#setp hal_pru_generic.pwmgen.00.out.01.pin       0xA0
-#setp hal_pru_generic.pwmgen.00.out.01.enable    1
-#setp hal_pru_generic.pwmgen.00.out.01.value     0.2
+#setp hpg.pwmgen.00.out.01.pin       0xA0
+#setp hpg.pwmgen.00.out.01.enable    1
+#setp hpg.pwmgen.00.out.01.value     0.2
 
 # J4 GPIO2.16
-#setp hal_pru_generic.pwmgen.00.out.02.pin       0x50
-#setp hal_pru_generic.pwmgen.00.out.02.enable    1
-#setp hal_pru_generic.pwmgen.00.out.02.value     0.2
+#setp hpg.pwmgen.00.out.02.pin       0x50
+#setp hpg.pwmgen.00.out.02.enable    1
+#setp hpg.pwmgen.00.out.02.value     0.2
 
 #setp bbio_temp.set 0x480
-#net thermostat <= bbio_temp.temp hal_pru_generic.pwmgen.00.out.00.value
-#net thermostat => hal_pru_generic.pwmgen.00.out.00.value
+#net thermostat <= bbio_temp.temp hpg.pwmgen.00.out.00.value
+#net thermostat => hpg.pwmgen.00.out.00.value

--- a/configs/ARM/BeagleBone/PMDX-432/Standard-Configs/K9-Generic.hal
+++ b/configs/ARM/BeagleBone/PMDX-432/Standard-Configs/K9-Generic.hal
@@ -43,7 +43,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 # uncertain about P9-17 to 20, these are I2C channels - are these needed if we want to use BB-IO to talk to them?
 loadrt hal_bb_gpio input_pins=107,108,109,110,111,112,115,116,126,211,212,214,215,216,222,223,224,226 output_pins=113,114,117,118,119,127,129,134,136,139,140,141,142,143,144,145,146,213,217,218,221
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 
 
 # Python user-mode HAL module to read ADC value and generate a thermostat output for PWM
@@ -53,12 +53,12 @@ loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CO
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
 # revel in the free time here from not having to run PID
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 
@@ -76,34 +76,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P9.31 GPIO3_14
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0x8E
+setp hpg.stepgen.00.steppin         0x8E
 # P9.29 GPIO3_15
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x8F
+setp hpg.stepgen.00.dirpin          0x8F
 
 
 # ################
@@ -115,34 +115,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P9.30 GPIO3_16
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0x90
+setp hpg.stepgen.01.steppin         0x90
 # P9.28 GPIO3_17
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x91
+setp hpg.stepgen.01.dirpin          0x91
 
 
 # ################
@@ -154,33 +154,33 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P9.42 GPIO3_18 / GPIO0_7
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0x92
+setp hpg.stepgen.02.steppin         0x92
 # P9.27 GPIO3_19
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x93
+setp hpg.stepgen.02.dirpin          0x93
 
 
 # ################
@@ -192,34 +192,34 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 # P9.41 GPIO3_20 / GPIO0_20
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0x94
+setp hpg.stepgen.03.steppin         0x94
 # P9.25 GPIO3_21
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x95
+setp hpg.stepgen.03.dirpin          0x95
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/PMDX-432/Standard-Configs/K9-Generic.hal
+++ b/configs/ARM/BeagleBone/PMDX-432/Standard-Configs/K9-Generic.hal
@@ -253,23 +253,23 @@ net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
 # PWM Signals
 # ##################################################
 
-#setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+#setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 PRU1.out1
-#setp hal_pru_generic.pwmgen.00.out.00.pin       0xA1
-#setp hal_pru_generic.pwmgen.00.out.00.enable    1
-#setp hal_pru_generic.pwmgen.00.out.00.value     0.2
+#setp hpg.pwmgen.00.out.00.pin       0xA1
+#setp hpg.pwmgen.00.out.00.enable    1
+#setp hpg.pwmgen.00.out.00.value     0.2
 
 # J3 PRU1.out0
-#setp hal_pru_generic.pwmgen.00.out.01.pin       0xA0
-#setp hal_pru_generic.pwmgen.00.out.01.enable    1
-#setp hal_pru_generic.pwmgen.00.out.01.value     0.2
+#setp hpg.pwmgen.00.out.01.pin       0xA0
+#setp hpg.pwmgen.00.out.01.enable    1
+#setp hpg.pwmgen.00.out.01.value     0.2
 
 # J4 GPIO2.16
-#setp hal_pru_generic.pwmgen.00.out.02.pin       0x50
-#setp hal_pru_generic.pwmgen.00.out.02.enable    1
-#setp hal_pru_generic.pwmgen.00.out.02.value     0.2
+#setp hpg.pwmgen.00.out.02.pin       0x50
+#setp hpg.pwmgen.00.out.02.enable    1
+#setp hpg.pwmgen.00.out.02.value     0.2
 
 #setp bbio_temp.set 0x480
-#net thermostat <= bbio_temp.temp hal_pru_generic.pwmgen.00.out.00.value
-#net thermostat => hal_pru_generic.pwmgen.00.out.00.value
+#net thermostat <= bbio_temp.temp hpg.pwmgen.00.out.00.value
+#net thermostat => hpg.pwmgen.00.out.00.value

--- a/configs/ARM/BeagleBone/PocketNC/PocketNC.hal
+++ b/configs/ARM/BeagleBone/PocketNC/PocketNC.hal
@@ -415,7 +415,7 @@ setp spindleScale.gain 0.005
 setp spindleScale.offset 0.035
 net spindleSpeedDummy motion.spindle-speed-out
 net spindleSpeed motion.spindle-speed-out-rps => spindleScale.in
-net spindlePwm spindleScale.out => hal_pru_generic.pwmgen.00.out.00.value
+net spindlePwm spindleScale.out => hpg.pwmgen.00.out.00.value
 
 net spindleAtSpeed <= bb_gpio.p8.in-22
 net spindleAtSpeed => motion.spindle-at-speed
@@ -434,22 +434,22 @@ newsig bed.temp.set  float
 newsig bed.temp.meas float
 
 
-setp hal_pru_generic.pwmgen.00.pwm_period       10000000
+setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hal_pru_generic.pwmgen.00.out.00.pin       0x37
-setp hal_pru_generic.pwmgen.00.out.00.enable    1
-##setp hal_pru_generic.pwmgen.00.out.00.value     0.0
+setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.enable    1
+##setp hpg.pwmgen.00.out.00.value     0.0
 
 # J3 E1 Heater PRU1.out0
-#setp hal_pru_generic.pwmgen.00.out.01.pin       0x36
-#setp hal_pru_generic.pwmgen.00.out.01.enable    1
-#setp hal_pru_generic.pwmgen.00.out.01.value     0.0
+#setp hpg.pwmgen.00.out.01.pin       0x36
+#setp hpg.pwmgen.00.out.01.enable    1
+#setp hpg.pwmgen.00.out.01.value     0.0
 
 # J4 Bed Heater GPIO2.16
-#setp hal_pru_generic.pwmgen.00.out.02.pin       0x52
-#setp hal_pru_generic.pwmgen.00.out.02.enable    1
-#setp hal_pru_generic.pwmgen.00.out.02.value     0.0
+#setp hpg.pwmgen.00.out.02.pin       0x52
+#setp hpg.pwmgen.00.out.02.enable    1
+#setp hpg.pwmgen.00.out.02.value     0.0
 
 # PID for Extruder 0 temperature control
 net e0.temp.meas    <= Therm.temp0
@@ -461,7 +461,7 @@ net e0.temp.set     => pid.0.command
 net e0.heater  <= pid.0.output
 #net e0.heater  => limit1.0.in
 #net e0.heaterl <= limit1.0.out
-#net e0.heaterl => hal_pru_generic.pwmgen.00.out.00.value
+#net e0.heaterl => hpg.pwmgen.00.out.00.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values
@@ -477,7 +477,7 @@ net bed.temp.set     => pid.1.command
 #net bed.heater  <= pid.1.output
 #net bed.heater  => limit1.1.in
 #net bed.heaterl <= limit1.1.out
-#net bed.heaterl => hal_pru_generic.pwmgen.00.out.02.value
+#net bed.heaterl => hpg.pwmgen.00.out.02.value
 
 # Limit heater PWM to positive values
 # PWM mimics hm2 implementation, which generates output for negative values

--- a/configs/ARM/BeagleBone/PocketNC/PocketNC.hal
+++ b/configs/ARM/BeagleBone/PocketNC/PocketNC.hal
@@ -27,7 +27,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 #loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,110,114,117,118
 #loadrt hal_bb_gpio output_pins=107,126,211,212,218,224,226 input_pins=108,109,110,114,117,118,122
 loadrt hal_bb_gpio output_pins=211,212,218,224 input_pins=107,108,109,110,114,117,118,119,122,126,213,216
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid num_chan=2
 loadrt limit1 count=2
 
@@ -49,7 +49,7 @@ loadusr -Wn Therm /home/machinekit/machinekit-dev/configs/ARM/BeagleBone/BeBoPr-
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position	servo-thread
+addf hpg.capture-position	servo-thread
 addf bb_gpio.read						servo-thread
 addf motion-command-handler				servo-thread
 addf motion-controller					servo-thread
@@ -57,7 +57,7 @@ addf pid.0.do-pid-calcs					servo-thread
 addf pid.1.do-pid-calcs					servo-thread
 addf limit1.0							servo-thread
 addf limit1.1							servo-thread
-addf [PRUCONF](DRIVER).update			servo-thread
+addf hpg.update			servo-thread
 addf bb_gpio.write						servo-thread
 addf spindleScale						servo-thread
 #addf pwrToggle							servo-thread
@@ -95,34 +95,34 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable
+net emcmot.00.enable => hpg.stepgen.00.enable
 
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
-net emcmot.00.pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
+net emcmot.00.pos-cmd => hpg.stepgen.00.position-cmd
 
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb
 net motor.00.pos-fb => axis.0.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
+#setp hpg.stepgen.00.step_type       0
 # P8.43 PRU1.out2
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         0x4C
 # P8.44 PRU1.out4
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          0x4D
 
 
 # ################
@@ -134,34 +134,34 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable
+net emcmot.01.enable => hpg.stepgen.01.enable
 
 
 # position command and feedback
 net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
-net emcmot.01.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
+net emcmot.01.pos-cmd => hpg.stepgen.01.position-cmd
 
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb
 net motor.01.pos-fb => axis.1.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
+#setp hpg.stepgen.01.step_type       0
 # P8.42 PRU1.out5
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         0x4E
 # P8.39 PRU1.out6
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          0x4F
 
 
 # ################
@@ -173,34 +173,34 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable
+net emcmot.02.enable => hpg.stepgen.02.enable
 
 
 # position command and feedback
 net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
-net emcmot.02.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
+net emcmot.02.pos-cmd => hpg.stepgen.02.position-cmd
 
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb
 net motor.02.pos-fb => axis.2.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
+#setp hpg.stepgen.02.step_type       0
 # P8.27 PRU1.out8
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         0x50
 # P8.29 PRU1.out9
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          0x51
 
 
 # ################
@@ -212,40 +212,40 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable
+net emcmot.03.enable => hpg.stepgen.03.enable
 
 
 # position command and feedback
 net emcmot.03.pos-cmd <= axis.3.motor-pos-cmd
-net emcmot.03.pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
+net emcmot.03.pos-cmd => hpg.stepgen.03.position-cmd
 
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb
 net motor.03.pos-fb => axis.3.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
+#setp hpg.stepgen.03.step_type       0
 ## P9.22 GPIO2.25
-#setp [PRUCONF](DRIVER).stepgen.03.steppin         0x22
+#setp hpg.stepgen.03.steppin         0x22
 ## P9.21 GPIO1.30
-#setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x23
+#setp hpg.stepgen.03.dirpin          0x23
 
 
 # P9.27 GPIO3.19
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0x93
+setp hpg.stepgen.03.steppin         0x93
 # P9.28 GPIO3.17
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x91
+setp hpg.stepgen.03.dirpin          0x91
 
 
 
@@ -259,40 +259,40 @@ newsig emcmot.04.enable bit
 sets emcmot.04.enable FALSE
 
 net emcmot.04.enable <= axis.4.amp-enable-out
-net emcmot.04.enable => [PRUCONF](DRIVER).stepgen.04.enable
+net emcmot.04.enable => hpg.stepgen.04.enable
 
 
 # position command and feedback
 net emcmot.04.pos-cmd <= axis.4.motor-pos-cmd
-net emcmot.04.pos-cmd => [PRUCONF](DRIVER).stepgen.04.position-cmd
+net emcmot.04.pos-cmd => hpg.stepgen.04.position-cmd
 
-net motor.04.pos-fb <= [PRUCONF](DRIVER).stepgen.04.position-fb
+net motor.04.pos-fb <= hpg.stepgen.04.position-fb
 net motor.04.pos-fb => axis.4.motor-pos-fb
 
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.04.dirsetup        [AXIS_4]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.04.dirhold         [AXIS_4]DIRHOLD
+setp hpg.stepgen.04.dirsetup        [AXIS_4]DIRSETUP
+setp hpg.stepgen.04.dirhold         [AXIS_4]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.04.steplen         [AXIS_4]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.04.stepspace       [AXIS_4]STEPSPACE
+setp hpg.stepgen.04.steplen         [AXIS_4]STEPLEN
+setp hpg.stepgen.04.stepspace       [AXIS_4]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.04.position-scale  [AXIS_4]SCALE
+setp hpg.stepgen.04.position-scale  [AXIS_4]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.04.maxvel          [AXIS_4]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.04.maxaccel        [AXIS_4]STEPGEN_MAX_ACC
+setp hpg.stepgen.04.maxvel          [AXIS_4]STEPGEN_MAX_VEL
+setp hpg.stepgen.04.maxaccel        [AXIS_4]STEPGEN_MAX_ACC
 
-#setp [PRUCONF](DRIVER).stepgen.04.step_type       0
+#setp hpg.stepgen.04.step_type       0
 # P8.30 GPIO2.25
-#setp [PRUCONF](DRIVER).stepgen.04.steppin         0x24
+#setp hpg.stepgen.04.steppin         0x24
 # P8.21 GPIO1.30
-#setp [PRUCONF](DRIVER).stepgen.04.dirpin          0x25
+#setp hpg.stepgen.04.dirpin          0x25
 
 
 # P9.29 GPIO3.15
-setp [PRUCONF](DRIVER).stepgen.04.steppin         0x8f
+setp hpg.stepgen.04.steppin         0x8f
 # P9.30 GPIO3.16
-setp [PRUCONF](DRIVER).stepgen.04.dirpin          0x90
+setp hpg.stepgen.04.dirpin          0x90
 
 
 # ##################################################

--- a/configs/ARM/BeagleBone/Probotix/Comet.hal
+++ b/configs/ARM/BeagleBone/Probotix/Comet.hal
@@ -15,16 +15,16 @@ loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EM
 # loadrt threads fp1=0 name1=fast period1=50000 name2=slow period2=1000000
 
 loadrt hal_bb_gpio output_pins=113,116 input_pins=108,114,115,117,118
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt gantry count=1 personality=2
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf gantry.0.read                        servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
 addf gantry.0.write                       servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 
@@ -39,65 +39,65 @@ setp bb_gpio.p8.in-18.invert 0
 # set up the axis parameters and create the axis signals
 
 # x-axis
-setp [PRUCONF](DRIVER).stepgen.00.position-scale [AXIS_0]SCALE
-setp [PRUCONF](DRIVER).stepgen.00.steplen 2000
-setp [PRUCONF](DRIVER).stepgen.00.stepspace 2000
-setp [PRUCONF](DRIVER).stepgen.00.dirhold 35000
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup 35000
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel [AXIS_0]STEPGEN_MAXACCEL
-#setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-net xpos-cmd axis.0.motor-pos-cmd => [PRUCONF](DRIVER).stepgen.00.position-cmd
-net xpos-fb [PRUCONF](DRIVER).stepgen.00.position-fb => axis.0.motor-pos-fb
-net xenable axis.0.amp-enable-out => [PRUCONF](DRIVER).stepgen.00.enable
+setp hpg.stepgen.00.position-scale [AXIS_0]SCALE
+setp hpg.stepgen.00.steplen 2000
+setp hpg.stepgen.00.stepspace 2000
+setp hpg.stepgen.00.dirhold 35000
+setp hpg.stepgen.00.dirsetup 35000
+setp hpg.stepgen.00.maxaccel [AXIS_0]STEPGEN_MAXACCEL
+#setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+net xpos-cmd axis.0.motor-pos-cmd => hpg.stepgen.00.position-cmd
+net xpos-fb hpg.stepgen.00.position-fb => axis.0.motor-pos-fb
+net xenable axis.0.amp-enable-out => hpg.stepgen.00.enable
 
-setp [PRUCONF](DRIVER).stepgen.00.steppin         142
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          143
+setp hpg.stepgen.00.steppin         142
+setp hpg.stepgen.00.dirpin          143
 
 # y-axis gantry
-net y1pos-cmd gantry.0.joint.00.pos-cmd => [PRUCONF](DRIVER).stepgen.01.position-cmd
-net y1pos-fb  gantry.0.joint.00.pos-fb  <= [PRUCONF](DRIVER).stepgen.01.position-fb
-net y2pos-cmd gantry.0.joint.01.pos-cmd => [PRUCONF](DRIVER).stepgen.02.position-cmd
-net y2pos-fb  gantry.0.joint.01.pos-fb  <= [PRUCONF](DRIVER).stepgen.02.position-fb
+net y1pos-cmd gantry.0.joint.00.pos-cmd => hpg.stepgen.01.position-cmd
+net y1pos-fb  gantry.0.joint.00.pos-fb  <= hpg.stepgen.01.position-fb
+net y2pos-cmd gantry.0.joint.01.pos-cmd => hpg.stepgen.02.position-cmd
+net y2pos-fb  gantry.0.joint.01.pos-fb  <= hpg.stepgen.02.position-fb
 net ypos-cmd  gantry.0.position-cmd     <= axis.1.motor-pos-cmd
 net ypos-fb   gantry.0.position-fb      => axis.1.motor-pos-fb
-net yenable axis.1.amp-enable-out => [PRUCONF](DRIVER).stepgen.01.enable [PRUCONF](DRIVER).stepgen.02.enable
+net yenable axis.1.amp-enable-out => hpg.stepgen.01.enable [PRUCONF](DRIVER).stepgen.02.enable
 setp gantry.0.search-vel [AXIS_1]HOME_SEARCH_VEL
 
 # y1-axis
-setp [PRUCONF](DRIVER).stepgen.01.position-scale [AXIS_1]SCALE
-setp [PRUCONF](DRIVER).stepgen.01.steplen 2000
-setp [PRUCONF](DRIVER).stepgen.01.stepspace 2000
-setp [PRUCONF](DRIVER).stepgen.01.dirhold 35000
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup 35000
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel [AXIS_1]STEPGEN_MAXACCEL
+setp hpg.stepgen.01.position-scale [AXIS_1]SCALE
+setp hpg.stepgen.01.steplen 2000
+setp hpg.stepgen.01.stepspace 2000
+setp hpg.stepgen.01.dirhold 35000
+setp hpg.stepgen.01.dirsetup 35000
+setp hpg.stepgen.01.maxaccel [AXIS_1]STEPGEN_MAXACCEL
 
-setp [PRUCONF](DRIVER).stepgen.01.steppin         144
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          145
+setp hpg.stepgen.01.steppin         144
+setp hpg.stepgen.01.dirpin          145
 
 # y2-axis
-setp [PRUCONF](DRIVER).stepgen.02.position-scale [AXIS_1]SCALE
-setp [PRUCONF](DRIVER).stepgen.02.steplen 2000
-setp [PRUCONF](DRIVER).stepgen.02.stepspace 2000
-setp [PRUCONF](DRIVER).stepgen.02.dirhold 35000
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup 35000
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel [AXIS_1]STEPGEN_MAXACCEL
+setp hpg.stepgen.02.position-scale [AXIS_1]SCALE
+setp hpg.stepgen.02.steplen 2000
+setp hpg.stepgen.02.stepspace 2000
+setp hpg.stepgen.02.dirhold 35000
+setp hpg.stepgen.02.dirsetup 35000
+setp hpg.stepgen.02.maxaccel [AXIS_1]STEPGEN_MAXACCEL
 
-setp [PRUCONF](DRIVER).stepgen.02.steppin         52
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          147
+setp hpg.stepgen.02.steppin         52
+setp hpg.stepgen.02.dirpin          147
 
 # z-axis
-setp [PRUCONF](DRIVER).stepgen.03.position-scale [AXIS_2]SCALE
-setp [PRUCONF](DRIVER).stepgen.03.steplen 2000
-setp [PRUCONF](DRIVER).stepgen.03.stepspace 2000
-setp [PRUCONF](DRIVER).stepgen.03.dirhold 35000
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup 35000
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel [AXIS_2]STEPGEN_MAXACCEL
-net zpos-cmd axis.2.motor-pos-cmd => [PRUCONF](DRIVER).stepgen.03.position-cmd
-net zpos-fb [PRUCONF](DRIVER).stepgen.03.position-fb => axis.2.motor-pos-fb
-net zenable axis.2.amp-enable-out => [PRUCONF](DRIVER).stepgen.03.enable
+setp hpg.stepgen.03.position-scale [AXIS_2]SCALE
+setp hpg.stepgen.03.steplen 2000
+setp hpg.stepgen.03.stepspace 2000
+setp hpg.stepgen.03.dirhold 35000
+setp hpg.stepgen.03.dirsetup 35000
+setp hpg.stepgen.03.maxaccel [AXIS_2]STEPGEN_MAXACCEL
+net zpos-cmd axis.2.motor-pos-cmd => hpg.stepgen.03.position-cmd
+net zpos-fb hpg.stepgen.03.position-fb => axis.2.motor-pos-fb
+net zenable axis.2.amp-enable-out => hpg.stepgen.03.enable
 
-setp [PRUCONF](DRIVER).stepgen.03.steppin         39
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          149
+setp hpg.stepgen.03.steppin         39
+setp hpg.stepgen.03.dirpin          149
 
 
 # debounce the y-axis switches and connect them to signals

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.hal
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.hal
@@ -38,7 +38,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,113,119,126,214 input_pins=109,110,114,118,241
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
+loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 #(JP) Not suing PID loop so comment out
 loadrt pid num_chan=4
 loadrt limit1 count=2
@@ -47,7 +47,7 @@ loadrt limit1 count=2
 # THREADS
 # ################################################
 
-addf [PRUCONF](DRIVER).capture-position   servo-thread
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -58,7 +58,7 @@ addf pid.2.do-pid-calcs                   servo-thread
 addf pid.3.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf [PRUCONF](DRIVER).update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 
@@ -75,33 +75,33 @@ newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
 
 net emcmot.00.enable <= axis.0.amp-enable-out
-net emcmot.00.enable => [PRUCONF](DRIVER).stepgen.00.enable pid.0.enable
+net emcmot.00.enable => hpg.stepgen.00.enable pid.0.enable
 
 # position command and feedback
 net emcmot.00.pos-cmd axis.0.motor-pos-cmd => pid.0.command
 net emcmot.00.vel-cmd axis.0.joint-vel-cmd => pid.0.command-deriv
-net motor.00.pos-fb <= [PRUCONF](DRIVER).stepgen.00.position-fb axis.0.motor-pos-fb pid.0.feedback
-net motor.00.command pid.0.output [PRUCONF](DRIVER).stepgen.00.velocity-cmd
+net motor.00.pos-fb <= hpg.stepgen.00.position-fb axis.0.motor-pos-fb pid.0.feedback
+net motor.00.command pid.0.output hpg.stepgen.00.velocity-cmd
 setp pid.0.error-previous-target true
 setp pid.0.maxerror .001
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.00.dirsetup        [AXIS_0]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.00.dirhold         [AXIS_0]DIRHOLD
+setp hpg.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hpg.stepgen.00.dirhold         [AXIS_0]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.00.steplen         [AXIS_0]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.00.stepspace       [AXIS_0]STEPSPACE
+setp hpg.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hpg.stepgen.00.stepspace       [AXIS_0]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.00.position-scale  [AXIS_0]SCALE
+setp hpg.stepgen.00.position-scale  [AXIS_0]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
-setp [PRUCONF](DRIVER).stepgen.00.control-type    1
-setp [PRUCONF](DRIVER).stepgen.00.stepinvert      [AXIS_0]STEP_INVERT
-#setp [PRUCONF](DRIVER).stepgen.00.step_type       0
-setp [PRUCONF](DRIVER).stepgen.00.steppin         0x4C
-setp [PRUCONF](DRIVER).stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.control-type    1
+setp hpg.stepgen.00.stepinvert      [AXIS_0]STEP_INVERT
+#setp hpg.stepgen.00.step_type       0
+setp hpg.stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.dirpin          0x4D
 
 # set PID loop gains from inifile
 setp pid.0.Pgain [AXIS_0]P
@@ -127,33 +127,33 @@ newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
 
 net emcmot.01.enable <= axis.1.amp-enable-out
-net emcmot.01.enable => [PRUCONF](DRIVER).stepgen.01.enable pid.1.enable
+net emcmot.01.enable => hpg.stepgen.01.enable pid.1.enable
 
 # position command and feedback
 net emcmot.01.pos-cmd axis.1.motor-pos-cmd => pid.1.command
 net emcmot.01.vel-cmd axis.1.joint-vel-cmd => pid.1.command-deriv
-net motor.01.pos-fb <= [PRUCONF](DRIVER).stepgen.01.position-fb axis.1.motor-pos-fb pid.1.feedback
-net motor.01.command pid.1.output [PRUCONF](DRIVER).stepgen.01.velocity-cmd
+net motor.01.pos-fb <= hpg.stepgen.01.position-fb axis.1.motor-pos-fb pid.1.feedback
+net motor.01.command pid.1.output hpg.stepgen.01.velocity-cmd
 setp pid.1.error-previous-target true
 setp pid.1.maxerror .001
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.01.dirsetup        [AXIS_1]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.01.dirhold         [AXIS_1]DIRHOLD
+setp hpg.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hpg.stepgen.01.dirhold         [AXIS_1]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.01.steplen         [AXIS_1]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.01.stepspace       [AXIS_1]STEPSPACE
+setp hpg.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hpg.stepgen.01.stepspace       [AXIS_1]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.01.position-scale  [AXIS_1]SCALE
+setp hpg.stepgen.01.position-scale  [AXIS_1]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
-setp [PRUCONF](DRIVER).stepgen.01.control-type    1
-setp [PRUCONF](DRIVER).stepgen.01.stepinvert      [AXIS_1]STEP_INVERT
-#setp [PRUCONF](DRIVER).stepgen.01.step_type       0
-setp [PRUCONF](DRIVER).stepgen.01.steppin         0x4E
-setp [PRUCONF](DRIVER).stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.control-type    1
+setp hpg.stepgen.01.stepinvert      [AXIS_1]STEP_INVERT
+#setp hpg.stepgen.01.step_type       0
+setp hpg.stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.dirpin          0x4F
 
 # set PID loop gains from inifile
 setp pid.1.Pgain [AXIS_1]P
@@ -179,33 +179,33 @@ newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
 
 net emcmot.02.enable <= axis.2.amp-enable-out
-net emcmot.02.enable => [PRUCONF](DRIVER).stepgen.02.enable pid.2.enable
+net emcmot.02.enable => hpg.stepgen.02.enable pid.2.enable
 
 # position command and feedback
 net emcmot.02.pos-cmd axis.2.motor-pos-cmd => pid.2.command
 net emcmot.02.vel-cmd axis.2.joint-vel-cmd => pid.2.command-deriv
-net motor.02.pos-fb <= [PRUCONF](DRIVER).stepgen.02.position-fb axis.2.motor-pos-fb pid.2.feedback
-net motor.02.command pid.2.output [PRUCONF](DRIVER).stepgen.02.velocity-cmd
+net motor.02.pos-fb <= hpg.stepgen.02.position-fb axis.2.motor-pos-fb pid.2.feedback
+net motor.02.command pid.2.output hpg.stepgen.02.velocity-cmd
 setp pid.2.error-previous-target true
 setp pid.2.maxerror .001
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.02.dirsetup        [AXIS_2]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.02.dirhold         [AXIS_2]DIRHOLD
+setp hpg.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hpg.stepgen.02.dirhold         [AXIS_2]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.02.steplen         [AXIS_2]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.02.stepspace       [AXIS_2]STEPSPACE
+setp hpg.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hpg.stepgen.02.stepspace       [AXIS_2]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.02.position-scale  [AXIS_2]SCALE
+setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-setp [PRUCONF](DRIVER).stepgen.02.control-type    1
-setp [PRUCONF](DRIVER).stepgen.02.stepinvert      [AXIS_2]STEP_INVERT
-#setp [PRUCONF](DRIVER).stepgen.02.step_type       0
-setp [PRUCONF](DRIVER).stepgen.02.steppin         0x50
-setp [PRUCONF](DRIVER).stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.control-type    1
+setp hpg.stepgen.02.stepinvert      [AXIS_2]STEP_INVERT
+#setp hpg.stepgen.02.step_type       0
+setp hpg.stepgen.02.steppin         0x50
+setp hpg.stepgen.02.dirpin          0x51
 
 # set PID loop gains from inifile
 setp pid.2.Pgain [AXIS_2]P
@@ -230,33 +230,33 @@ newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
 
 net emcmot.03.enable <= axis.3.amp-enable-out
-net emcmot.03.enable => [PRUCONF](DRIVER).stepgen.03.enable pid.3.enable
+net emcmot.03.enable => hpg.stepgen.03.enable pid.3.enable
 
 # position command and feedback
 net emcmot.03.pos-cmd axis.3.motor-pos-cmd => pid.3.command
 net emcmot.03.vel-cmd axis.3.joint-vel-cmd => pid.3.command-deriv
-net motor.03.pos-fb <= [PRUCONF](DRIVER).stepgen.03.position-fb axis.3.motor-pos-fb pid.3.feedback
-net motor.03.command pid.3.output [PRUCONF](DRIVER).stepgen.03.velocity-cmd
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb axis.3.motor-pos-fb pid.3.feedback
+net motor.03.command pid.3.output hpg.stepgen.03.velocity-cmd
 setp pid.3.error-previous-target true
 setp pid.3.maxerror .001
 
 # timing parameters
-setp [PRUCONF](DRIVER).stepgen.03.dirsetup        [AXIS_3]DIRSETUP
-setp [PRUCONF](DRIVER).stepgen.03.dirhold         [AXIS_3]DIRHOLD
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
 
-setp [PRUCONF](DRIVER).stepgen.03.steplen         [AXIS_3]STEPLEN
-setp [PRUCONF](DRIVER).stepgen.03.stepspace       [AXIS_3]STEPSPACE
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
 
-setp [PRUCONF](DRIVER).stepgen.03.position-scale  [AXIS_3]SCALE
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
 
-setp [PRUCONF](DRIVER).stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
-setp [PRUCONF](DRIVER).stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
-setp [PRUCONF](DRIVER).stepgen.03.control-type    1
-setp [PRUCONF](DRIVER).stepgen.03.stepinvert      [AXIS_3]STEP_INVERT
-#setp [PRUCONF](DRIVER).stepgen.03.step_type       0
-setp [PRUCONF](DRIVER).stepgen.03.steppin         0x3E
-setp [PRUCONF](DRIVER).stepgen.03.dirpin          0x3F
+setp hpg.stepgen.03.control-type    1
+setp hpg.stepgen.03.stepinvert      [AXIS_3]STEP_INVERT
+#setp hpg.stepgen.03.step_type       0
+setp hpg.stepgen.03.steppin         0x3E
+setp hpg.stepgen.03.dirpin          0x3F
 
 # set PID loop gains from inifile
 setp pid.3.Pgain [AXIS_3]P


### PR DESCRIPTION
Recent changes to the PRU driver create HAL names that are too long with
the default driver name of hal_pru_generic.  This changes the driver
name to hpg and updates the example HAL files to match.

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>