### PR TITLE
Python API updates 3

### DIFF
--- a/lib/python/machinekit/launcher.py
+++ b/lib/python/machinekit/launcher.py
@@ -150,6 +150,7 @@ def install_comp(filename):
 
 # starts realtime
 def start_realtime():
+    global _realtimeStarted
     sys.stdout.write("starting realtime...")
     sys.stdout.flush()
     subprocess.check_call('realtime start', shell=True)
@@ -159,6 +160,7 @@ def start_realtime():
 
 # stops realtime
 def stop_realtime():
+    global _realtimeStarted
     sys.stdout.write("stopping realtime... ")
     sys.stdout.flush()
     subprocess.check_call('realtime stop', shell=True)

--- a/lib/python/machinekit/launcher.py
+++ b/lib/python/machinekit/launcher.py
@@ -127,7 +127,7 @@ def load_bbio_file(filename):
 # installs a comp RT component
 def install_comp(filename):
     install = True
-    base = os.path.splitext(os.path.basename(filename))[0]
+    base, ext = os.path.splitext(os.path.basename(filename))
     flavor = compat.default_flavor()
     moduleDir = compat.get_rtapi_config("RTLIB_DIR")
     moduleName = flavor.name + '/' + base + flavor.mod_ext
@@ -139,12 +139,19 @@ def install_comp(filename):
             install = False
 
     if install is True:
+        if ext == '.icomp':
+            cmdBase = 'instcomp'
+        else:
+            cmdBase = 'comp'
         sys.stdout.write("installing " + filename + '... ')
         sys.stdout.flush()
         if os.access(moduleDir, os.W_OK):  # if we have write access we might not need sudo
-            subprocess.check_call('comp --install ' + filename, shell=True)
+            cmd = '%s --install %s' % (cmdBase, filename)
         else:
-            subprocess.check_call('sudo comp --install ' + filename, shell=True)
+            cmd = 'sudo %s --install %s' % (cmdBase, filename)
+
+        subprocess.check_call(cmd, shell=True)
+
         sys.stdout.write('done\n')
 
 

--- a/src/hal/cython/machinekit/hal_loadusr.pyx
+++ b/src/hal/cython/machinekit/hal_loadusr.pyx
@@ -22,15 +22,19 @@ def loadusr(command, wait=False, wait_name=None, wait_timeout=5.0, shell=False, 
     p = subprocess.Popen(cmd, shell=shell)
 
     wait = wait or (wait_name is not None)
+
     if not wait:
         return
+
+    if wait_name is None:
+        wait_name = command.split(' ')[0]  # guess the name
 
     timeout = 0.0
     while True:
         p.poll()
         # check if process is alive
         ret = p.returncode
-        if ret is not None and ret != 0:
+        if ret is not None:
             raise RuntimeError(command + ' exited with return code ' + str(ret))
         # check if component exists
         if (wait_name is not None) and (wait_name in components):

--- a/src/hal/cython/machinekit/hal_net.pyx
+++ b/src/hal/cython/machinekit/hal_net.pyx
@@ -53,7 +53,6 @@ def net(sig,*pinnames):
         writers = s.writers
         bidirs = s.bidirs
         t = s.type
-        assert writers + bidirs < 2
 
     if signame in pins:
         raise TypeError("net: '%s' is a pin - first argument must be a signal name" % signame)

--- a/src/hal/cython/machinekit/hal_signal.pyx
+++ b/src/hal/cython/machinekit/hal_signal.pyx
@@ -183,11 +183,11 @@ cdef modifier_name(hal_sig_t *sig, int dir):
      return None
 
 
-cdef _new_sig(char *name, int type):
+cdef _newsig(char *name, int type, init=None):
     if not valid_type(type):
-        raise TypeError("new_sig: %s - invalid type %d " % (name, type))
-    return Signal(name, type, wrap=False)
+        raise TypeError("newsig: %s - invalid type %d " % (name, type))
+    return Signal(name, type, init=init, wrap=False)
 
-def newsig(name,type):
-    _new_sig(name,type)
+def newsig(name, type, init=None):
+    _newsig(name, type, init)
     return signals[name] # add to sigdict

--- a/src/machinekitcfg.py-tmp.in
+++ b/src/machinekitcfg.py-tmp.in
@@ -59,7 +59,7 @@ def find(section, option, default=None):
         return default
     try:
         return __estimateType(_cfg.get(section, option))
-    except configparser.NoOptionError or configparser.NoSectionError:
+    except (configparser.NoOptionError, configparser.NoSectionError):
         return default
 
 

--- a/src/machinekitcfg.py-tmp.in
+++ b/src/machinekitcfg.py-tmp.in
@@ -65,21 +65,8 @@ def find(section, option, default=None):
 
 class Config(object):
 
-
     def does_io(self):
         if self.BUILD_DRIVERS: return True
-
-    def runs_on_xenomai(self):
-        return self.THREADS in ['xenomai-kernel', 'xenomai']
-
-    def runs_on_rtai(self):
-        return self.THREADS == 'rtai'
-
-    def is_rt(self):
-        return self.THREADS in rtstyles
-
-    def is_kernel_rt(self):
-        return self.BUILD_SYS == "kbuild"
 
     # automatic substitution by configure starts here
 
@@ -93,181 +80,183 @@ class Config(object):
         self.BUILD_THREAD_FLAVORS="@BUILD_THREAD_FLAVORS@"
 
         # Directories
-	self.prefix="@prefix@"
-	self.exec_prefix="@exec_prefix@"
+        self.prefix="@prefix@"
+        self.exec_prefix="@exec_prefix@"
         self.rundir= "@RUNDIR@"
-	self.EMC2_HOME="@EMC2_HOME@"
-	self.LIB_DIR="@EMC2_HOME@/lib"
+        self.EMC2_HOME="@EMC2_HOME@"
+        self.LIB_DIR="@EMC2_HOME@/lib"
 
         #used for install stuff
         #but have them here as reference
         #build system only uses EMC2_RTLIB_DIR when creating rtapi.ini
-	self.EMC2_BIN_DIR="@EMC2_BIN_DIR@"
-	self.EMC2_LIBEXEC_DIR="@EMC2_LIBEXEC_DIR@"
-	self.EMC2_TCL_DIR="@EMC2_TCL_DIR@"
-	self.EMC2_HELP_DIR="@EMC2_HELP_DIR@"
-	self.EMC2_RTLIB_DIR="@EMC2_RTLIB_DIR@"
-	self.EMC2_USER_CONFIG_DIR="~/emc2/configs"
-	self.EMC2_SYSTEM_CONFIG_DIR="@EMC2_SYSTEM_CONFIG_DIR@"
-	self.EMC2_NCFILES_DIR="@EMC2_NCFILES_DIR@"
-	self.REALTIME="@REALTIME@"
-	self.EMC2_IMAGEDIR="@EMC2_IMAGE_DIR@"
+        self.EMC2_BIN_DIR="@EMC2_BIN_DIR@"
+        self.EMC2_LIBEXEC_DIR="@EMC2_LIBEXEC_DIR@"
+        self.EMC2_TCL_DIR="@EMC2_TCL_DIR@"
+        self.EMC2_HELP_DIR="@EMC2_HELP_DIR@"
+        self.EMC2_RTLIB_DIR="@EMC2_RTLIB_DIR@"
+        self.EMC2_USER_CONFIG_DIR="~/emc2/configs"
+        self.EMC2_SYSTEM_CONFIG_DIR="@EMC2_SYSTEM_CONFIG_DIR@"
+        self.EMC2_NCFILES_DIR="@EMC2_NCFILES_DIR@"
+        self.REALTIME="@REALTIME@"
+        self.EMC2_IMAGEDIR="@EMC2_IMAGE_DIR@"
 
 
         # Standard configure directories
         # do we really need these?
-	self.bindir = "@bindir@"
-	self.sbindir = "@sbindir@"
-	self.libexecdir = "@libexecdir@"
-	self.datadir = "@datadir@"
-	self.datarootdir = "@datarootdir@"
-	self.sysconfdir = "@sysconfdir@"
-	self.sharedstatedir = "@sharedstatedir@"
-	self.localstatedir = "@localstatedir@"
-	self.libdir = "@libdir@"
-	self.infodir = "@infodir@"
-	self.mandir = "@mandir@"
-	self.includedir = "@includedir@"
-	self.docdir = "@docdir@"
-	self.sampleconfsdir = self.datadir + \
+        self.bindir = "@bindir@"
+        self.sbindir = "@sbindir@"
+        self.libexecdir = "@libexecdir@"
+        self.datadir = "@datadir@"
+        self.datarootdir = "@datarootdir@"
+        self.sysconfdir = "@sysconfdir@"
+        self.sharedstatedir = "@sharedstatedir@"
+        self.localstatedir = "@localstatedir@"
+        self.libdir = "@libdir@"
+        self.infodir = "@infodir@"
+        self.mandir = "@mandir@"
+        self.includedir = "@includedir@"
+        self.docdir = "@docdir@"
+        self.sampleconfsdir = self.datadir + \
                               "/linuxcnc/examples/sample-configs"
-	self.ncfilesdir = self.prefix + "/share/linuxcnc/ncfiles"
-	self.tcldir = self.prefix + "/lib/tcltk/linuxcnc"
+        self.ncfilesdir = self.prefix + "/share/linuxcnc/ncfiles"
+        self.tcldir = self.prefix + "/lib/tcltk/linuxcnc"
 
 
         # i18n variables:
-	self.package = "@PACKAGE@"
-	self.localedir = "@LOCALEDIR@"
-	self.LANGUAGES = "@LANGUAGES@"
+        self.package = "@PACKAGE@"
+        self.localedir = "@LOCALEDIR@"
+        self.LANGUAGES = "@LANGUAGES@"
 
 
         # /Standard configure directories
-	self.RUN_IN_PLACE = "@RUN_IN_PLACE@"
-	self.CC = "@CC@"
-	self.MANDB = "@MANDB@"
-	self.HIDRAW_H_USABLE = "@HIDRAW_H_USABLE@"
+        self.RUN_IN_PLACE = "@RUN_IN_PLACE@"
+        self.CC = "@CC@"
+        self.MANDB = "@MANDB@"
+        self.HIDRAW_H_USABLE = "@HIDRAW_H_USABLE@"
 
 
-	self.BUILD_DRIVERS = "@BUILD_DRIVERS@"
-	self.USE_PORTABLE_PARPORT_IO = "@USE_PORTABLE_PARPORT_IO@"
-	self.TARGET_PLATFORM_PC = "@TARGET_PLATFORM_PC@"
-	self.TARGET_PLATFORM_BEAGLEBONE = "@TARGET_PLATFORM_BEAGLEBONE@"
-	self.TARGET_PLATFORM_RASPBERRY = "@TARGET_PLATFORM_RASPBERRY@"
-	self.ARCHITECTURE="@ARCHITECTURE@"
+        self.BUILD_DRIVERS = "@BUILD_DRIVERS@"
+        self.USE_PORTABLE_PARPORT_IO = "@USE_PORTABLE_PARPORT_IO@"
+        self.TARGET_PLATFORM_PC = "@TARGET_PLATFORM_PC@"
+        self.TARGET_PLATFORM_BEAGLEBONE = "@TARGET_PLATFORM_BEAGLEBONE@"
+        self.TARGET_PLATFORM_RASPBERRY = "@TARGET_PLATFORM_RASPBERRY@"
+        self.ARCHITECTURE="@ARCHITECTURE@"
 
-	self.USERMODE_PCI="@USERMODE_PCI@"
+        self.USERMODE_PCI="@USERMODE_PCI@"
 
         #libudev for if USERMODE_PCI==yes
-	self.LIBUDEV_CFLAGS="@LIBUDEV_CFLAGS@"
-	self.LIBUDEV_LIBS="@LIBUDEV_LIBS@"
+        self.LIBUDEV_CFLAGS="@LIBUDEV_CFLAGS@"
+        self.LIBUDEV_LIBS="@LIBUDEV_LIBS@"
 
         # deps for xemc
-	self.CFLAGS_X = "@X_CFLAGS@"
-	self.XLIBS = "@XAW_LIBS@"
-	self.HAVE_XAW = "@HAVE_XAW@"
+        self.CFLAGS_X = "@X_CFLAGS@"
+        self.XLIBS = "@XAW_LIBS@"
+        self.HAVE_XAW = "@HAVE_XAW@"
 
         # ncurses support for keystick
-	self.KEYSTICKLIBS =  "@NCURSES_LIBS@"
-	self.HAVE_NCURSES = "@HAVE_NCURSES@"
+        self.KEYSTICKLIBS =  "@NCURSES_LIBS@"
+        self.HAVE_NCURSES = "@HAVE_NCURSES@"
 
         # readline support for halcmd
-	self.READLINE_LIBS =  "@READLINE_LIBS@"
+        self.READLINE_LIBS =  "@READLINE_LIBS@"
 
         # flags for glib
-	self.GLIB_CFLAGS = "@GLIB_CFLAGS@"
-	self.GLIB_LIBS = "@GLIB_LIBS@"
+        self.GLIB_CFLAGS = "@GLIB_CFLAGS@"
+        self.GLIB_LIBS = "@GLIB_LIBS@"
 
         # local flags for GTK include
-	self.GTK_VERSION = "@GTK_VER@"
-	self.GTK_CFLAGS = "@GTK_CFLAGS@"
-	self.GTK_LIBS = "@GTK_LIBS@"
-	self.HAVE_GNOMEPRINT = "@HAVE_GNOMEPRINT@"
+        self.GTK_VERSION = "@GTK_VER@"
+        self.GTK_CFLAGS = "@GTK_CFLAGS@"
+        self.GTK_LIBS = "@GTK_LIBS@"
+        self.HAVE_GNOMEPRINT = "@HAVE_GNOMEPRINT@"
 
         # tcl tk cflags, includes and libs
-	self.TCL_DBGX="@TCL_DBGX@"
-	self.TK_DBGX="@TK_DBGX@"
-	self.TCL_CFLAGS="@TCL_CFLAGS@ @TK_CFLAGS@"
-	self.TCL_LIBS="@TCL_LIBS@ @TK_LIBS@ @LIBS@"
-	self.HAVE_WORKING_BLT="@HAVE_WORKING_BLT@"
+        self.TCL_DBGX="@TCL_DBGX@"
+        self.TK_DBGX="@TK_DBGX@"
+        self.TCL_CFLAGS="@TCL_CFLAGS@ @TK_CFLAGS@"
+        self.TCL_LIBS="@TCL_LIBS@ @TK_LIBS@ @LIBS@"
+        self.HAVE_WORKING_BLT="@HAVE_WORKING_BLT@"
 
 
-	self.AR = "@AR@"
-	self.ARFLAGS = "cr" #??
-	self.CXX = "@CXX@"
-	self.CXXFLAGS = "@CFLAGS@"
-	self.RANLIB = "@RANLIB@"
-	self.MSGFMT = "@MSGFMT@"
-	self.XGETTEXT = "@XGETTEXT@"
+        self.AR = "@AR@"
+        self.ARFLAGS = "cr" #??
+        self.CXX = "@CXX@"
+        self.CXXFLAGS = "@CFLAGS@"
+        self.RANLIB = "@RANLIB@"
+        self.MSGFMT = "@MSGFMT@"
+        self.XGETTEXT = "@XGETTEXT@"
 
-	self.BUILD_DOCS = "@BUILD_DOCS@"
-	self.BUILD_DOCS_PDF = "@BUILD_DOCS_PDF@"
-	self.BUILD_DOCS_HTML = "@BUILD_DOCS_HTML@"
-	self.PYTHON = "@PYTHON@"
+        self.BUILD_DOCS = "@BUILD_DOCS@"
+        self.BUILD_DOCS_PDF = "@BUILD_DOCS_PDF@"
+        self.BUILD_DOCS_HTML = "@BUILD_DOCS_HTML@"
+        self.PYTHON = "@PYTHON@"
 
 #
 # i18n
 #
-# 	self.CONFIG_RTAPI=m
+#       self.CONFIG_RTAPI=m
 
 # # rtapi examples
-# 	self.CONFIG_RTAPI_EXAMPLES_EXTINT=m
-# 	self.CONFIG_RTAPI_EXAMPLES_FIFO=m
-# 	self.CONFIG_RTAPI_EXAMPLES_SEM=m
-# 	self.CONFIG_RTAPI_EXAMPLES_SHMEM=m
-# 	self.CONFIG_RTAPI_EXAMPLES_TIMER=m
+#       self.CONFIG_RTAPI_EXAMPLES_EXTINT=m
+#       self.CONFIG_RTAPI_EXAMPLES_FIFO=m
+#       self.CONFIG_RTAPI_EXAMPLES_SEM=m
+#       self.CONFIG_RTAPI_EXAMPLES_SHMEM=m
+#       self.CONFIG_RTAPI_EXAMPLES_TIMER=m
 
 # # emc motion module
-# 	self.CONFIG_MOTMOD=m
+#       self.CONFIG_MOTMOD=m
 
 # # HAL components
-# 	self.CONFIG_BLOCKS=m
-# 	self.CONFIG_BOSS_PLC=m
-# 	self.CONFIG_DEBOUNCE=m
-# 	self.CONFIG_ENCODER=m
-# 	self.CONFIG_COUNTER=m
-# 	self.CONFIG_ENCODER_RATIO=m
-# 	self.CONFIG_STEPGEN=m
-# 	self.CONFIG_LCD=m
-# 	self.CONFIG_FREQGEN=m
-# 	self.CONFIG_PWMGEN=m
-# 	self.CONFIG_SIGGEN=m
-# 	self.CONFIG_AT_PID=m
-# 	self.CONFIG_PID=m
-# 	self.CONFIG_PEPPER=m
-# 	self.CONFIG_SUPPLY=m
-# 	self.CONFIG_CLASSICLADDER_RT=m
-# 	self.CONFIG_TIMEDELAY=m
-# 	self.CONFIG_SIM_ENCODER=m
-# 	self.CONFIG_WEIGHTED_SUM=m
-# 	self.CONFIG_WATCHDOG=m
-# 	self.CONFIG_MODMATH=m
-# 	self.CONFIG_STREAMER=m
-# 	self.CONFIG_SAMPLER=m
+#       self.CONFIG_BLOCKS=m
+#       self.CONFIG_BOSS_PLC=m
+#       self.CONFIG_DEBOUNCE=m
+#       self.CONFIG_ENCODER=m
+#       self.CONFIG_COUNTER=m
+#       self.CONFIG_ENCODER_RATIO=m
+#       self.CONFIG_STEPGEN=m
+#       self.CONFIG_LCD=m
+#       self.CONFIG_FREQGEN=m
+#       self.CONFIG_PWMGEN=m
+#       self.CONFIG_SIGGEN=m
+#       self.CONFIG_AT_PID=m
+#       self.CONFIG_PID=m
+#       self.CONFIG_PEPPER=m
+#       self.CONFIG_SUPPLY=m
+#       self.CONFIG_CLASSICLADDER_RT=m
+#       self.CONFIG_TIMEDELAY=m
+#       self.CONFIG_SIM_ENCODER=m
+#       self.CONFIG_WEIGHTED_SUM=m
+#       self.CONFIG_WATCHDOG=m
+#       self.CONFIG_MODMATH=m
+#       self.CONFIG_STREAMER=m
+#       self.CONFIG_SAMPLER=m
 
 # # HAL drivers
-# 	self.CONFIG_HAL_PARPORT=m
-# 	self.CONFIG_PROBE_PARPORT=m
-# 	self.CONFIG_HAL_TIRO=m
-# 	self.CONFIG_HAL_EVOREG=m
-# 	self.CONFIG_HAL_MOTENC=m
-# 	self.CONFIG_HAL_SKELETON=m
-# 	self.CONFIG_HAL_GPIO=m
-# 	self.CONFIG_HAL_SPI=m
-# 	self.CONFIG_HAL_SPEAKER=m
-# 	self.CONFIG_HAL_STG=m
-# 	self.CONFIG_HAL_VTI=m
-# 	self.CONFIG_HAL_AX521H=m
-# 	self.CONFIG_HAL_PPMC=m
-# 	self.CONFIG_PCI_8255=m
-# 	self.CONFIG_HOSTMOT2=m
-# 	self.CONFIG_OPTO_AC5=m
+#       self.CONFIG_HAL_PARPORT=m
+#       self.CONFIG_PROBE_PARPORT=m
+#       self.CONFIG_HAL_TIRO=m
+#       self.CONFIG_HAL_EVOREG=m
+#       self.CONFIG_HAL_MOTENC=m
+#       self.CONFIG_HAL_SKELETON=m
+#       self.CONFIG_HAL_GPIO=m
+#       self.CONFIG_HAL_SPI=m
+#       self.CONFIG_HAL_SPEAKER=m
+#       self.CONFIG_HAL_STG=m
+#       self.CONFIG_HAL_VTI=m
+#       self.CONFIG_HAL_AX521H=m
+#       self.CONFIG_HAL_PPMC=m
+#       self.CONFIG_PCI_8255=m
+#       self.CONFIG_HOSTMOT2=m
+#       self.CONFIG_OPTO_AC5=m
 
 
-	self.BUILD_PYTHON="@BUILD_PYTHON@"
-	self.INCLUDEPY="@INCLUDEPY@"
-	self.SITEPY="@SITEPY@"
+        self.BUILD_PYTHON="@BUILD_PYTHON@"
+        self.INCLUDEPY="@INCLUDEPY@"
+        self.SITEPY="@SITEPY@"
 
 
-# if __name__ == "__main__":
-#     c = Config()
-#     print dir(c)
+# global Config exposes variable to module
+__config = Config()
+for attr in dir(__config):
+    if not attr.startswith("__"):
+        setattr(sys.modules[__name__], attr, getattr(__config, attr))


### PR DESCRIPTION
This patch includes following changes
- adapted install_comp for instcomps
- adding the init argument also to newsig
- cleaned up machinekitconfig.py -> whitespace, obsolete functions
- exposing machinekit.config variables to module space
- bugfix in hal_net
- bugfix in launcher
- bugfix config