### PR TITLE
Sample configs update

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper-DecaMux.hal
@@ -25,7 +25,7 @@ loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EM
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,224,226 input_pins=108,109,110,114,117,118
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 loadrt pepper count=2
 

--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/BeBoPr++Pepper.hal
@@ -25,7 +25,7 @@ loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EM
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,224,226 input_pins=108,109,110,114,117,118
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 loadrt pepper count=1
 

--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/lineardelta.hal
@@ -29,7 +29,7 @@ loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EM
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,224,226 input_pins=108,109,110,114,117,118
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 loadrt pepper
 

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/BeBoPr++.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/BeBoPr++.hal
@@ -26,7 +26,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 
 

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/TAKE-5.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/TAKE-5.hal
@@ -26,7 +26,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,224,226 input_pins=108,109,110,114,117,118
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 
 

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/lineardelta.hal
@@ -29,7 +29,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 
 

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
@@ -26,7 +26,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 
 

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
@@ -30,7 +30,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 
 

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/velocity-extruding/lineardelta-vel-extr.hal
@@ -31,7 +31,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 
 

--- a/configs/ARM/BeagleBone/BeBoPr/BeBoPr.hal
+++ b/configs/ARM/BeagleBone/BeBoPr/BeBoPr.hal
@@ -26,7 +26,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=103,105,107,120,128,140,141 input_pins=131,132,133,135,137,138
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 
 

--- a/configs/ARM/BeagleBone/CRAMPS/CRAMPS.hal
+++ b/configs/ARM/BeagleBone/CRAMPS/CRAMPS.hal
@@ -26,7 +26,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=816,822,823,824,825,826,914,923,925 input_pins=807,808,809,810,817,911,913
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 
 

--- a/configs/ARM/BeagleBone/PocketNC/PocketNC.hal
+++ b/configs/ARM/BeagleBone/PocketNC/PocketNC.hal
@@ -28,7 +28,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 #loadrt hal_bb_gpio output_pins=107,126,211,212,218,224,226 input_pins=108,109,110,114,117,118,122
 loadrt hal_bb_gpio output_pins=211,212,218,224 input_pins=107,108,109,110,114,117,118,119,122,126,213,216
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 
 # Spindle math

--- a/configs/ARM/BeagleBone/Replicape/replicape.hal
+++ b/configs/ARM/BeagleBone/Replicape/replicape.hal
@@ -24,7 +24,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 # load low-level drivers
 loadrt hal_bb_gpio output_pins= input_pins=923,925,916,918,911,913
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt limit1 count=2
 loadrt mux2 count=2
 loadrt and2 count=2

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.hal
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.hal
@@ -40,7 +40,7 @@ loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AX
 loadrt hal_bb_gpio output_pins=107,113,119,126,214 input_pins=109,110,114,118,241
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 #(JP) Not suing PID loop so comment out
-loadrt pid num_chan=4
+loadrt pid count=4
 loadrt limit1 count=2
 
 # ################################################

--- a/configs/attic/demo_mazak/demo_mazak.hal
+++ b/configs/attic/demo_mazak/demo_mazak.hal
@@ -31,7 +31,11 @@ loadrt hal_parport cfg="0x0378_in"
 #     This adds together the 5 bits (with bit 4 being equal to 13)
 #     and outputs the sum as an S32
 #
-loadrt weighted_sum wsum_sizes=5
+#   This is not actually used, but if it was, would be like this
+
+#   Create a weighted sum component with 5 in pins and
+#   5 weight pins
+#   newinst weighted_sum wsum pincount=5
 
 # I/O Mapping - Physical I/O points to driver pins
 # --------------------------------------------------------
@@ -102,7 +106,7 @@ loadrt encoder num_chan=1
 
 # PID loops: 3 for axis control and one for spindle orient
 #
-loadrt pid num_chan=4
+loadrt pid count=4
 
 # classicladder for machine logic
 # (load the realtime portion)
@@ -112,7 +116,8 @@ loadrt classicladder_rt numRungs=50 numBits=50 numWords=8 numTimers=20 numMonost
 loadusr -w classicladder --nogui demo_mazak.clp
 
 # load debounce to handle the pushbuttons on the operator panels
-loadrt debounce cfg="8"
+# not connected to anything in this sample
+loadrt debounce 
 setp debounce.0.delay 3
 
 # -----------------------------------------------

--- a/configs/by_interface/general_mechatronics/GM6-PCI/3-axis-servo.hal
+++ b/configs/by_interface/general_mechatronics/GM6-PCI/3-axis-servo.hal
@@ -8,7 +8,7 @@ loadrt hal_gm
 # trajectory planner
 loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
-loadrt pid num_chan=3
+loadrt pid count=3
 loadrt not
 
 loadusr halmeter

--- a/configs/by_interface/mesa/hm2-servo/hm2-servo.hal
+++ b/configs/by_interface/mesa/hm2-servo/hm2-servo.hal
@@ -34,7 +34,7 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # standard components
-loadrt pid num_chan=3
+loadrt pid count=3
 
 # only the 7i43 needs this, but it doesnt hurt the others
 loadrt probe_parport

--- a/configs/by_interface/parport/etch-servo/etch.hal
+++ b/configs/by_interface/parport/etch-servo/etch.hal
@@ -6,7 +6,7 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 loadrt hal_parport cfg="0x378"
 loadrt encoder num_chan=2
-loadrt pid num_chan=2
+loadrt pid count=2
 loadrt pwmgen output_type=1,1
 loadrt ddt count=4
 loadrt constant count=1

--- a/configs/by_interface/pico/USC_encod/univstep_load.hal
+++ b/configs/by_interface/pico/USC_encod/univstep_load.hal
@@ -9,7 +9,7 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
-loadrt pid num_chan=4
+loadrt pid count=4
 
 # install driver
 loadrt hal_ppmc

--- a/configs/by_interface/pico/ppmc/ppmc_load.hal
+++ b/configs/by_interface/pico/ppmc/ppmc_load.hal
@@ -10,7 +10,7 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
-loadrt pid num_chan=4
+loadrt pid count=4
 
 # install Universal PWM Controller driver
 loadrt hal_ppmc

--- a/configs/by_interface/pico/ppmc_vel/ppmc_load.hal
+++ b/configs/by_interface/pico/ppmc_vel/ppmc_load.hal
@@ -21,7 +21,7 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
-loadrt pid num_chan=4
+loadrt pid count=4
 
 # install Universal PWM Controller driver
 loadrt hal_ppmc timestamp="0x00"

--- a/configs/by_interface/pico/univpwm/univpwm_load.hal
+++ b/configs/by_interface/pico/univpwm/univpwm_load.hal
@@ -9,7 +9,7 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
-loadrt pid num_chan=4
+loadrt pid count=4
 
 # install Universal PWM Controller driver
 loadrt hal_ppmc

--- a/configs/by_interface/pico/univpwmv/univpwm_load.hal
+++ b/configs/by_interface/pico/univpwmv/univpwm_load.hal
@@ -11,7 +11,7 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD traj_period_nsec=[EMCMOT]SERVO_PERIOD key=[EMCMOT]SHMEM_KEY tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
-loadrt pid num_chan=4
+loadrt pid count=4
 
 # install Universal PWM Controller driver
 loadrt hal_ppmc port_addr="0x378" timestamp="0x00"

--- a/configs/by_interface/pico/univstep/univstep_load.hal
+++ b/configs/by_interface/pico/univstep/univstep_load.hal
@@ -9,7 +9,7 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # next load the PID module, for four PID loops
-loadrt pid num_chan=4
+loadrt pid count=4
 
 # install driver
 loadrt hal_ppmc

--- a/configs/by_interface/pluto/lathe-pluto/lathe-pluto.hal
+++ b/configs/by_interface/pluto/lathe-pluto/lathe-pluto.hal
@@ -3,12 +3,12 @@ loadrt trivkins
 # trajectory planner
 loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
-loadrt at_pid num_chan=2 debug=1
+loadrt pid count=2
 loadrt ddt count=4
 loadrt pluto_servo
 loadrt scale
 loadrt mux2
-loadrt debounce cfg=1
+loadrt debounce
 loadrt limit1 count=1
 
 # define the order of execution for RT code

--- a/configs/by_interface/vitalsystems/motenc_pidtest.hal
+++ b/configs/by_interface/vitalsystems/motenc_pidtest.hal
@@ -10,7 +10,7 @@ loadrt hal_motenc
 loadrt threads name1=motenc.thread period1=1000000
 
 # then load the PID module, for three PID loops
-loadrt pid num_chan=3
+loadrt pid count=3
 
 # and load the signal generator module
 loadrt siggen

--- a/configs/by_machine/boss/boss.hal
+++ b/configs/by_machine/boss/boss.hal
@@ -11,7 +11,7 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # PID module, for four PID loops
-loadrt pid num_chan=4
+loadrt pid count=4
 
 # Install motenc driver.
 loadrt hal_motenc
@@ -21,7 +21,7 @@ loadrt boss_plc
 
 # Install debounce filters for operator console (cycle hold/start,
 # limit override, spindle increase/decrease/status).
-loadrt debounce cfg="7"
+loadrt debounce
 
 # Add functions to servo thread so they will be evaluated
 # every servo period.

--- a/configs/by_machine/boss/pid_test.hal
+++ b/configs/by_machine/boss/pid_test.hal
@@ -11,7 +11,7 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 # PID module, for four PID loops
-loadrt at_pid num_chan=4
+loadrt pid count=4
 
 # Install motenc driver.
 loadrt hal_motenc
@@ -21,7 +21,7 @@ loadrt boss_plc
 
 # Install debounce filters for operator console (cycle hold/start,
 # limit override, spindle increase/decrease/status).
-loadrt debounce cfg="6"
+loadrt debounce
 
 # Load muxes for motion feedback and PID command.
 loadrt mux2 count=8

--- a/configs/by_machine/smithy/1240combined.hal
+++ b/configs/by_machine/smithy/1240combined.hal
@@ -33,7 +33,7 @@ loadrt charge_pump
 setp charge-pump.enable TRUE
 
 # load and configure the spindle speed PID
-loadrt pid num_chan=1
+loadrt pid count=1
 setp pid.0.Pgain 0.1
 setp pid.0.Igain 100.0
 setp pid.0.Dgain 0.0
@@ -180,7 +180,7 @@ net chargepump hm2_5i20.0.gpio.022.out charge-pump.out
 # Safety Relay Monitoring Contacts
 net estop-enable hm2_5i20.0.gpio.037.in iocontrol.0.emc-enable-in
 # Run Switch
-loadrt debounce cfg=1
+loadrt debounce
 setp debounce.0.delay 1000
 net key-on hm2_5i20.0.gpio.039.in_not debounce.0.0.in
 net machine-on debounce.0.0.out hm2_5i20.0.sserial.port-0.run hm2_5i20.0.8i20.0.0.amp_enable halui.machine.on

--- a/configs/by_machine/smithy/1240combined_4axis.hal
+++ b/configs/by_machine/smithy/1240combined_4axis.hal
@@ -33,7 +33,7 @@ loadrt charge_pump
 setp charge-pump.enable TRUE
 
 # load and configure the spindle speed PID
-loadrt pid num_chan=1
+loadrt pid count=1
 setp pid.0.Pgain 0.1
 setp pid.0.Igain 100.0
 setp pid.0.Dgain 0.0
@@ -180,7 +180,7 @@ net chargepump hm2_5i20.0.gpio.022.out charge-pump.out
 # Safety Relay Monitoring Contacts
 net estop-enable hm2_5i20.0.gpio.037.in iocontrol.0.emc-enable-in
 # Run Switch
-loadrt debounce cfg=1
+loadrt debounce
 setp debounce.0.delay 1000
 net key-on hm2_5i20.0.gpio.039.in_not debounce.0.0.in
 net machine-on debounce.0.0.out hm2_5i20.0.sserial.port-0.run hm2_5i20.0.8i20.0.0.amp_enable halui.machine.on

--- a/configs/by_machine/smithy/1240rutex.hal
+++ b/configs/by_machine/smithy/1240rutex.hal
@@ -6,7 +6,7 @@ loadrt stepgen step_type=0,0,0
 loadrt match8 count=1
 # Used to filter out spurious limit switch signals
 # THIS IS VERY BAD & SHOULD BE FIXED IN HARDWARE!!!
-loadrt debounce cfg=1
+loadrt debounce
 setp debounce.0.delay 2
 loadrt hal_parport cfg="0x378"
 

--- a/configs/by_machine/smithy/1240rutex_4axis.hal
+++ b/configs/by_machine/smithy/1240rutex_4axis.hal
@@ -6,7 +6,7 @@ loadrt stepgen step_type=0,0,0,0
 loadrt match8 count=1
 # Used to filter out spurious limit switch signals
 # THIS IS VERY BAD & SHOULD BE FIXED IN HARDWARE!!!
-loadrt debounce cfg=1
+loadrt debounce
 setp debounce.0.delay 2
 loadrt hal_parport cfg="0x378"
 

--- a/configs/by_machine/smithy/1315.hal
+++ b/configs/by_machine/smithy/1315.hal
@@ -100,7 +100,7 @@ net chargepump hm2_5i20.0.gpio.022.out charge-pump.out
 # Safety Relay Monitoring Contacts
 net estop-enable hm2_5i20.0.gpio.037.in iocontrol.0.emc-enable-in
 # Run Switch
-loadrt debounce cfg=1
+loadrt debounce
 setp debounce.0.delay 1000
 net key-on hm2_5i20.0.gpio.039.in_not debounce.0.0.in
 net machine-on debounce.0.0.out halui.machine.on

--- a/configs/common/core_servo.hal
+++ b/configs/common/core_servo.hal
@@ -8,7 +8,7 @@ loadrt trivkins
 loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 # PID module, for three PID loops
-loadrt pid num_chan=3
+loadrt pid count=3
 
 # hook functions to realtime thread
 addf motion-command-handler servo-thread

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -662,7 +662,7 @@ static int comp_id;
         print >>f, "        };\n"
 
         strng = " rtapi_snprintf(buf, sizeof(buf),\"%s"
-        if (len(functions) == 1):
+        if (len(functions) == 1) and name == "_":
             strng += "\", name);"
         else :
             strng += ".%s\", name);" % (to_hal(name))


### PR DESCRIPTION
Edit of sample configs to use instantiated versions of components
pid and debounce

2 instances found where at_pid was loaded but pid was used - corrected

Signed-off-by: Mick <arceye@mgware.co.uk>