### PR TITLE
Python API updates

### DIFF
--- a/src/hal/cython/machinekit/hal_compdict.pyx
+++ b/src/hal/cython/machinekit/hal_compdict.pyx
@@ -37,6 +37,9 @@ cdef class Components:
     def __getitem__(self, char *name):
         hal_required()
 
+        if isinstance(name, int):
+            return comp_names()[name]
+
         if name in self.comps:
             return self.comps[name]
         cdef hal_comp_t *comp
@@ -52,6 +55,8 @@ cdef class Components:
         return c
 
     def __contains__(self, arg):
+        if isinstance(arg, Component):
+            arg = arg.name
         try:
             self.__getitem__(arg)
             return True
@@ -68,5 +73,13 @@ cdef class Components:
     def __call__(self):
         hal_required()
         return comp_names()
+
+    def __repr__(self):
+        hal_required()
+        compdict = {}
+        for name in comp_names():
+            compdict[name] = self[name]
+        return str(compdict)
+
 
 components = Components()

--- a/src/hal/cython/machinekit/hal_component.pyx
+++ b/src/hal/cython/machinekit/hal_component.pyx
@@ -50,22 +50,27 @@ cdef class Component:
             raise KeyError("component %s: nonexistent pin %s" % (self._comp.name, name))
 
     def pins(self):
-        ''' return names of all pins owned by this component, which includes all instance pins'''
+        ''' return list of Pin objects owned by this component, which includes all instance pins'''
         cdef hal_pin_t *p
-        cdef list names
-        names = []
         p = NULL
 
+        pinnames = []
         with HALMutex():
             p = halpr_find_pin_by_owner_id(self._comp.comp_id, p)
             while p != NULL:
-                names.append(p.name)
+                pinnames.append(p.name)
                 p = halpr_find_pin_by_owner_id(self._comp.comp_id, p)
 
-        return names
+        pinlist = []
+        for n in pinnames:
+            pinlist.append(pins[n])
+        return pinlist
 
-
-
+    def pin(self, name, base=None):
+        ''' return component Pin object, base does not need to be supplied if pin name matches component name '''
+        if base == None:
+            base = self.name
+        return Pin('%s.%s' % (base, name))
 
     def exit(self):
         if self._cc != NULL:

--- a/src/hal/cython/machinekit/hal_inst.pyx
+++ b/src/hal/cython/machinekit/hal_inst.pyx
@@ -38,4 +38,28 @@ cdef class Instance:
     property comp_id:
         def __get__(self): return self._inst.comp_id
 
+    def pins(self):
+        ''' return a list of Pin objects owned by this instance'''
+        cdef hal_pin_t *p
+        p = NULL
+
+        pinnames = []
+        with HALMutex():
+            p = halpr_find_pin_by_owner_id(self._inst.inst_id, p)
+            while p != NULL:
+                pinnames.append(p.name)
+                p = halpr_find_pin_by_owner_id(self._inst.inst_id, p)
+
+        pinlist = []
+        for n in pinnames:
+            pinlist.append(pins[n])
+        return pinlist
+
+    def pin(self, name, base=None):
+        ''' return component Pin object, base does not need to be supplied if pin name matches component name '''
+        if base == None:
+            base = self.name
+        return Pin('%s.%s' % (base, name))
+
+
     # TODO: add a bufferview of the shm area

--- a/src/hal/cython/machinekit/hal_instdict.pyx
+++ b/src/hal/cython/machinekit/hal_instdict.pyx
@@ -34,6 +34,9 @@ cdef class Instances:
     def __getitem__(self, char *name):
         hal_required()
 
+        if isinstance(name, int):
+            return inst_names()[name]
+
         if name in self.insts:
             return self.insts[name]
         cdef hal_inst_t *p
@@ -46,6 +49,8 @@ cdef class Instances:
         return inst
 
     def __contains__(self, arg):
+        if isinstance(arg, Instance):
+            arg = arg.name
         try:
             self.__getitem__(arg)
             return True
@@ -59,5 +64,12 @@ cdef class Instances:
     def __call__(self):
         hal_required()
         return inst_names()
+
+    def __repr__(self):
+        hal_required()
+        instdict = {}
+        for name in inst_names():
+            instdict[name] = self[name]
+        return str(instdict)
 
 instances = Instances()

--- a/src/hal/cython/machinekit/hal_instdict.pyx
+++ b/src/hal/cython/machinekit/hal_instdict.pyx
@@ -32,6 +32,8 @@ cdef class Instances:
         self.insts = dict()
 
     def __getitem__(self, char *name):
+        hal_required()
+
         if name in self.insts:
             return self.insts[name]
         cdef hal_inst_t *p

--- a/src/hal/cython/machinekit/hal_loadusr.pyx
+++ b/src/hal/cython/machinekit/hal_loadusr.pyx
@@ -22,7 +22,7 @@ def loadusr(command, wait=False, wait_name=None, wait_timeout=5.0, shell=False):
             raise RuntimeError(command + ' exited with return code ' + str(ret))
         # check if component exists
         if (wait_name is not None) and (wait_name in components):
-            return
+            return components[wait_name]
         # check for timeout
         if timeout >= wait_timeout:
             p.kill()

--- a/src/hal/cython/machinekit/hal_net.pyx
+++ b/src/hal/cython/machinekit/hal_net.pyx
@@ -19,13 +19,32 @@ cdef _haltype(int type):
     return _typedict.get(type, "HAL_TYPE_UNSPECIFIED")
 
 
-def net(signame,*pinnames):
+def net(sig,*pinnames):
     cdef int writers = 0, bidirs = 0, t = HAL_TYPE_UNSPECIFIED
     writer_name = None
     bidir_name = None
 
-    if isinstance(signame, Signal):
-        signame = signame.name
+    signame = None
+    if isinstance(sig, Pin) \
+       or (isinstance(sig, str) and (sig in pins)):
+        pin = sig
+        if isinstance(sig, str):
+            pin = pins[sig]
+
+        if not (pin.dir == HAL_OUT or pin.dir == HAL_IO):
+            raise RuntimeError('net: pin must have dir HAL_OUT or HAL_IO to create a signal')
+
+        if not pin.signal:
+            signame = pin.name.replace('.', '-')
+            net(signame, pin)
+        signame = pin.signal.name
+
+    elif isinstance(sig, Signal):
+        signame = sig.name
+    elif isinstance(sig, str):
+        signame = sig
+    else:
+        raise TypeError("net: first argument must be a signal or pin")
 
     s = None
     writer = None

--- a/src/hal/cython/machinekit/hal_net.pyx
+++ b/src/hal/cython/machinekit/hal_net.pyx
@@ -28,6 +28,7 @@ def net(signame,*pinnames):
         signame = signame.name
 
     s = None
+    writer = None
     if signame in signals: #  pre-existing net type
         s = signals[signame]
         writers = s.writers
@@ -70,20 +71,22 @@ def net(signame,*pinnames):
 
         if w.dir == HAL_OUT:
             if writers:
-              raise TypeError("net: signal '%s' can not add writer pin '%s', "
-                              "it already has %s pin '%s" %
-                              (signame, w.name, _pindir(writer.dir),writer.name))
-
-            if bidirs:
-              raise TypeError("net: signal '%s' can not add bidir pin '%s', "
-                              "it already has %s pin '%s" %
-                              (signame, w.name, _pindir(bidir.dir),bidir.name))
+                if not writer:
+                    writer = pins[s.writername]
+                raise TypeError("net: signal '%s' can not add writer pin '%s', "
+                                "it already has %s pin '%s" %
+                                (signame, w.name, _pindir(writer.dir), writer.name))
             writer = w
             writers += 1
 
         if w.dir == HAL_IO:
             if writers:
-                raise RuntimeError("net: IO direction error")
+                if not writer:
+                    writer = pins[s.writername]
+                raise TypeError("net: signal '%s' can not add writer pin '%s', "
+                                "it already has %s pin '%s" %
+                                (signame, w.name, _pindir(writer.dir), writer.name))
+
             bidir = w
             bidirs += 1
 

--- a/src/hal/cython/machinekit/hal_net.pyx
+++ b/src/hal/cython/machinekit/hal_net.pyx
@@ -42,11 +42,17 @@ def net(signame,*pinnames):
         raise RuntimeError("net: at least one pin name expected")
 
     pinlist = []
-    for n in pinnames:
-        if isinstance(n, Pin):
-            n = n.name
+    for names in pinnames:
+        if not hasattr(names, '__iter__'):
+            names = [names]
+        for pin in names:
+            if isinstance(pin, str):
+                pin = pins[pin]  # get wrappers - will raise KeyError if pin dont exist
+            elif not isinstance(pin, Pin):
+                RuntimeError('net: Can only link pins to signals')
+            pinlist.append(pin)
 
-        w = pins[n]       # get wrappers - will raise KeyError if pin dont exist
+    for w in pinlist:
 
         if w.linked:
             if w.signame == signame:  # already on same signal
@@ -80,8 +86,6 @@ def net(signame,*pinnames):
                 raise RuntimeError("net: IO direction error")
             bidir = w
             bidirs += 1
-
-        pinlist.append(w)
 
     if not s:
         s = Signal(signame, t)

--- a/src/hal/cython/machinekit/hal_net.pyx
+++ b/src/hal/cython/machinekit/hal_net.pyx
@@ -91,6 +91,9 @@ def net(signame,*pinnames):
 
     for p in pinlist:
         #print >> sys.stderr, "------ net: link", p.name, signame
-        p.link(signame)
+        r = hal_link(p.name, signame)
+        if r:
+            raise RuntimeError("Failed to link pin %s to %s: %d - %s" %
+                               (p.name, signame, r, hal_lasterror()))
 
     return s

--- a/src/hal/cython/machinekit/hal_pin.pyx
+++ b/src/hal/cython/machinekit/hal_pin.pyx
@@ -95,12 +95,8 @@ cdef class _Pin:
         def __get__(self): return self._pin.dir
 
     def link(self, sig):
-        if isinstance(sig, Signal):
-            sig = sig.name
-        r = hal_link(self._pin.name, sig)
-        if r:
-            raise RuntimeError("Failed to link pin %s to %s: %d - %s" %
-                               (self._pin.name, sig, r, hal_lasterror()))
+        net(sig, self)  # net is more verbose than link
+
     def unlink(self):
         r = hal_unlink(self._pin.name)
         if r:
@@ -136,6 +132,8 @@ cdef class _Pin:
         else:
             # a pin we allocated storage for
             return hal2py(self._pin.type, self._storage[0])
+
+    
 
 class Pin(_Pin):
     def __init__(self, *args, init=None,eps=0):

--- a/src/hal/cython/machinekit/hal_pin.pyx
+++ b/src/hal/cython/machinekit/hal_pin.pyx
@@ -1,6 +1,30 @@
 from .hal_priv cimport MAX_EPSILON, hal_data_u
 from .hal_util cimport shmptr, pin_linked, linked_signal
 
+
+def describe_hal_type(haltype):
+    if haltype == HAL_FLOAT:
+        return 'float'
+    elif haltype == HAL_BIT:
+        return 'bit'
+    elif haltype == HAL_U32:
+        return 'u32'
+    elif haltype == HAL_S32:
+        return 's32'
+    else:
+        return 'unknown'
+
+def describe_hal_dir(haldir):
+    if haldir == HAL_IN:
+        return 'in'
+    elif haldir == HAL_OUT:
+        return 'out'
+    elif haldir == HAL_IO:
+        return 'io'
+    else:
+        return 'unknown'
+
+
 cdef class _Pin:
     cdef hal_data_u **_storage
     cdef hal_pin_t *_pin
@@ -134,4 +158,6 @@ class Pin(_Pin):
     def get(self): raise NotImplementedError("Pin is write-only")
 
     def __repr__(self):
-        return "<hal.Pin %s %s %s >" % self.names[self]
+        return "<hal.Pin %s %s %s>" % (self.name,
+                                        describe_hal_type(self.type),
+                                        describe_hal_dir(self.dir))

--- a/src/hal/cython/machinekit/hal_pin.pyx
+++ b/src/hal/cython/machinekit/hal_pin.pyx
@@ -98,28 +98,10 @@ cdef class _Pin:
         # check if we have a signal
         if isinstance(arg, Signal) \
            or (isinstance(arg, str) and (arg in signals)):
-            net(arg, self)  # net is more verbose than link
-            return self.signal
+            return net(arg, self)  # net is more verbose than link
 
         # we got a pin or list of pins
-        pins = arg
-        if not (self.dir == HAL_OUT or self.dir == HAL_IO):
-            raise RuntimeError('pin must be out or io to create a signal')
-
-        if not hasattr(pins, '__iter__'):
-            pins = [pins]
-        for pin in pins:
-            if isinstance(pin, str):
-                pin = Pin(pin)
-            elif not isinstance(pin, Pin):
-                raise TypeError('linking of %s to signal %s not possible' %
-                                (str(pin), self.name))
-            if not self.signal:
-                signame = self.name.replace('.', '-')
-                net(signame, self)
-
-            net(self.signal, pin)  # net is more verbose than link
-        return self.signal
+        return net(self, arg)
 
     def __iadd__(self, pins):
         return self.link(pins)

--- a/src/hal/cython/machinekit/hal_pindict.pyx
+++ b/src/hal/cython/machinekit/hal_pindict.pyx
@@ -32,7 +32,12 @@ cdef class Pins:
     def __cinit__(self):
         self.pins = dict()
 
-    def __getitem__(self, char *name):
+    def __getitem__(self, name):
+        hal_required()
+
+        if isinstance(name, int):
+            return pin_names()[name]
+
         if name in self.pins:
             return self.pins[name]
         cdef hal_pin_t *p
@@ -45,6 +50,8 @@ cdef class Pins:
         return pin
 
     def __contains__(self, arg):
+        if isinstance(arg, Pin):
+            arg = arg.name
         try:
             self.__getitem__(arg)
             return True
@@ -58,5 +65,12 @@ cdef class Pins:
     def __call__(self):
         hal_required()
         return pin_names()
+
+    def __repr__(self):
+        hal_required()
+        pindict = {}
+        for name in pin_names():
+            pindict[name] = self[name]
+        return str(pindict)
 
 pins = Pins()

--- a/src/hal/cython/machinekit/hal_sigdict.pyx
+++ b/src/hal/cython/machinekit/hal_sigdict.pyx
@@ -31,6 +31,9 @@ cdef class Signals:
     def __getitem__(self, char *name):
         hal_required()
 
+        if isinstance(name, int):
+            return pin_names()[name]
+
         if name in self.sigs:
             return self.sigs[name]
 
@@ -46,6 +49,8 @@ cdef class Signals:
         return sig
 
     def __contains__(self, arg):
+        if isinstance(arg, Signal):
+            arg = arg.name
         try:
             self.__getitem__(arg)
             return True
@@ -66,5 +71,12 @@ cdef class Signals:
     def __call__(self):
         hal_required()
         return sig_names()
+
+    def __repr__(self):
+        hal_required()
+        sigdict = {}
+        for name in sig_names():
+            sigdict[name] = self[name]
+        return str(sigdict)
 
 signals = Signals()

--- a/src/hal/cython/machinekit/hal_signal.pyx
+++ b/src/hal/cython/machinekit/hal_signal.pyx
@@ -157,6 +157,10 @@ cdef class Signal:
             self._alive_check()
             return self._sig.handle
 
+    def __repr__(self):
+        return "<hal.Signal %s %s>" % (self.name,
+                                       describe_hal_type(self.type))
+
 
 cdef modifier_name(hal_sig_t *sig, int dir):
      cdef hal_pin_t *pin

--- a/src/hal/cython/machinekit/rtapi.pyx
+++ b/src/hal/cython/machinekit/rtapi.pyx
@@ -250,3 +250,18 @@ atexit.register(_atexit)
 
 (lambda s=__import__('signal'):
      s.signal(s.SIGTERM, s.default_int_handler))()
+
+# global RTAPIcommand to use in HAL config files
+__rtapicmd = None
+def init_RTAPI(**kwargs):
+    global __rtapicmd
+    if not __rtapicmd:
+        __rtapicmd = RTAPIcommand(**kwargs)
+        for method in dir(__rtapicmd):
+            if callable(getattr(__rtapicmd, method)) and method is not '__init__':
+                setattr(sys.modules[__name__], method, getattr(__rtapicmd, method))
+    else:
+        raise RuntimeError('RTAPIcommand already initialized')
+    if not __rtapicmd:
+        raise RuntimeError('unable to initialize RTAPIcommand - realtime not running?')
+

--- a/src/hal/cython/machinekit/rtapi.pyx
+++ b/src/hal/cython/machinekit/rtapi.pyx
@@ -157,7 +157,7 @@ def classify_comp(comp):
     c = hal.components[comp]
     if c.type is not hal.TYPE_RT:
         return CS_NOT_RT
-    if c.ctor is None:
+    if not c.has_ctor:
         return CS_RTLOADED_NOT_INSTANTIABLE
     return CS_RTLOADED_AND_INSTANTIABLE
 

--- a/src/hal/cython/machinekit/rtapi.pyx
+++ b/src/hal/cython/machinekit/rtapi.pyx
@@ -142,6 +142,26 @@ if sys.version_info >= (3, 0):
 else:
     import ConfigParser as configparser
 
+# enums for classify_comp
+CS_NOT_LOADED = 0
+CS_NOT_RT = 1
+CS_RTLOADED_NOT_INSTANTIABLE = 2
+CS_RTLOADED_AND_INSTANTIABLE = 3
+
+autoload = True  #  autoload components on newinst
+
+# classifies a component for newinst
+def classify_comp(comp):
+    if not comp in hal.components:
+        return CS_NOT_LOADED
+    c = hal.components[comp]
+    if c.type is not hal.TYPE_RT:
+        return CS_NOT_RT
+    if c.ctor is None:
+        return CS_RTLOADED_NOT_INSTANTIABLE
+    return CS_RTLOADED_AND_INSTANTIABLE
+
+
 class RTAPIcommand:
     ''' connect to the rtapi_app RT demon to pass commands '''
 
@@ -206,6 +226,7 @@ class RTAPIcommand:
 
     def newinst(self, *args, instance=0, **kwargs):
         cdef char** argv
+        cdef char** tmpArgv
         cdef char *name
 
         if len(args) < 2:
@@ -216,12 +237,26 @@ class RTAPIcommand:
             args +=('%s=%s' % (key, str(kwargs[key])), )
         argv = _to_argv(args[2:])
 
-        if comp not in hal.components:
-             rtapi_loadrt(instance, comp, <const char **>argv)
+        status = classify_comp(comp)
+        if status is CS_NOT_LOADED:
+            if autoload:  # flag to prevent creating a new instance
+                tmpArgv = _to_argv([])
+                rtapi_loadrt(instance, comp, <const char **>tmpArgv)
+            else:
+                raise RuntimeError("component '%s' not loaded\n" % comp)
+        elif status is CS_NOT_RT:
+            raise RuntimeError("'%s' not an RT component\n" % comp)
+        elif status is CS_RTLOADED_NOT_INSTANTIABLE:
+            raise RuntimeError("legacy component '%s' loaded, but not instantiable\n" % comp)
+        elif status is CS_RTLOADED_AND_INSTANTIABLE:
+            pass  # good
+
+        #TODO check singleton
+
         if instname in hal.instances:
             raise RuntimeError('instance with name ' + instname + ' already exists')
 
-        r = rtapi_newinst( instance, comp, instname, <const char **>argv)
+        r = rtapi_newinst(instance, comp, instname, <const char **>argv)
         free(argv)
         if r:
             raise RuntimeError("rtapi_newinst '%s' failed: %s" % (args,strerror(-r)))

--- a/src/hal/cython/machinekit/rtapi.pyx
+++ b/src/hal/cython/machinekit/rtapi.pyx
@@ -217,6 +217,8 @@ class RTAPIcommand:
         if r:
             raise RuntimeError("rtapi_loadrt '%s' failed: %s" % (args,strerror(-r)))
 
+        return hal.components[name]
+
     def unloadrt(self,char *name, int instance=0):
         if name == NULL:
             raise RuntimeError("unloadrt needs at least the module name as argument")
@@ -260,6 +262,8 @@ class RTAPIcommand:
         free(argv)
         if r:
             raise RuntimeError("rtapi_newinst '%s' failed: %s" % (args,strerror(-r)))
+
+        return hal.instances[instname]
 
     def delinst(self, char *instname, instance=0):
         r = rtapi_delinst( instance, instname)


### PR DESCRIPTION
- adds a way to init RTAPI inside the module to use it as a singleton in Python based HAL configs
e.g.
```python
from machinekit import rtapi as rt
rt.ini_RTAPI()
import myconfig
```
myconfig.py
```python
from machinekit import rtapi as rt
rt.newinst('and2', 'and2.bla')
```
- partially backports newinst functionality from halcmd
- improves string representation and hal dictionaries
- using Instance and Component
- adds pin lists to instance and component
- net now also links lists of pins
- pins can now be linked with automatic signal creation:
```python
x = rt.newinst('and2', 'and2.test')
y = rt.newinst('and2', 'and2.test2')
x.pin('out').link(y.pin('in0'))  # creates sig and2-test-out
# alternative using net command
hal.net('and2.test.out', 'and2.test2.in0')
```