### PR TITLE
rtapi_app: properly quote kmod args

### DIFF
--- a/src/machinetalk/include/pbutil.hh
+++ b/src/machinetalk/include/pbutil.hh
@@ -40,6 +40,6 @@ int
 note_printf(pb::Container &c, const char *fmt, ...);
 
 // fold a RepeatedPtrField into a std::string, separated by delim
-std::string pbconcat(const pbstringarray_t &args, const std::string &delim = " ");
+std::string pbconcat(const pbstringarray_t &args, const std::string &delim = " ", const std::string &quote = "");
 
 #endif // _PBUTIL_HH_INCLUDED

--- a/src/machinetalk/lib/pbutil.cc
+++ b/src/machinetalk/lib/pbutil.cc
@@ -97,11 +97,11 @@ note_printf(pb::Container &c, const char *fmt, ...)
     return n;
 }
 
-std::string pbconcat(const pbstringarray_t &args, const std::string &delim)
+std::string pbconcat(const pbstringarray_t &args, const std::string &delim, const std::string &quote)
 {
     std::string s;
     for (int i = 0; i < args.size(); i++) {
-	s += args.Get(i);
+	s += quote + args.Get(i) + quote;
 	if (i < args.size()-1)
 	    s += delim;
     }

--- a/src/rtapi/rtapi_app.cc
+++ b/src/rtapi/rtapi_app.cc
@@ -515,7 +515,7 @@ static int do_load_cmd(int instance,
 
     if (w == NULL) {
 	if (kernel_threads(flavor)) {
-	    string cmdargs = pbconcat(args);
+	    string cmdargs = pbconcat(args, " ", "'");
 	    retval = run_module_helper("insert %s %s", name.c_str(), cmdargs.c_str());
 	    if (retval) {
 		note_printf(pbreply, "couldnt insmod %s - see dmesg\n", name.c_str());


### PR DESCRIPTION
this used to break at
loadrt hm2_pci config="num_stepgens=1 num_encoders=1"

as the space would break apart the arg
this patch mutates kmod args to explicitly quote with '

thanks to Amit for the patience