### PR TITLE
Fixup e94b7ad1:  Unbreak tclConfig.sh

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2683,7 +2683,6 @@ EOFOUTER
 # so testing is done by finding tclConfig.sh and tkConfig.sh                 #
 # if the search fails the traditional check is done                          #
 ##############################################################################
-export DEB_HOST_MULTIARCH=${host_cpu}-${host_os}
 SC_PATH_TCLCONFIG
 SC_LOAD_TCLCONFIG
 TCL_CFLAGS="$TCL_INCLUDE_SPEC -DUSE_TCL_STUBS"


### PR DESCRIPTION
Setting `DEB_HOST_MULTIARCH` to the value detected by `config.guess`
will be wrong in many cases, and indeed breaks the multiarch
`tclConfig.sh` script on i?86:

    $ dpkg-architecture -qDEB_HOST_MULTIARCH
    i386-linux-gnu
    $ ./config.guess
    i686-pc-linux-gnu
    $ dpkg-query -L tcl8.6-dev | grep tclConfig.sh
    /usr/lib/tcl8.6/tclConfig.sh
    /usr/lib/i386-linux-gnu/tcl8.6/tclConfig.sh
    $ cat /usr/lib/tcl8.6/tclConfig.sh
    #! /bin/sh
    . /usr/lib/`dpkg-architecture -qDEB_HOST_MULTIARCH`/tcl8.6/tclConfig.sh

Fixes #644