### PR TITLE
rtapi_math: linking to librtapi_math.so.0

### DIFF
--- a/src/emc/kinematics/Submakefile
+++ b/src/emc/kinematics/Submakefile
@@ -17,7 +17,7 @@ PYTARGETS += $(DELTAMODULE)
 ../bin/genserkins: $(call TOOBJS, $(GENSERKINSSRCS)) \
 	../lib/liblinuxcnchal.so \
 	../lib/libposemath.so \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CC) $(LDFLAGS) -o $@ $^
 TARGETS += ../bin/genserkins

--- a/src/emc/rs274ngc/Submakefile
+++ b/src/emc/rs274ngc/Submakefile
@@ -42,7 +42,7 @@ TARGETS += ../lib/librs274.so ../lib/librs274.so.0
 	../lib/liblinuxcncini.so \
 	../lib/libpyplugin.so \
 	../lib/liblinuxcnchal.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	@mkdir -p ../lib
 	@rm -f $@

--- a/src/emc/sai/Submakefile
+++ b/src/emc/sai/Submakefile
@@ -22,7 +22,7 @@ LIBREADLINE=-lreadline
 	../lib/liblinuxcnchal.so.0 \
 	../lib/liblinuxcncini.so.0 \
 	../lib/libpyplugin.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) $(LDFLAGS) $(PROFILE_LDFLAGS) \
 	-o $@ $^ $(ULFLAGS) $(BOOST_PYTHON_LIBS) -l$(LIBPYTHON) $(LIBREADLINE)

--- a/src/emc/task/Submakefile
+++ b/src/emc/task/Submakefile
@@ -7,7 +7,7 @@ USERSRCS += $(EMCSVRSRCS)
 	../lib/liblinuxcnc.a \
 	../lib/libnml.so.0 \
 	../lib/liblinuxcncini.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	@$(CXX) $(LDFLAGS) -o $@ $^ 
 TARGETS += ../bin/linuxcncsvr
@@ -40,7 +40,7 @@ USERSRCS += $(MILLTASKSRCS)
 	../lib/libposemath.so.0 \
 	../lib/liblinuxcnchal.so.0 \
 	../lib/libpyplugin.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) -o $@ $^ $(LDFLAGS) $(BOOST_PYTHON_LIBS) -l$(LIBPYTHON)
 TARGETS += ../bin/milltask

--- a/src/emc/usr_intf/Submakefile
+++ b/src/emc/usr_intf/Submakefile
@@ -58,7 +58,7 @@ TARGETS += ../tcl/linuxcnc.so
 	../lib/liblinuxcnc.a \
 	../lib/libnml.so.0 \
 	../lib/liblinuxcncini.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) $(LDFLAGS) -o $@ $^ -lpthread
 TARGETS += ../bin/linuxcncrsh
@@ -67,7 +67,7 @@ TARGETS += ../bin/linuxcncrsh
 	../lib/liblinuxcnc.a \
 	../lib/libnml.so.0 \
 	../lib/liblinuxcncini.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) $(LDFLAGS) -o $@ $^ -lpthread
 TARGETS += ../bin/schedrmt
@@ -76,7 +76,7 @@ TARGETS += ../bin/schedrmt
 	../lib/liblinuxcnc.a \
 	../lib/libnml.so.0 \
 	../lib/liblinuxcncini.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) $(LDFLAGS) -o $@ $^
 TARGETS += ../bin/linuxcnclcd
@@ -87,7 +87,7 @@ TARGETS += ../bin/linuxcnclcd
 	../lib/liblinuxcncini.so.0 \
 	../lib/libnml.so.0 \
 	../lib/liblinuxcnchal.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) $(LDFLAGS) -o $@ $^ 
 TARGETS += ../bin/halui
@@ -97,7 +97,7 @@ ifeq "$(HAVE_NCURSES)" "yes"
 	../lib/liblinuxcnc.a \
 	../lib/libnml.so.0 \
 	../lib/liblinuxcncini.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) $(LDFLAGS) -o $@ $^ $(KEYSTICKLIBS)
 TARGETS += ../bin/keystick
@@ -109,7 +109,7 @@ $(call TOOBJSDEPS,$(XEMCSRCS)): EXTRAFLAGS = $(CFLAGS_X)
 	../lib/liblinuxcnc.a \
 	../lib/libnml.so.0 \
 	../lib/liblinuxcncini.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) $(LDFLAGS) -o $@ $^ $(XLIBS)
 TARGETS += ../bin/xlinuxcnc
@@ -120,7 +120,7 @@ ifeq "$(BUILD_EMCWEB)" "yes"
 	../lib/liblinuxcnc.a \
 	../lib/libnml.so.0 \
 	../lib/liblinuxcncini.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) $(LDFLAGS) $(BOOST_LDFLAGS) -o $@ $(ULFLAGS) $^ \
 	    $(BOOST_SERIALIZATION_LIB) $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) \

--- a/src/emc/usr_intf/axis/Submakefile
+++ b/src/emc/usr_intf/axis/Submakefile
@@ -17,7 +17,7 @@ $(EMCMODULE): $(call TOOBJS, $(EMCMODULESRCS)) \
 	../lib/liblinuxcnc.a \
 	../lib/libnml.so.0 \
 	../lib/liblinuxcncini.so \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking python module $(notdir $@)
 	$(Q)$(CXX) $(LDFLAGS) -shared -o $@ $^ -L/usr/X11R6/lib -lGL
 

--- a/src/hal/user_comps/Submakefile
+++ b/src/hal/user_comps/Submakefile
@@ -42,7 +42,7 @@ ifdef HAVE_LIBUSB10
 XHC_HB04_SRC = hal/user_comps/xhc-hb04.cc
 USERSRCS += $(XHC_HB04_SRC)
 $(call TOOBJSDEPS, $(XHC_HB04_SRC)) : EXTRAFLAGS += $(LIBUSB10_CFLAGS)
-../bin/xhc-hb04: $(call TOOBJS, $(XHC_HB04_SRC)) ../lib/liblinuxcnchal.so.0 ../lib/liblinuxcncini.so.0 ../lib/librtapi_math.so
+../bin/xhc-hb04: $(call TOOBJS, $(XHC_HB04_SRC)) ../lib/liblinuxcnchal.so.0 ../lib/liblinuxcncini.so.0 ../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CC) $(LDFLAGS) -o $@ $^ -lstdc++ $(LIBUSB10_LIBS)
 TARGETS += ../bin/xhc-hb04

--- a/src/hal/user_comps/vfdb_vfd/Submakefile
+++ b/src/hal/user_comps/vfdb_vfd/Submakefile
@@ -7,7 +7,7 @@ VFDB_LIBS = $(LIBMODBUS_LIBS)
 $(call TOOBJSDEPS, $(VFDB_SRCS)) : EXTRAFLAGS += $(VFDB_CFLAGS)
 
 USERSRCS += $(VFDB_SRCS)
-../bin/vfdb_vfd: $(call TOOBJS, $(VFDB_SRCS)) ../lib/liblinuxcnchal.so.0 ../lib/liblinuxcncini.so.0 ../lib/librtapi_math.so
+../bin/vfdb_vfd: $(call TOOBJS, $(VFDB_SRCS)) ../lib/liblinuxcnchal.so.0 ../lib/liblinuxcncini.so.0 ../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CC) $(LDFLAGS) -o $@ $^ $(VFDB_LIBS) 
 

--- a/src/hal/utils/Submakefile
+++ b/src/hal/utils/Submakefile
@@ -14,7 +14,7 @@ $(call TOOBJSDEPS, hal/utils/halsh.c) : EXTRAFLAGS += $(TCL_CFLAGS)
 	../lib/liblinuxcnchal.so.0 \
 	../lib/liblinuxcnc-pb2++.so.0 \
 	../lib/libmtalk.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CC) $(LDFLAGS) -shared $^  $(TCL_LIBS) -o $@
 TARGETS += ../tcl/hal.so
@@ -27,7 +27,7 @@ $(call TOOBJSDEPS, $(HALCMDCCSRCS)) : EXTRAFLAGS =  \
 	../lib/liblinuxcnchal.so.0 \
 	../lib/liblinuxcnc-pb2++.so.0 \
 	../lib/libmtalk.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CC) $(LDFLAGS) -o $@ $^ $(READLINE_LIBS) \
 	$(PROTOBUF_LIBS) $(CZMQ_LIBS) $(AVAHI_LIBS) -lm -lstdc++
@@ -66,7 +66,7 @@ USERSRCS += $(HALSCOPESRCS)
 
 ../bin/halscope: $(call TOOBJS, $(HALSCOPESRCS)) \
 	../lib/liblinuxcnchal.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CC) $(LDFLAGS) -o $@ $^ $(GTK_LIBS)
 TARGETS += ../bin/halscope

--- a/src/libnml/Submakefile
+++ b/src/libnml/Submakefile
@@ -22,7 +22,7 @@ USERSRCS += $(LIBNMLSRCS)
 
 TARGETS += ../lib/libnml.so ../lib/libnml.so.0
 
-../lib/libnml.so.0: $(call TOOBJS,$(LIBNMLSRCS)) ../lib/librtapi_math.so
+../lib/libnml.so.0: $(call TOOBJS,$(LIBNMLSRCS)) ../lib/librtapi_math.so.0
 	$(ECHO) Creating shared library $(notdir $@)
 	@mkdir -p ../lib
 	@rm -f $@

--- a/src/libnml/posemath/Submakefile
+++ b/src/libnml/posemath/Submakefile
@@ -4,7 +4,7 @@ $(call TOOBJSDEPS, $(POSEMATHSRCS)) : EXTRAFLAGS=-fPIC
 USERSRCS += $(POSEMATHSRCS) 
 TARGETS += ../lib/libposemath.so ../lib/libposemath.so.0
 
-../lib/libposemath.so.0: $(call TOOBJS,$(POSEMATHSRCS)) ../lib/librtapi_math.so
+../lib/libposemath.so.0: $(call TOOBJS,$(POSEMATHSRCS)) ../lib/librtapi_math.so.0
 	$(ECHO) Creating shared library $(notdir $@)
 	@mkdir -p ../lib
 	@rm -f $@

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -167,7 +167,7 @@ $(call TOOBJSDEPS, rtapi/$(threads)/rtapi_app.cc): EXTRAFLAGS = \
 	../lib/liblinuxcncshm.so \
 	../lib/libmtalk.so.0 \
 	../lib/liblinuxcnc-pb2++.so.0 \
-	../lib/librtapi_math.so
+	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	@mkdir -p $(dir $@)
 	$(Q)$(CXX) -Wl,-rpath,$(EMC2_RTLIB_DIR) $(RTAPI_APP_RPATH) \


### PR DESCRIPTION
This patch https://github.com/machinekit/machinekit/commit/136de2e13f78ff50047248a0c6a3534305a21a72 changed the creating of the librtapi_math.so to a symlink. Apps and libraries still may need to be linked against to librtapi_math.so.0 to build packages correctly.