### PR TITLE
instantiated component bugfix

### DIFF
--- a/src/hal/i_components/bitslice.icomp
+++ b/src/hal/i_components/bitslice.icomp
@@ -16,7 +16,7 @@ function _ nofp;
 FUNCTION(_)
 {
 int i;
-    for (i = 0; i < pincount ; i++)
+    for (i = 0; i < localpincount ; i++)
         out(i) = (in >> i)&1;
 
 return 0;

--- a/src/hal/i_components/debounce.icomp
+++ b/src/hal/i_components/debounce.icomp
@@ -28,7 +28,7 @@ int n;
         delay = 1;
 
     // loop through filters
-    for (n = 0; n < pincount; n++)
+    for (n = 0; n < localpincount; n++)
         {
         if(_in(n))
             {

--- a/src/hal/i_components/gantry.icomp
+++ b/src/hal/i_components/gantry.icomp
@@ -51,6 +51,11 @@ pin in  float search-vel "HOME_SEARCH_VEL from ini file";
 function read  fp "Update position-fb and home/limit outputs based on joint values";
 function write fp "Update joint pos-cmd outputs based on position-cmd in";
 
+variable float offset[7] = 0.0;
+variable float prev_cmd = 0.0;
+variable int   fb_joint = 0;
+variable int   latching = 0;
+
 instanceparam int maxpincount = 7;
 
 instanceparam int pincount = 7;
@@ -75,11 +80,9 @@ and as slow as practical.  When a joint home switch trips, the commanded
 velocity will drop immediately from HOME_SEARCH_VEL to zero, with no limit on
 accleration.
 """;
+
 license "GPL";
-variable float offset[7] = 0.0;
-variable float prev_cmd = 0.0;
-variable int   fb_joint = 0;
-variable int   latching = 0;
+
 ;;
 FUNCTION(read) {
     int i=1;
@@ -89,7 +92,7 @@ FUNCTION(read) {
     limit=joint_home(0);
 
     // All other joints, if configured
-    while (i < pincount) {
+    while (i < localpincount) {
         // Check to see if machine is in latching state
         if(latching==0)
         {
@@ -116,7 +119,7 @@ FUNCTION(read) {
     // stop.  If all joints are not homed, but the current joint used
     // for feedback is, find a joint that's still active
     if ((joint_home(fb_joint) == 1) && (home == 0)) {
-        for (i=0; i < pincount; i++) {
+        for (i=0; i < localpincount; i++) {
             if (joint_home(i) == 0) {
                 position_fb = joint_pos_fb(i) + offset[i];
                 fb_joint = i;
@@ -150,7 +153,7 @@ FUNCTION(write) {
     // If we're moving towards home and all home switches are not closed
     if ( ((delta * search_vel) > 0) && (home==0) ) {
         // Check each joint to see if it's home switch is active
-        for (i=0; i < pincount; i++) {
+        for (i=0; i < localpincount; i++) {
             // If home switch is active, update offset, not pos_cmd
             // so the other joints can catch up
             if (joint_home(i)==1) {
@@ -160,7 +163,7 @@ FUNCTION(write) {
     }
 
     // Update each joint's commanded position
-    for (i=0; i < pincount; i++) {
+    for (i=0; i < localpincount; i++) {
         joint_pos_cmd(i) = position_cmd - offset[i];
         joint_offset(i)  = offset[i];
     }

--- a/src/hal/i_components/lgantry.icomp
+++ b/src/hal/i_components/lgantry.icomp
@@ -54,9 +54,12 @@ pin in  float search-vel "HOME_SEARCH_VEL from ini file";
 function read  fp "Update position-fb and home/limit outputs based on joint values";
 function write fp "Update joint pos-cmd outputs based on position-cmd in";
 
-instanceparam int maxpincount = 7;
-
-instanceparam int pincount = 7;
+variable float offset[pincount] = 0.0;
+variable float prev_cmd = 0.0;
+variable int   fb_joint = 0;
+variable int   prev_home[pincount] = 0;
+variable int   curr_home[pincount] = 0;
+variable float pos_fb_target[pincount] = 0.0;
 
 description """
 Drives multiple physical motors (joints) from a single axis input
@@ -88,18 +91,21 @@ The homing input must be connected to the axis homing output motion in order to 
 the gantry component. When the axis is not homing latching will not be activated.
 """;
 license "GPL";
-variable float offset[pincount] = 0.0;
-variable float prev_cmd = 0.0;
-variable int   fb_joint = 0;
-variable int   prev_home[pincount] = 0;
-variable int   curr_home[pincount] = 0;
-variable float pos_fb_target[pincount] = 0.0;
+
+// maximum array size - fixed
+instanceparam int maxpincount = 7;
+
+// default value for param if not passed
+instanceparam int pincount = 7;
+
 ;;
+
+
 FUNCTION(read)
 {
     int i;
     int previous_home;
-
+/**/
     // Save previous home state
     previous_home = home;
 
@@ -108,7 +114,7 @@ FUNCTION(read)
     limit = 0;
 
     // All other joints, if configured
-    for (i = 0; i < pincount; i++) {
+    for (i = 0; i < localpincount; i++) {
         // check to see if machine is in home state
         if(previous_home == 0) {
             // Once all joints are within proximity of homing switches,
@@ -139,7 +145,7 @@ FUNCTION(read)
     // within proximity of the homing switch when not in home mode.
     // Feedback joint will use the first joint that IS in proximity of
     // homing switch.
-    for (i = 0; i < pincount; i++) {
+    for (i = 0; i < localpincount; i++) {
         if (joint_home(i) == home) {
             fb_joint = i;
             break;
@@ -173,7 +179,7 @@ FUNCTION(write)
         // If we're moving towards home and all home switches are not closed
         if ((((delta * search_vel) > 0) && (home == 0)) || (home == 1)) {
             // Check each joint to see if it's home switch is active
-            for (i = 0; i < pincount; i++) {
+            for (i = 0; i < localpincount; i++) {
                 // If home switch is active but system not in home mode,
                 // update offset, not pos_cmd so the other joints can catch up
                 // When home, this happens when home switch is inactive
@@ -185,7 +191,7 @@ FUNCTION(write)
     }
 
     // Update each joint's commanded position
-    for (i = 0; i < pincount; i++) {
+    for (i = 0; i < localpincount; i++) {
         joint_pos_cmd(i) = position_cmd - offset[i];
         joint_offset(i) = offset[i];
     }

--- a/src/hal/i_components/lincurve.icomp
+++ b/src/hal/i_components/lincurve.icomp
@@ -43,8 +43,8 @@ FUNCTION(_)
 {
     double f, x;
     x = in_;
-    if (x >= x_val(pincount-1)) {
-        out_ = y_val(pincount-1);
+    if (x >= x_val(localpincount-1)) {
+        out_ = y_val(localpincount-1);
         out_io = out_;
         return 0;
     }
@@ -64,7 +64,7 @@ return 0;
 }
 
 EXTRA_INST_SETUP(){
-//	if (pincount > 16) pincount = 16;
-	if (pincount < 2) pincount = 2;
+//	if (localpincount > 16) localpincount = 16;
+	if (localpincount < 2) localpincount = 2;
 	return 0;
 }

--- a/src/hal/i_components/lutn.icomp
+++ b/src/hal/i_components/lutn.icomp
@@ -24,7 +24,7 @@ int i;
 ip = arg;
 int shift = 0;
 
-    for (i = 0; i < pincount; i++)
+    for (i = 0; i < localpincount; i++)
 	if (in(i))
 	    shift += (1 << i);
 

--- a/src/hal/i_components/multiswitch.icomp
+++ b/src/hal/i_components/multiswitch.icomp
@@ -59,7 +59,7 @@ FUNCTION(_)
     if (position < 0) position = top_position;
     if (position > top_position) position = 0;
 
-    for (i = 0 ; i < pincount; i++)
+    for (i = 0 ; i < localpincount; i++)
         {
         bit(i) = (i == position);
         }
@@ -70,6 +70,6 @@ return 0;
 
 EXTRA_INST_SETUP()
 {
-    top_position = pincount - 1;
+    top_position = localpincount - 1;
     return 0;
 }

--- a/src/hal/i_components/mux16.icomp
+++ b/src/hal/i_components/mux16.icomp
@@ -46,11 +46,7 @@ pin out s32 out_s;
 
 param r float elapsed "Current value of the internal debounce timer\n for debugging.";
 param r s32 selected "Current value of the internal selection variable after conversion\n for debugging";
-pin in float in##[pincount] "array of selectable outputs";
-
-instanceparam int maxpincount = 16;
-
-instanceparam int pincount = 16;
+pin in float in##[16] "array of selectable outputs";
 
 variable double delaytime;
 variable int lastnum;

--- a/src/hal/i_components/select8.icomp
+++ b/src/hal/i_components/select8.icomp
@@ -3,25 +3,21 @@ param rw bit enable = TRUE "Set enable to FALSE to cause all outputs to be set F
 pin in s32 sel "The number of the output to set TRUE.  All other outputs well be set FALSE";
 pin out bit out#[8] "Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true";
 
-instanceparam int maxpincount = 8;
-
-instanceparam int pincount = 8;
-
 function _ nofp;
 license "GPL";
 ;;
 FUNCTION(_)
 {
-	hal_s32_t temp_sel;
-	int i, temp_enable;
-	temp_sel = sel;
-	temp_enable = enable;
-	for (i=0; i < pincount ; i++) {
-		if (!temp_enable || temp_sel!=i)
-			out(i)=0;
-		else
-			out(i)=1;
-	}
+    hal_s32_t temp_sel;
+    int i, temp_enable;
+    temp_sel = sel;
+    temp_enable = enable;
+    for (i=0; i < 8 ; i++) {
+        if (!temp_enable || temp_sel!=i)
+            out(i)=0;
+        else
+            out(i)=1;
+    }
 
 return 0;
 }

--- a/src/hal/i_components/weighted_sum.icomp
+++ b/src/hal/i_components/weighted_sum.icomp
@@ -68,7 +68,7 @@ int b, running_total;
 	if (!hold) 
 		{
 		running_total = offset;
-		for (b=0 ; b < pincount ; b++) 
+		for (b=0 ; b < localpincount ; b++) 
 			{
 			if (in(b)) 
 				running_total += weight(b);


### PR DESCRIPTION
Use per-instance variable for code iteration in instcomp

kernel instanceparams remain globally available to components
even after instantiation, overriding local of same name

Are reset by subsequent instantiations, affecting previous ones.
If previous instance had fewer pins, can cause array overruns
in that instance

Components using those instparams amended

Signed-off-by: Mick <arceye@mgware.co.uk>