### PR TITLE
hal/i_components: added io_muxn, safety_latch and led_dim components

### DIFF
--- a/src/hal/i_components/io_muxn.icomp
+++ b/src/hal/i_components/io_muxn.icomp
@@ -1,0 +1,87 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2015 Alexander Rössler
+ *
+ *
+ * This module acts as multiplexing gate for IO sinnals
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * THE AUTHORS OF THIS PROGRAM ACCEPT ABSOLUTELY NO LIABILITY FOR
+ * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE
+ * TO RELY ON SOFTWARE ALONE FOR SAFETY.  Any machinery capable of
+ * harming persons must have provisions for completely removing power
+ * from all motors, etc, before persons enter any danger area.  All
+ * machinery must be designed to comply with local and national safety
+ * codes, and the authors of this software can not, and do not, take
+ * any responsibility for such compliance.
+ *
+ * This code was written as part of the LinuxCNC project.  For more
+ * information, go to www.linuxcnc.org.
+ *
+ ******************************************************************************/
+component io_muxn "Gate one of N input values";
+pin in s32 sel = 0;
+pin io float out "Follows the value of \\fBin<M>\\fR whereas M is the value of the \\fBsel\\fR input. \
+If \\fBsel\\fR is not in the range of available inputs 0 is output.";
+pin io float in#.[pincount];
+
+variable hal_s32_t last_sel = -1; // will apply input to output on start-up
+variable hal_float_t last_in = 0.0;
+variable hal_float_t last_out = 0.0;
+
+instanceparam int pincount = 2;
+
+option MAXCOUNT 16;
+
+function _ fp;
+license "GPL";
+author "Alexander Roessler";
+;;
+FUNCTION(_)
+{
+    if ((sel < 0) || (sel >= localpincount))
+    {
+        return 0; // incorrect sel, we change nothing
+    }
+
+    if (sel != last_sel)
+    {
+        out = in_(sel);
+        last_sel = sel;
+        last_out = out;
+        last_in = in_(sel);
+    }
+    else
+    {
+        if (last_out != out)
+        {
+            in_(sel) = out;
+            last_out = out;
+            last_in = out;
+        }
+        else if (last_in != in_(sel))
+        {
+            out = in_(sel);
+            last_in = in_(sel);
+            last_out = in_(sel);
+        }
+    }
+
+    return 0;
+}

--- a/src/hal/i_components/led_dim.icomp
+++ b/src/hal/i_components/led_dim.icomp
@@ -1,0 +1,73 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2015 Alexander Rössler
+ *
+ *
+ * This module allows dimming LEDs using HAL
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * THE AUTHORS OF THIS PROGRAM ACCEPT ABSOLUTELY NO LIABILITY FOR
+ * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE
+ * TO RELY ON SOFTWARE ALONE FOR SAFETY.  Any machinery capable of
+ * harming persons must have provisions for completely removing power
+ * from all motors, etc, before persons enter any danger area.  All
+ * machinery must be designed to comply with local and national safety
+ * codes, and the authors of this software can not, and do not, take
+ * any responsibility for such compliance.
+ *
+ * This code was written as part of the LinuxCNC project.  For more
+ * information, go to www.linuxcnc.org.
+ *
+ ******************************************************************************/
+component led_dim "LinuxCNC HAL component for dimming LEDs";
+pin in  float in "Brightness input value -> 0 to 1";
+pin out float out "Luminance output value -> 0 to 1";
+function _  fp "Update the output value";
+description """
+Component for LED dimming according to human perception of brightness of light.
+.LP
+The output is calculated using the CIE 1931 formula.
+""";
+license "GPL";
+variable hal_float_t last_in = 0.0;
+;;
+#include <rtapi_math.h>
+#define MIN(x,y) (x < y ? x : y)
+
+FUNCTION(_) {
+    if (last_in != in)
+    {
+        hal_float_t input = MIN(MAX(in, 0.0), 1.0); // clamp to 0.0, 1.0
+
+        // luminance calculation based on CIE 1931 formula
+        // see http://forum.arduino.cc/index.php/topic,147810.0.html
+        if (input < 0.079996)
+        {
+            out = input / 9.033;
+        }
+        else
+        {
+            out = rtapi_pow((input + 0.16) / 1.16, 3.0);
+        }
+
+        last_in = in;
+    }
+
+    return 0;
+}

--- a/src/hal/i_components/safety_latch.icomp
+++ b/src/hal/i_components/safety_latch.icomp
@@ -1,0 +1,118 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2015 Alexander Rössler
+ *
+ *
+ * Safety latch for error signals
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * THE AUTHORS OF THIS PROGRAM ACCEPT ABSOLUTELY NO LIABILITY FOR
+ * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE
+ * TO RELY ON SOFTWARE ALONE FOR SAFETY.  Any machinery capable of
+ * harming persons must have provisions for completely removing power
+ * from all motors, etc, before persons enter any danger area.  All
+ * machinery must be designed to comply with local and national safety
+ * codes, and the authors of this software can not, and do not, take
+ * any responsibility for such compliance.
+ *
+ * This code was written as part of the LinuxCNC project.  For more
+ * information, go to www.linuxcnc.org.
+ *
+ ******************************************************************************/
+component safety_latch "latch for error signals";
+description """
+HAL component that implements a safety latch for error singnals
+with customizable harm, healing and latching features.
+
+When the component is not enabled the error input value is
+forwarded to output without further modififactions.
+
+If error-in is true the error count is increased by harm.
+If error-in is false the error count is decreased by heal.
+When the error count exceeds the threscold value error-out is
+set to true. If latching is false the error-out pin will only
+return to false when reset is set to true.
+
+The inputs pin min and max clamp the error count value to a
+specified range.
+""";
+pin in bit error_in = false "Error Input";
+pin in s32 heal = 1 "Heal when ok per tick";
+pin in s32 harm = 1 "Harm when error per tick";
+pin in bit latching = true "If a reset is necessary to heal an error";
+pin in bit reset = false "Reset input";
+pin in s32 threshold = 100 "Error output threshold";
+pin in s32 min = 0 "Minimum count";
+pin in s32 max = 1000 "Maximum count";
+pin in bit enable = true "If not enabled the error count is passed to the output";
+pin out s32 count = 0 "Current count";
+pin out bit error_out = false "Error output";
+pin out bit ok_out = true "Ok output";
+
+variable hal_bit_t last_reset = 0;
+
+function _ nofp;
+license "GPL";
+author "Alexander Roessler";
+;;
+#define MIN(x,y) (x < y ? x : y)
+
+FUNCTION(_)
+{
+    if (!enable)
+    {
+        error_out = error_in;
+        ok_out = !error_in;
+        count = 0;
+    }
+    else
+    {
+        if ((reset ^ last_reset) && reset)
+        {
+            count = 0;
+            error_out = false;
+            ok_out = true;
+        }
+
+        if (error_in)
+        {
+            count += harm;
+        }
+        else
+        {
+            count -= heal;
+        }
+        count = MIN(MAX(count, min), max);
+
+        if (count >= threshold)
+        {
+            error_out = true;
+            ok_out = false;
+        }
+        else if (!latching)
+        {
+            error_out = false;
+            ok_out = true;
+        }
+    }
+
+    last_reset = reset;
+
+    return 0;
+}

--- a/src/hal/i_components/select8.icomp
+++ b/src/hal/i_components/select8.icomp
@@ -1,5 +1,5 @@
 component select8 "8-bit binary match detector";
-pin io bit enable = TRUE "Set enable to FALSE to cause all outputs to be set FALSE";
+pin io bit enable = true "Set enable to FALSE to cause all outputs to be set FALSE";
 pin in s32 sel "The number of the output to set TRUE.  All other outputs well be set FALSE";
 pin out bit out#[8] "Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true";
 
@@ -8,17 +8,18 @@ license "GPL";
 ;;
 FUNCTION(_)
 {
-    hal_s32_t temp_sel;
     hal_s32_t i;
-    hal_bit_t temp_enable;
-    temp_sel = sel;
-    temp_enable = enable;
-    for (i=0; i < 8 ; i++) {
-        if (!temp_enable || temp_sel!=i)
-            out(i)=0;
+    for (i=0; i < 8 ; i++)
+    {
+        if (!enable || (sel != i) )
+        {
+            out(i) = 0;
+        }
         else
-            out(i)=1;
+        {
+            out(i) = 1;
+        }
     }
 
-return 0;
+    return 0;
 }

--- a/src/hal/i_components/selectn.icomp
+++ b/src/hal/i_components/selectn.icomp
@@ -1,0 +1,30 @@
+component selectn "select one of n";
+pin io bit enable = true "Set enable to FALSE to cause all outputs to be set FALSE";
+pin in s32 sel "The number of the output to set TRUE.  All other outputs well be set FALSE";
+pin out bit out#[pincount] "Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true";
+
+instanceparam int pincount = 2;
+
+option MAXCOUNT 16;
+
+function _ nofp;
+license "GPL";
+author "Alexander Roessler";
+;;
+FUNCTION(_)
+{
+    hal_s32_t i;
+    for (i=0; i < localpincount ; i++)
+    {
+        if (!enable || (sel != i))
+        {
+            out(i) = 0;
+        }
+        else
+        {
+            out(i) = 1;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds 3 additional HAL components:
* io_muxn is a multiplexer gate for IO signals, useful for multiplexing config signals
* led_dim converts brightness to luminance for dimming LEDs
* safety_latch latches error signals with configurable healing, harm and latching behavior
* selectn select on of n outputs
* small code cleanup for select8 component