### PR TITLE
Python API updates 2

### DIFF
--- a/src/hal/cython/machinekit/hal_loadusr.pyx
+++ b/src/hal/cython/machinekit/hal_loadusr.pyx
@@ -3,10 +3,22 @@ import subprocess
 import shlex
 import time
 
-def loadusr(command, wait=False, wait_name=None, wait_timeout=5.0, shell=False):
+def loadusr(command, wait=False, wait_name=None, wait_timeout=5.0, shell=False, **kwargs):
     cmd = command
+
+    for key in kwargs.keys():  # pass arguments using kwargs
+        arg = kwargs[key]
+        prefix = '--'
+        if len(key) == 1:  # single length arguments have single prefix
+            prefix = '-'
+        if isinstance(arg, bool):  # boolean is store_true type argument
+            if arg is True:
+                cmd += ' %s%s' % (prefix, key)
+        else:
+            cmd += ' %s%s %s' % (prefix, key, str(arg))
+
     if not shell:
-        cmd = shlex.split(command)  # correctly split the command
+        cmd = shlex.split(cmd)  # correctly split the command
     p = subprocess.Popen(cmd, shell=shell)
 
     wait = wait or (wait_name is not None)

--- a/src/hal/cython/machinekit/hal_pin.pyx
+++ b/src/hal/cython/machinekit/hal_pin.pyx
@@ -164,6 +164,7 @@ class Pin(_Pin):
     def get(self): raise NotImplementedError("Pin is write-only")
 
     def __repr__(self):
-        return "<hal.Pin %s %s %s>" % (self.name,
-                                        describe_hal_type(self.type),
-                                        describe_hal_dir(self.dir))
+        return "<hal.Pin %s %s %s %s>" % (self.name,
+                                          describe_hal_type(self.type),
+                                          describe_hal_dir(self.dir),
+                                          self.get())

--- a/src/hal/cython/machinekit/hal_pin.pyx
+++ b/src/hal/cython/machinekit/hal_pin.pyx
@@ -95,13 +95,14 @@ cdef class _Pin:
         def __get__(self): return self._pin.dir
 
     def link(self, arg):
-        # check if we have a signal
-        if isinstance(arg, Signal) \
-           or (isinstance(arg, str) and (arg in signals)):
-            return net(arg, self)  # net is more verbose than link
+        # check if we have a pin or a list of pins
+        if isinstance(arg, Pin) \
+           or (isinstance(arg, str) and (arg in pins)) \
+           or hasattr(arg, '__iter__'):
+            return net(self, arg)  # net is more verbose than link
 
-        # we got a pin or list of pins
-        return net(self, arg)
+        # we got a signal or a new signal
+        return net(arg, self)
 
     def __iadd__(self, pins):
         return self.link(pins)

--- a/src/hal/cython/machinekit/hal_signal.pyx
+++ b/src/hal/cython/machinekit/hal_signal.pyx
@@ -164,8 +164,9 @@ cdef class Signal:
             return self._sig.handle
 
     def __repr__(self):
-        return "<hal.Signal %s %s>" % (self.name,
-                                       describe_hal_type(self.type))
+        return "<hal.Signal %s %s %s>" % (self.name,
+                                          describe_hal_type(self.type),
+                                          self.get())
 
 
 cdef modifier_name(hal_sig_t *sig, int dir):

--- a/src/hal/cython/machinekit/hal_signal.pyx
+++ b/src/hal/cython/machinekit/hal_signal.pyx
@@ -19,9 +19,12 @@ cdef class Signal:
             with HALMutex():
                 self._sig = halpr_find_sig_by_name(name)
                 if self._sig == NULL:
-                    raise RuntimeError("signal %s does not exist" % name)
+                    raise RuntimeError("signal '%s' does not exist" % name)
 
         else:
+            if name in signals:
+                raise RuntimeError("Failed to create signal: a signal with the name '%s' already exists" % name)
+
             r = hal_signal_new(name, type)
             if r:
                 raise RuntimeError("Failed to create signal %s: %s" % (name, hal_lasterror()))
@@ -39,12 +42,7 @@ cdef class Signal:
     def link(self, *pins):
         self._alive_check()
         for p in pins:
-            if isinstance(p, Pin):
-                p.link(self._sig.name)
-            else:
-                r = hal_link(self._p, self._sig.name)
-                if r:
-                    raise RuntimeError("Failed to link pin %s to %s: %s" % (p, self._sig.name, hal_lasterror()))
+            net(self._sig.name, p)
 
     def __iadd__(self, pins):
         self._alive_check()


### PR DESCRIPTION
This patch adds another set of features to the HAL Python API:
- allows passing arguments to loadusr using Python kwargs
- more sane error message when trying to create a signal that already exists
- attaching to existing signals specifying the signal type (and raising an error if signal has different type)
- show the value of pin and signal in Python string representation
- fix signal linking