### PR TITLE
Machinekit python config updates

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -17,8 +17,8 @@ Build-Depends: debhelper (>= 6),
     uuid-dev, uuid-runtime, libavahi-client-dev,
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
     python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
-    python-netifaces, python-simplejson, libtk-img,
-    libboost-thread-dev, python-pyftpdlib, @BUILD_DEPS@ @TCL_TK_BUILD_DEPS@
+    python-simplejson, libtk-img, libboost-thread-dev,
+    python-pyftpdlib, @BUILD_DEPS@ @TCL_TK_BUILD_DEPS@
 Standards-Version: 2.1.0
 
 Package: machinekit-dev
@@ -48,7 +48,7 @@ Depends: ${shlibs:Depends}, machinekit-rt-threads, @TCL_TK_DEPS@,
     python-numpy, python-gtksourceview2,
     python-vte, python-xlib, python-gtkglext1, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
-    python-avahi, python-netifaces, python-simplejson, python-pyftpdlib,
+    python-avahi, python-simplejson, python-pyftpdlib,
     tclreadline, bc, procps, psmisc, module-init-tools | kmod
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/src/machinekitcfg.py-tmp.in
+++ b/src/machinekitcfg.py-tmp.in
@@ -16,40 +16,6 @@
 # Author: Michael Haberler <license AT mah DOT priv DOT at>
 # License: GPL Version 2 or later
 # Copyright (c) 2013 All rights reserved.
-import netifaces
-
-rtstyles =  ['xenomai-kernel', 'xenomai',
-             'rt-preempt', 'rtai', 'posix']
-
-
-def choose_interface(pref):
-    '''
-    given an interface preference list, return a tuple (interface, ip)
-    or None if no match found
-    If an interface has several ip addresses, the first one is picked.
-    pref is a list of interface names or prefixes:
-
-    pref = ['eth0','usb3']
-    or
-    pref = ['wlan','eth', 'usb']
-    '''
-
-    # retrieve list of network interfaces
-    interfaces = netifaces.interfaces()
-
-    # find a match in preference oder
-    for p in pref:
-        for i in interfaces:
-            if i.startswith(p):
-                ifcfg = netifaces.ifaddresses(i)
-                # we want the first ip address
-                try:
-                    ip = ifcfg[netifaces.AF_INET][0]['addr']
-                except KeyError:
-                    continue
-                return (i, ip)
-    return None
-
 
 class Config(object):
 

--- a/src/machinekitcfg.py-tmp.in
+++ b/src/machinekitcfg.py-tmp.in
@@ -16,6 +16,33 @@
 # Author: Michael Haberler <license AT mah DOT priv DOT at>
 # License: GPL Version 2 or later
 # Copyright (c) 2013 All rights reserved.
+import sys
+if sys.version_info >= (3, 0):
+    import configparser
+else:
+    import ConfigParser as configparser
+
+_cfg = None  # global ConfigParser object
+
+
+# loads a ini file to the config
+def load_ini(iniName):
+    global _cfg
+    if _cfg is None:
+        _cfg = configparser.ConfigParser()
+    _cfg.read(iniName)
+
+
+# find a config entry, compatible to linuxcnc.ini
+# note: the module acts as singleton
+def find(section, option, default=None):
+    if _cfg is None:
+        return default
+    try:
+        return _cfg.get(section, option)
+    except configparser.NoOptionError:
+        return default
+
 
 class Config(object):
 

--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -3,7 +3,6 @@ import os
 import sys
 from stat import *
 import zmq
-import netifaces
 import threading
 import time
 import math


### PR DESCRIPTION
This PR does following things:
- removes the obsolete choose_netifaces function
- adds a linuxcnc.ini-like way to use config variables in Machinekit HAL configurations, note that the modules acts as singleton. Config variables can be passed to Python-HAL files.

example:
```python
from machinekit import config
config.load_ini('myconfig.ini')
import mypythonhalconfig
```
mypythonhalconfig.py
```python
from machinekit import config
from machinekit import hal
x = config.find('AXIS_0', 'SCALE')
hal.Pin('e0.scale').set(float(x))
``` 