### PR TITLE
Use boolean values and tests for hal_bit_t data types

### DIFF
--- a/src/hal/i_components/abs.icomp
+++ b/src/hal/i_components/abs.icomp
@@ -18,8 +18,8 @@ component abs "Compute the absolute value and sign of the input signal";
 pin in float in "Analog input value" ;
 pin out float out "Analog output value, always positive";
 pin out bit sign "Sign of input, false for positive, true for negative" ;
-pin out bit is_positive "TRUE if input is positive, FALSE if input is 0 or negative";
-pin out bit is_negative "TRUE if input is negative, FALSE if input is 0 or positive";
+pin out bit is_positive "true if input is positive, false if input is 0 or negative";
+pin out bit is_negative "true if input is negative, false if input is 0 or positive";
 
 function _;
 license "GPL";
@@ -27,18 +27,18 @@ license "GPL";
 FUNCTION(_) {
     hal_float_t tmp = in;
     if ( tmp >= 0.0 ) {
-	sign = 0;
+	sign = false;
 	out = tmp;
     } else {
-	sign = 1;
+	sign = true;
 	out = -tmp;
     }
 
-    if (tmp > 0.000001) is_positive = 1;
-    else is_positive = 0;
+    if (tmp > 0.000001) is_positive = true;
+    else is_positive = false;
 
-    if (tmp < -0.000001) is_negative = 1;
-    else is_negative = 0;
+    if (tmp < -0.000001) is_negative = true;
+    else is_negative = false;
 
     return 0;
 }

--- a/src/hal/i_components/abs_s32.icomp
+++ b/src/hal/i_components/abs_s32.icomp
@@ -18,8 +18,8 @@ component abs_s32 "Compute the absolute value and sign of the input signal";
 pin in s32 in "input value" ;
 pin out s32 out "output value, always non-negative";
 pin out bit sign "Sign of input, false for positive, true for negative" ;
-pin out bit is_positive "TRUE if input is positive, FALSE if input is 0 or negative";
-pin out bit is_negative "TRUE if input is negative, FALSE if input is 0 or positive";
+pin out bit is_positive "true if input is positive, false if input is 0 or negative";
+pin out bit is_negative "true if input is negative, false if input is 0 or positive";
 
 function _ nofp;
 license "GPL";
@@ -27,18 +27,18 @@ license "GPL";
 FUNCTION(_) {
     __s32 tmp = in;
     if ( tmp >= 0 ) {
-	sign = 0;
+	sign = false;
 	out = tmp;
     } else {
-	sign = 1;
+	sign = true;
 	out = -tmp;
     }
 
-    if (tmp > 0) is_positive = 1;
-    else is_positive = 0;
+    if (tmp > 0) is_positive = true;
+    else is_positive = false;
 
-    if (tmp < 0) is_negative = 1;
-    else is_negative = 0;
+    if (tmp < 0) is_negative = true;
+    else is_negative = false;
 
 return 0;
 }

--- a/src/hal/i_components/andn.icomp
+++ b/src/hal/i_components/andn.icomp
@@ -21,7 +21,7 @@ function _ nofp;
 FUNCTION(_)
 {
     hal_s32_t n;
-    hal_bit_t value = 1;
+    hal_bit_t value = true;
 
     // loop through inputs
     for (n = 0; n < localpincount; n++)

--- a/src/hal/i_components/biquad.icomp
+++ b/src/hal/i_components/biquad.icomp
@@ -40,10 +40,10 @@ H(z) = (n0 + n1z-1 + n2z-2) / (1+ d1z-1 + d2z-2)""";
 
 pin in float in "Filter input.";
 pin out float out "Filter output.";
-pin in bit enable = 0 "Filter enable. When false, the in is passed to out \
+pin in bit enable = false "Filter enable. When false, the in is passed to out \
 without any filtering. A transition from false to true causes filter \
 coefficients to be calculated according to parameters";
-pin out bit valid = 0 "When false, indicates an error occured when caclulating \
+pin out bit valid = false "When false, indicates an error occured when caclulating \
 filter coefficients.";
 
 pin io u32 type_ = 0 "Filter type determines the type of filter \
@@ -89,7 +89,7 @@ typedef enum {
 
 EXTRA_INST_SETUP()
 {
-    lastEnable = 0;
+    lastEnable = false;
 
     return(0);
 }
@@ -127,7 +127,7 @@ struct inst_data *ip = arg;
 
     // If not direct coefficient loading.
     if(type_ != TYPE_DIRECT){
-        valid = 0;
+        valid = false;
 
         sampleRate = (1.0 / ((hal_float_t)period * 1e-9)); 
 
@@ -163,5 +163,5 @@ struct inst_data *ip = arg;
         s1 = s2 = 0.0;
     }
 
-    valid = 1;
+    valid = true;
 }

--- a/src/hal/i_components/comp.icomp
+++ b/src/hal/i_components/comp.icomp
@@ -21,17 +21,17 @@ FUNCTION(_)
 
     if(tmp < -halfhyst)
         {
-	out = 0;
-	    equal = 0;
+	out = false;
+	    equal = false;
         }
     else if(tmp > halfhyst)
         {
-	out = 1;
-	    equal = 0;
+	out = true;
+	    equal = false;
         }
     else
         {
-	equal = 1;
+	equal = true;
         }
 
 	return 0;

--- a/src/hal/i_components/debounce.icomp
+++ b/src/hal/i_components/debounce.icomp
@@ -36,14 +36,14 @@ hal_s32_t n;
             if (_state(n) < delay)
                 _state(n)++;
             else
-                _out(n) = 1;
+                _out(n) = true;
             }
         else
             {
             if (_state(n) > 0)
                 _state(n)--;
             else
-                _out(n) = 0;
+                _out(n) = false;
             }
         }
     return 0;

--- a/src/hal/i_components/edge.icomp
+++ b/src/hal/i_components/edge.icomp
@@ -20,13 +20,13 @@ pin in bit in;
 pin out bit out "Goes high when the desired edge is seen on 'in'";
 pin out bit out_invert "Goes low when the desired edge is seen on 'in'";
 
-pin io bit both=FALSE "If TRUE, selects both edges.  Otherwise, selects one edge according to in-edge";
-pin io bit in_edge=TRUE "If both is FALSE, selects the one desired edge: TRUE means falling, FALSE means rising";
+pin io bit both=false "If true, selects both edges.  Otherwise, selects one edge according to in-edge";
+pin io bit in_edge=true "If both is false, selects the one desired edge: true means falling, false means rising";
 pin io s32 out_width_ns=0 "Time in nanoseconds of the output pulse";
 
 pin out s32 time_left_ns "Time left in this output pulse";
 pin out bit last_in "Previous input value";
-variable hal_s32_t first = 1;
+variable hal_bit_t first = true;
 
 function _ nofp "Produce output pulses from input edges";
 license "GPL";
@@ -53,17 +53,17 @@ FUNCTION(_)
             }
         else if(time_left_ns > 0)
             {
-            out = 1;
+            out = true;
             }
         else
             {
             time_left_ns = 0;
-            out = 0;
+            out = false;
             }
         }
     else
         {
-        first = 0;
+        first = false;
         }
     last_in = new_in;
     out_invert = !out;

--- a/src/hal/i_components/estop_latch.icomp
+++ b/src/hal/i_components/estop_latch.icomp
@@ -20,8 +20,8 @@ FUNCTION(_)
 	    if ( reset && !old_reset )
 	        {
 	    /* got a rising edge, indicate "OK" on outputs */
-	        ok_out = 1;
-	        fault_out = 0;
+	        ok_out = true;
+	        fault_out = false;
 	        }
 	    if( ok_out )
 	        {
@@ -32,8 +32,8 @@ FUNCTION(_)
     else
         {
 	/* fault condition exists, trip */
-	    ok_out = 0;
-	    fault_out = 1;
+	    ok_out = false;
+	    fault_out = true;
         }
     /* store state of reset input for next pass (for edge detect) */
     old_reset = reset;

--- a/src/hal/i_components/flipflop.icomp
+++ b/src/hal/i_components/flipflop.icomp
@@ -16,11 +16,11 @@ hal_bit_t c;
     c = clk;
     if ( reset )
         {
-	out = 0;
+	out = false;
         }
     else if ( set )
         {
-        out = 1;
+        out = true;
         }
     else if ( c && ! oldclk )
         {

--- a/src/hal/i_components/gantry.icomp
+++ b/src/hal/i_components/gantry.icomp
@@ -54,7 +54,7 @@ function write fp "Update joint pos-cmd outputs based on position-cmd in";
 variable hal_float_t offset[7] = 0.0;
 variable hal_float_t prev_cmd = 0.0;
 variable hal_s32_t   fb_joint = 0;
-variable hal_bit_t   latching = 0;
+variable hal_bit_t   latching = false;
 
 instanceparam int pincount = 7;
 
@@ -96,9 +96,9 @@ FUNCTION(read) {
     // All other joints, if configured
     while (i < localpincount) {
         // Check to see if machine is in latching state
-        if(latching==0)
+        if(!latching)
         {
-            // Don't asset home until all joints hit their home switches
+            // Don't assert home until all joints hit their home switches
             home  &= joint_home(i);
         }
         else
@@ -120,9 +120,9 @@ FUNCTION(read) {
     // track active joints or motion gets upset with the sudden
     // stop.  If all joints are not homed, but the current joint used
     // for feedback is, find a joint that's still active
-    if ((joint_home(fb_joint) == 1) && (home == 0)) {
+    if ((joint_home(fb_joint) ) && (home == 0)) {
         for (i=0; i < localpincount; i++) {
-            if (joint_home(i) == 0) {
+            if (!joint_home(i)) {
                 position_fb = joint_pos_fb(i) + offset[i];
                 fb_joint = i;
                 break;
@@ -158,7 +158,7 @@ FUNCTION(write) {
         for (i=0; i < localpincount; i++) {
             // If home switch is active, update offset, not pos_cmd
             // so the other joints can catch up
-            if (joint_home(i)==1) {
+            if (joint_home(i)) {
                 offset[i] += delta;
             }
         }

--- a/src/hal/i_components/hbridge.icomp
+++ b/src/hal/i_components/hbridge.icomp
@@ -28,26 +28,26 @@ FUNCTION(_)
     if (enable) {
 	if (brake) {
 	    // motor DC brake
-	    up = 0;
-	    down = 0;
-	    enable_out = 1;
+	    up = 0.0;
+	    down = 0.0;
+	    enable_out = true;
 	} else {
 	    // normal forward/reverse operation
 	    hal_float_t negcmd = command * - 1.0;
 	    if (command < 0.0) {
-		up = 0;
+		up = 0.0;
 		down = MINIMUM(negcmd, maxout);
 	    } else {
 		up = MINIMUM(command, maxout);
-		down = 0;
+		down = 0.0;
 	    }
-	    enable_out = 1;
+	    enable_out = true;
 	}
     } else {
 	// let motor run freely
-	up = 0;
-	down = 0;
-	enable_out = 0;
+	up = 0.0;
+	down = 0.0;
+	enable_out = false;
     }
 
 	return 0;

--- a/src/hal/i_components/integ.icomp
+++ b/src/hal/i_components/integ.icomp
@@ -11,7 +11,7 @@ license "GPL";
 ;;
 FUNCTION(_)
 {
-    if(reset) out = 0;
+    if(reset) out = 0.0;
     else out = out + gain * in * fperiod;
     if (out > max_) out = max_;
     if (out < min_) out = min_;

--- a/src/hal/i_components/joyhandle.icomp
+++ b/src/hal/i_components/joyhandle.icomp
@@ -21,7 +21,7 @@ pin io float power = 2.0;
 pin io float deadband = 0.0;
 pin io float scale = 1.0;
 pin io float offset = 0.0;
-pin io bit inverse = 0;
+pin io bit inverse = false;
 
 description """
 The component \\fBjoyhandle\\fR uses the following formula for a non linear joypad movements:

--- a/src/hal/i_components/latencybins.icomp
+++ b/src/hal/i_components/latencybins.icomp
@@ -26,9 +26,6 @@ Usage:
 
 Maintainers note: hardcoded for MAXBINNUMBER==1000
 
-NB.  Since there is no hal_64_t yet, this component has been left 'as is'
-using __64 type etc
-ArcEye 22062015
 """;
 
 pin in  s32 maxbinnumber = 1000;  // MAXBINNUMBER

--- a/src/hal/i_components/lgantry.icomp
+++ b/src/hal/i_components/lgantry.icomp
@@ -108,7 +108,7 @@ FUNCTION(read)
 
     // Prepare home and limit
     home = !previous_home;
-    limit = 0;
+    limit = false;
 
     // All other joints, if configured
     for (i = 0; i < localpincount; i++) {

--- a/src/hal/i_components/lut5.icomp
+++ b/src/hal/i_components/lut5.icomp
@@ -12,7 +12,7 @@ description """
 constructs a logic function with up to 5 inputs using a
 \\fBl\\fRook-\\fBu\\fRp \\fBt\\fRable. The value for \\fBfunction\\fR can be
 determined by writing the truth table, and computing the sum of \\fBall\\fR
-the \\fBweights\\fR for which the output value would be \\fRTRUE\\fR.
+the \\fBweights\\fR for which the output value would be \\fRtrue\\fR.
 The weights are hexadecimal not decimal so hexadecimal math must be used to
 sum the weights. A wiki page has a calculator to assist in computing the proper
 value for function.
@@ -25,22 +25,22 @@ logical functions of 5 inputs so \\fBAND\\fR, \\fBOR\\fR, \\fBNAND\\fR,
 .PP
 .SS Example Functions
 A 5-input
-\\fIand\\fR function is TRUE only when all the inputs are true, so the correct
+\\fIand\\fR function is true only when all the inputs are true, so the correct
 value for \\fBfunction\\fR is \\fB0x80000000\\fR.
 .PP
 A 2-input \\fIor\\fR function would be the sum of \\fB0x2\\fR + \\fB0x4\\fR +
 \\fB0x8\\fR, so the correct value for \\fBfunction\\fR is \\fB0xe\\fR.
 .PP
 A 5-input \\fIor\\fR
-function is TRUE whenever any of the inputs are true, so the correct value for
+function is true whenever any of the inputs are true, so the correct value for
 \\fBfunction\\fR is \\fB0xfffffffe\\fR. Because every weight except \\fB0x1\\fR
 is true the function is the sum of every line except the first one.
 .PP
 A 2-input \\fIxor\\fR function is
-TRUE whenever exactly one of the inputs is true, so the correct value for
+true whenever exactly one of the inputs is true, so the correct value for
 \\fBfunction\\fR is \\fB0x6\\fR.  Only \\fBin-0\\fR and \\fBin-1\\fR should be
-connected to signals, because if any other bit is \\fBTRUE\\fR then the output
-will be \\fBFALSE\\fR.
+connected to signals, because if any other bit is \\fBtrue\\fR then the output
+will be \\fBfalse\\fR.
 .PP
 .ie '\*[.T]'html' \\{\\
 .HTML \\

--- a/src/hal/i_components/match8.icomp
+++ b/src/hal/i_components/match8.icomp
@@ -1,5 +1,5 @@
 component match8 "8-bit binary match detector";
-pin in bit in = TRUE "cascade input - if false, output is false regardless of other inputs";
+pin in bit in = true "cascade input - if false, output is false regardless of other inputs";
 pin in bit a0;
 pin in bit a1;
 pin in bit a2;
@@ -22,7 +22,7 @@ license "GPL";
 ;;
 FUNCTION(_)
 {
-    hal_bit_t tmp = 0;
+    hal_bit_t tmp = false;
 
     if ( !in ) goto nomatch;
     if (( a0 && !b0 ) || ( !a0 && b0 )) goto nomatch;
@@ -33,7 +33,7 @@ FUNCTION(_)
     if (( a5 && !b5 ) || ( !a5 && b5 )) goto nomatch;
     if (( a6 && !b6 ) || ( !a6 && b6 )) goto nomatch;
     if (( a7 && !b7 ) || ( !a7 && b7 )) goto nomatch;
-    tmp = 1;
+    tmp = true;
 nomatch:
     out = tmp;
 

--- a/src/hal/i_components/multiclick.icomp
+++ b/src/hal/i_components/multiclick.icomp
@@ -57,8 +57,8 @@ pin and no fifth click followed it.""";
 // for debugging
 pin out s32 state;
 
-pin io bit invert_input = FALSE
-"""If FALSE (the default), clicks start with rising edges.  If TRUE,
+pin io bit invert_input = false
+"""If false (the default), clicks start with rising edges.  If true,
 clicks start with falling edges.""";
 
 pin io u32 max_hold_ns  = 250000000
@@ -157,7 +157,7 @@ FUNCTION(_)
 {
     hal_bit_t new_in = in;
 
-    if (1 == invert_input) {
+    if (invert_input) {
         new_in = !new_in;
     }
 
@@ -175,7 +175,7 @@ FUNCTION(_)
             single_click_hold_timer -= period;
         } else {
             single_click_hold_timer = 0;
-            single_click = 0;
+            single_click = false;
         }
     }
 
@@ -184,7 +184,7 @@ FUNCTION(_)
             single_click_only_hold_timer -= period;
         } else {
             single_click_only_hold_timer = 0;
-            single_click_only = 0;
+            single_click_only = false;
         }
     }
 
@@ -193,7 +193,7 @@ FUNCTION(_)
             double_click_hold_timer -= period;
         } else {
             double_click_hold_timer = 0;
-            double_click = 0;
+            double_click = false;
         }
     }
 
@@ -202,7 +202,7 @@ FUNCTION(_)
             double_click_only_hold_timer -= period;
         } else {
             double_click_only_hold_timer = 0;
-            double_click_only = 0;
+            double_click_only = false;
         }
     }
 
@@ -211,7 +211,7 @@ FUNCTION(_)
             triple_click_hold_timer -= period;
         } else {
             triple_click_hold_timer = 0;
-            triple_click = 0;
+            triple_click = false;
         }
     }
 
@@ -220,7 +220,7 @@ FUNCTION(_)
             triple_click_only_hold_timer -= period;
         } else {
             triple_click_only_hold_timer = 0;
-            triple_click_only = 0;
+            triple_click_only = false;
         }
     }
 
@@ -229,7 +229,7 @@ FUNCTION(_)
             quadruple_click_hold_timer -= period;
         } else {
             quadruple_click_hold_timer = 0;
-            quadruple_click = 0;
+            quadruple_click = false;
         }
     }
 
@@ -238,7 +238,7 @@ FUNCTION(_)
             quadruple_click_only_hold_timer -= period;
         } else {
             quadruple_click_only_hold_timer = 0;
-            quadruple_click_only = 0;
+            quadruple_click_only = false;
         }
     }
 
@@ -249,7 +249,7 @@ FUNCTION(_)
 
     switch (click_state) {
         case IDLE: {
-            if (1 == new_in) {
+            if (new_in) {
                 click_state = SAW_FIRST_RISING_EDGE;
                 timer = 0;
                 timeout = max_hold_ns;
@@ -258,18 +258,18 @@ FUNCTION(_)
         }
 
         case SAW_FIRST_RISING_EDGE: {
-            if (0 == new_in) {
+            if (!new_in) {
                 click_state = SAW_FIRST_CLICK;
                 timer = 0;
                 timeout = max_space_ns;
-                single_click = 1;
+                single_click = true;
                 single_click_hold_timer = output_hold_ns;
             }
             break;
         }
 
         case SAW_FIRST_CLICK: {
-            if (1 == new_in) {
+            if (new_in) {
                 click_state = SAW_SECOND_RISING_EDGE;
                 timer = 0;
                 timeout = max_hold_ns;
@@ -278,18 +278,18 @@ FUNCTION(_)
         }
 
         case SAW_SECOND_RISING_EDGE: {
-            if (0 == new_in) {
+            if (!new_in) {
                 click_state = SAW_SECOND_CLICK;
                 timer = 0;
                 timeout = max_space_ns;
-                double_click = 1;
+                double_click = true;
                 double_click_hold_timer = output_hold_ns;
             }
             break;
         }
 
         case SAW_SECOND_CLICK: {
-            if (1 == new_in) {
+            if (new_in) {
                 click_state = SAW_THIRD_RISING_EDGE;
                 timer = 0;
                 timeout = max_hold_ns;
@@ -298,18 +298,18 @@ FUNCTION(_)
         }
 
         case SAW_THIRD_RISING_EDGE: {
-            if (0 == new_in) {
+            if (!new_in) {
                 click_state = SAW_THIRD_CLICK;
                 timer = 0;
                 timeout = max_space_ns;
-                triple_click = 1;
+                triple_click = true;
                 triple_click_hold_timer = output_hold_ns;
             }
             break;
         }
 
         case SAW_THIRD_CLICK: {
-            if (1 == new_in) {
+            if (new_in) {
                 click_state = SAW_FOURTH_RISING_EDGE;
                 timer = 0;
                 timeout = max_hold_ns;
@@ -318,27 +318,27 @@ FUNCTION(_)
         }
 
         case SAW_FOURTH_RISING_EDGE: {
-            if (0 == new_in) {
+            if (!new_in) {
                 // four clicks is the most we look for, and we just saw it,
                 // so we're done now
                 click_state = SAW_FOURTH_CLICK;
                 timer = 0;
                 timeout = max_space_ns;
-                quadruple_click = 1;
+                quadruple_click = true;
                 quadruple_click_hold_timer = output_hold_ns;
             }
             break;
         }
 
         case SAW_FOURTH_CLICK: {
-            if (1 == new_in) {
+            if (new_in) {
                 click_state = HELD_TOO_LONG;
             }
             break;
         }
 
         case HELD_TOO_LONG: {
-            if (0 == new_in) {
+            if (!new_in) {
                 click_state = IDLE;
             }
             break;
@@ -351,29 +351,29 @@ FUNCTION(_)
     }
 
     if ((click_state != IDLE) && (click_state != HELD_TOO_LONG) && (timer > timeout)) {
-        if (1 == new_in) {
+        if (new_in) {
             click_state = HELD_TOO_LONG;
         } else {
             // timeout after some activity on the input line, trigger one
             // of the "only" outputs if appropriate
             switch (click_state) {
                 case SAW_FIRST_CLICK: {
-                    single_click_only = 1;
+                    single_click_only = true;
                     single_click_only_hold_timer = output_hold_ns;
                     break;
                 }
                 case SAW_SECOND_CLICK: {
-                    double_click_only = 1;
+                    double_click_only = true;
                     double_click_only_hold_timer = output_hold_ns;
                     break;
                 }
                 case SAW_THIRD_CLICK: {
-                    triple_click_only = 1;
+                    triple_click_only = true;
                     triple_click_only_hold_timer = output_hold_ns;
                     break;
                 }
                 case SAW_FOURTH_CLICK: {
-                    quadruple_click_only = 1;
+                    quadruple_click_only = true;
                     quadruple_click_only_hold_timer = output_hold_ns;
                     break;
                 }

--- a/src/hal/i_components/mux16.icomp
+++ b/src/hal/i_components/mux16.icomp
@@ -27,10 +27,10 @@ and whether use-graycode is active.
 The s32 value will be trunuated and limited to the max and min values of signed values.
 .RS
 .TP
-\\fBsel3=FALSE\\fR, \\fBsel2=FALSE\\fR, \\fBsel1=FALSE\\fR, \\fBsel0=FALSE\\fR
+\\fBsel3=false\\fR, \\fBsel2=false\\fR, \\fBsel1=false\\fR, \\fBsel0=false\\fR
 \\fBout\\fR follows \\fBin0\\fR
 .TP
-\\fBsel3=FALSE\\fR, \\fBsel2=FALSE\\fR, \\fBsel1=FALSE\\fR, \\fBsel0=TRUE\\fR
+\\fBsel3=false\\fR, \\fBsel2=false\\fR, \\fBsel1=false\\fR, \\fBsel0=true\\fR
 \\fBout\\fR follows \\fBin1\\fR
 .TP
 etc.
@@ -60,7 +60,7 @@ FUNCTION(_)
     hal_bit_t internal[4];
 
     if(suppress_no_input) {
-        if (sel(0) + sel(1) + sel(2) + sel(3) == 0) {
+        if (sel(0) + sel(1) + sel(2) + sel(3) == false) {
             return 0;
         }
     }
@@ -79,15 +79,15 @@ FUNCTION(_)
     if(debounce_time) {
         if (num != lastnum) {
             if (!running) {
-                running = 1;
-                delaytime = 0;
+                running = true;
+                delaytime = 0.0;
             }
             if (delaytime < debounce_time) {
                 delaytime += fperiod;
                 elapsed = delaytime;
                 return 0;
             }else{
-            running = 0;
+            running = false;
             lastnum = num;
             out_s = out_f = in(num);
             return 0;

--- a/src/hal/i_components/near.icomp
+++ b/src/hal/i_components/near.icomp
@@ -20,9 +20,9 @@ FUNCTION(_)
 		in2 = -in2;
 	}
 	if((scale > 1 && in1/scale <= in2 && in2 <= in1*scale) || rtapi_fabs(in1-in2) <= difference)
-		out = 1;
+		out = true;
 	else
-		out = 0;
+		out = false;
 
 return 0;
 }

--- a/src/hal/i_components/oneshot.icomp
+++ b/src/hal/i_components/oneshot.icomp
@@ -30,9 +30,9 @@ pin out bit out_not "Active low pulse";
 pin in float width=0 "Pulse width in seconds";
 pin out float time_left "Time left in current output pulse";
 
-pin in bit retriggerable=TRUE "Allow additional edges to extend pulse";
-pin in bit rising=TRUE "Trigger on rising edge";
-pin in bit falling=FALSE "Trigger on falling edge";
+pin in bit retriggerable=true "Allow additional edges to extend pulse";
+pin in bit rising=true "Trigger on rising edge";
+pin in bit falling=false "Trigger on falling edge";
 
 variable hal_float_t timer;
 variable hal_bit_t old_in;
@@ -46,7 +46,7 @@ license "GPL";
 EXTRA_INST_SETUP()
 {
     timer = 0.0;
-    old_in = 0;
+    old_in = false;
     return 0;
 }
 
@@ -56,7 +56,7 @@ FUNCTION(_)
 
     new = in;
     old = old_in;
-    trigger = 0;
+    trigger = false;
     /* detect edges */
     if ( new && (!old) && rising ) trigger = 1;
     if ( old && (!new) && falling ) trigger = 1;
@@ -65,7 +65,7 @@ FUNCTION(_)
     if ( timer > 0.0 ) {
 	if ( ! retriggerable ) {
 	    /* ignore edges during pulse */
-	    trigger = 0;
+	    trigger = false;
 	}
 	/* decrement timer */
 	timer -= (hal_float_t) ( period * 0.000000001 );
@@ -78,11 +78,11 @@ FUNCTION(_)
     /* drive outputs */
     time_left = timer;
     if ( timer > 0.0 ) {
-	out = 1;
-	out_not = 0;
+	out = true;
+	out_not = false;
     } else {
-	out = 0;
-	out_not = 1;
+	out = false;
+	out_not = true;
     }
 
 return 0;

--- a/src/hal/i_components/orient.icomp
+++ b/src/hal/i_components/orient.icomp
@@ -7,7 +7,7 @@ pin in  float angle       "orient target position in degrees, 0 <= angle < 360";
 pin out float command     "target spindle position, input to PID command";
 pin out float poserr      "in degrees - aid for PID tuning";
 
-variable hal_bit_t   last_enable = 0;
+variable hal_bit_t   last_enable = false;
 
 option fp yes;
 

--- a/src/hal/i_components/orn.icomp
+++ b/src/hal/i_components/orn.icomp
@@ -21,7 +21,7 @@ function _ nofp;
 FUNCTION(_)
 {
     hal_s32_t n;
-    hal_bit_t value = 0;
+    hal_bit_t value = false;
 
     // loop through inputs
     for (n = 0; n < localpincount; n++)

--- a/src/hal/i_components/out_to_io.icomp
+++ b/src/hal/i_components/out_to_io.icomp
@@ -1,8 +1,8 @@
 component out_to_io "converts a signal driven by an out pin to a change sensitive io signal";
 pin in u32 in_u32 = 0;
 pin in s32 in_s32 = 0;
-pin in float in_float = 0;
-pin in bit in_bit = 0;
+pin in float in_float = 0.0;
+pin in bit in_bit = false;
 pin io u32 out_u32;
 pin io s32 out_s32;
 pin io float out_float;

--- a/src/hal/i_components/pid.icomp
+++ b/src/hal/i_components/pid.icomp
@@ -99,7 +99,7 @@ description """
     threads and execute at different rates.
 """;
 
-pin in bit enable = 0 "Enable/disabled the PID loop";
+pin in bit enable = false "Enable/disabled the PID loop";
 pin in float command = 0.0 "Commanded value";
 pin in float command_deriv = 0.0 "Derivative command input";
 pin in float feedback = 0.0 "Feedback input";
@@ -124,8 +124,8 @@ pin in float maxerrorD = 0.0 "Limit on error differentiator";
 pin in float maxcmdD = 0.0 "Limit on command differentiator";
 pin in float maxcmdDD = 0.0 "Limit on command 2nd derivative";
 pin in float maxoutput = 0.0 "Limit on output value";
-pin in bit index_enable = 0 "Index enable";
-pin in bit error_previous_target = 0 "Error previous target";
+pin in bit index_enable = false "Index enable";
+pin in bit error_previous_target = false "Error previous target";
 // debug
 pin out float errorI "Integral of error";
 pin out float errorD "Derivative of error";
@@ -182,10 +182,10 @@ FUNCTION(do_pid_calcs) {
     } else if (tmp1 < -deadband) {
         tmp1 += deadband;
     } else {
-        tmp1 = 0;
+        tmp1 = 0.0;
     }
     /* do integrator calcs only if enabled */
-    if (enable != 0) {
+    if (enable) {
         /* if output is in limit, don't let integrator wind up */
         if ( ( tmp1 * limit_state ) <= 0.0 ) {
             /* compute integral term */
@@ -201,7 +201,7 @@ FUNCTION(do_pid_calcs) {
         }
     } else {
         /* not enabled, reset integrator */
-        errorI = 0;
+        errorI = 0.0;
     }
 #if 0
     /* DEBUG: compute command and feedback derivatives to dummysigs */
@@ -259,7 +259,7 @@ FUNCTION(do_pid_calcs) {
         }
     }
     /* do output calcs only if enabled */
-    if (enable != 0) {
+    if (enable) {
     /* calculate the output value */
     tmp1 =
         bias + Pgain * tmp1 + Igain * errorI +
@@ -288,12 +288,12 @@ FUNCTION(do_pid_calcs) {
 
     /* set 'saturated' outputs */
     if(limit_state) {
-        saturated = 1;
+        saturated = true;
         saturated_s += (hal_float_t) period * 1e-9;
         if(saturated_count != 2147483647)
             saturated_count += 1;
     } else {
-        saturated = 0;
+        saturated = false;
         saturated_s = 0.0;
         saturated_count = 0;
     }

--- a/src/hal/i_components/reset.icomp
+++ b/src/hal/i_components/reset.icomp
@@ -44,20 +44,20 @@ pin io  s32     out_s32      = 0    "Signed 32 bit integer output value";
 pin in  s32     reset_s32    = 0    "Signed 32 bit integer reset value";
 pin io  float   out_float    = 0.0  "Float output value";
 pin in  float   reset_float  = 0.0  "Float reset value";
-pin io  bit     out_bit      = 0    "Bit integer output value";
-pin in  bit     reset_bit    = 0    "Bit reset value";
-pin in  bit     retriggerable = 1   "Allow additional edges to reset";
-pin in  bit     rising        = 1   "Trigger on rising edge";
-pin in  bit     falling       = 0   "Trigger on falling edge";
+pin io  bit     out_bit      = false  "Bit integer output value";
+pin in  bit     reset_bit    = false  "Bit reset value";
+pin in  bit     retriggerable = true  "Allow additional edges to reset";
+pin in  bit     rising        = true  "Trigger on rising edge";
+pin in  bit     falling       = false "Trigger on falling edge";
 function _  fp "Update the output value";
 description """
 Component to reset IO signals.
 """;
 license "GPL";
-variable hal_bit_t last_trigger = 0;
+variable hal_bit_t last_trigger = false;
 ;;
 FUNCTION(_) {
-    if (((rising && (trigger == 1)) || (falling && (trigger == 0)))
+    if (((rising && (trigger)) || (falling && (!trigger)))
        && (trigger != last_trigger))
     {
         out_u32 = reset_u32;

--- a/src/hal/i_components/safety_latch.icomp
+++ b/src/hal/i_components/safety_latch.icomp
@@ -65,7 +65,7 @@ pin out s32 count = 0 "Current count";
 pin out bit error_out = false "Error output";
 pin out bit ok_out = true "Ok output";
 
-variable hal_bit_t last_reset = 0;
+variable hal_bit_t last_reset = false;
 
 function _ nofp;
 license "GPL";

--- a/src/hal/i_components/select8.icomp
+++ b/src/hal/i_components/select8.icomp
@@ -1,6 +1,6 @@
 component select8 "8-bit binary match detector";
-pin io bit enable = true "Set enable to FALSE to cause all outputs to be set FALSE";
-pin in s32 sel "The number of the output to set TRUE.  All other outputs well be set FALSE";
+pin io bit enable = true "Set enable to false to cause all outputs to be set false";
+pin in s32 sel "The number of the output to set true.  All other outputs well be set false";
 pin out bit out#[8] "Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true";
 
 function _ nofp;
@@ -13,11 +13,11 @@ FUNCTION(_)
     {
         if (!enable || (sel != i) )
         {
-            out(i) = 0;
+            out(i) = false;
         }
         else
         {
-            out(i) = 1;
+            out(i) = true;
         }
     }
 

--- a/src/hal/i_components/selectn.icomp
+++ b/src/hal/i_components/selectn.icomp
@@ -1,6 +1,6 @@
 component selectn "select one of n";
-pin io bit enable = true "Set enable to FALSE to cause all outputs to be set FALSE";
-pin in s32 sel "The number of the output to set TRUE.  All other outputs well be set FALSE";
+pin io bit enable = true "Set enable to false to cause all outputs to be set false";
+pin in s32 sel "The number of the output to set true.  All other outputs well be set false";
 pin out bit out#[pincount] "Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true";
 
 instanceparam int pincount = 2;
@@ -18,11 +18,11 @@ FUNCTION(_)
     {
         if (!enable || (sel != i))
         {
-            out(i) = 0;
+            out(i) = false;
         }
         else
         {
-            out(i) = 1;
+            out(i) = true;
         }
     }
 

--- a/src/hal/i_components/stats.icomp
+++ b/src/hal/i_components/stats.icomp
@@ -15,7 +15,7 @@ FUNCTION(_)
 {
     if (enable ^ prev_enable) { // edge
 	if (enable) {  // positive edge
-	    mean = 0;
+	    mean = 0.0;
 	    n = 0;
 	    m2 = 0.0;
 	}

--- a/src/hal/i_components/thc.icomp
+++ b/src/hal/i_components/thc.icomp
@@ -99,7 +99,7 @@ FUNCTION(_)
     if(enable){
         hal_float_t min_velocity = requested_vel -(requested_vel*(velocity_tol*0.01));
         if(current_vel > 0.0 && current_vel >= min_velocity){vel_status = 1;}
-        else {vel_status =0;}
+        else {vel_status = false;}
 
         if(torch_on && arc_ok && vel_status){ // allow correction
             if((volts + voltage_tol) > volts_requested){

--- a/src/hal/i_components/thcud.icomp
+++ b/src/hal/i_components/thcud.icomp
@@ -97,8 +97,8 @@ FUNCTION(_)
 {
     if(enable){
         hal_float_t min_velocity = requested_vel -(requested_vel*(1.0 /velocity_tol));
-        if(current_vel > 0.0 && current_vel >= min_velocity){vel_status = 1;}
-        else {vel_status =0;}
+        if(current_vel > 0.0 && current_vel >= min_velocity){vel_status = true;}
+        else {vel_status = false;}
 
         if(torch_on && arc_ok && vel_status){ // allow correction
             if(torch_down){
@@ -113,7 +113,7 @@ FUNCTION(_)
             hal_float_t z_diff;
             z_diff = z_pos_in - last_z_in;
             if(z_diff > 0.0 && offset != 0.0){ // torch is moving up
-                removing_offset = 1;
+                removing_offset = true;
                 if(offset > 0){ // positive offset
                     if(offset > z_diff){ // remove some
                         offset -= z_diff;
@@ -127,7 +127,7 @@ FUNCTION(_)
                     else {offset = 0.0;}
                 }
             }
-            else {removing_offset = 0;}
+            else {removing_offset = false;}
             last_z_in = z_pos_in;
         }
         z_pos_out = z_pos_in + offset;

--- a/src/hal/i_components/time.icomp
+++ b/src/hal/i_components/time.icomp
@@ -91,10 +91,10 @@ FUNCTION(_)
     totalnsec = totalnsec + period;
     totalseconds = (hal_u32_t)(totalnsec / 1e9);
     seconds = totalseconds % 60;
-	minutes = (totalseconds / 60) % 60;
-	hours = totalseconds / 3600;
-	}
-	old_start = start;
+    minutes = (totalseconds / 60) % 60;
+    hours = totalseconds / 3600;
+    }
+    old_start = start;
 
 return 0;
 

--- a/src/hal/i_components/timedelay.icomp
+++ b/src/hal/i_components/timedelay.icomp
@@ -23,12 +23,12 @@ if(in_ != out) {
     elapsed = timer;
     if(in_) {
         if(timer >= on_delay) {
-            out = 1;
+            out = true;
             timer = 0.0;
         }
     } else {
         if(timer >= off_delay) {
-            out = 0;
+            out = false;
             timer = 0.0;
         }
     }

--- a/src/hal/i_components/toggle.icomp
+++ b/src/hal/i_components/toggle.icomp
@@ -22,18 +22,18 @@ FUNCTION(_)
 	debounce_cntr++;
 	if ( debounce_cntr >= debounce ) {
 	    debounce_cntr = debounce;
-	    if ( debounced == 0 ) {
+	    if (!debounced ) {
 		/* toggle output */
 		out = !out;
 	    }
-	    debounced = 1;
+	    debounced = true;
 	}
     } else {
 	/* not pressed */
 	debounce_cntr--;
 	if ( debounce_cntr <= 0 ) {
 	    debounce_cntr = 0;
-	    debounced = 0;
+	    debounced = false;
 	}
     }
 

--- a/src/hal/i_components/toggle2nist.icomp
+++ b/src/hal/i_components/toggle2nist.icomp
@@ -15,7 +15,7 @@ pin in  bit is_on;
 pin out bit on;
 pin out bit off;
 variable hal_bit_t old_in;
-variable hal_bit_t to_state=0;
+variable hal_bit_t to_state=false;
 function _;
 license "GPL";
 ;;
@@ -23,21 +23,21 @@ FUNCTION(_)
 {
 if (in!=old_in) /* a toggle has occurred */ {
     if (is_on) {   /* turn OFF if it's on */
-        on=0;
-        off=1;
-        to_state=0;
+        on=false;
+        off=true;
+        to_state=false;
     }
     else if (!is_on) { /* turn ON if it's off */
-        on=1;
-        off=0;
-        to_state=1;
+        on=true;
+        off=false;
+        to_state=true;
     }
 }
 else {
 /* reset pins when we see the desired state */
     if (to_state==is_on) {
-        on=0;
-        off=0;
+        on=false;
+        off=false;
     }
 }
 old_in=in;

--- a/src/hal/i_components/updown.icomp
+++ b/src/hal/i_components/updown.icomp
@@ -3,13 +3,13 @@ pin in bit countup "Increment count when this pin goes from 0 to 1";
 pin in bit countdown "Decrement count when this pin goes from 0 to 1";
 pin in bit reset "Reset count when this pin goes from 0 to 1";
 pin out s32 count "The current count";
-pin io bit clamp "If TRUE, then clamp the output to the min and max parameters.";
-pin io bit wrap "If TRUE, then wrap around when the count goes above or below the min and max parameters.  Note that wrap implies (and overrides) clamp.";
+pin io bit clamp "If true, then clamp the output to the min and max parameters.";
+pin io bit wrap "If true, then wrap around when the count goes above or below the min and max parameters.  Note that wrap implies (and overrides) clamp.";
 pin io s32 max = 0x7FFFFFFF "If clamp or wrap is set, count will never exceed this number";
 pin io s32 min "If clamp or wrap is set, count will never be less than this number";
 variable hal_bit_t oldup;
 variable hal_bit_t olddown;
-variable hal_bit_t first = 1;
+variable hal_bit_t first = true;
 function _ nofp "Process inputs and update count if necessary";
 license "GPL";
 
@@ -21,7 +21,7 @@ FUNCTION(_)
 	if (first) {
 		oldup=countup;
 		olddown=countdown;
-		first=0;
+		first = false;
 	}
 	if ((!oldup) && (countup)) { // positive edge, count up
 		temp_count++;

--- a/src/hal/i_components/xor2.icomp
+++ b/src/hal/i_components/xor2.icomp
@@ -6,22 +6,22 @@ pin out bit out """\
 to the following rule:
 .RS
 .TP
-\\fBin0=TRUE in1=FALSE\\fR
+\\fBin0=true in1=false\\fR
 .TQ
-\\fBin0=FALSE in1=TRUE\\fR
-\\fBout=TRUE\\fR
+\\fBin0=false in1=true\\fR
+\\fBout=true\\fR
 .TP
 Otherwise,
-\\fBout=FALSE\\fR""";
+\\fBout=false\\fR""";
 function _ nofp;
 license "GPL";
 ;;
 FUNCTION(_)
 {
     if (( in0 && !in1 ) || ( in1 && !in0 ))
-	out = 1;
+	out = true;
     else
-	out = 0;
+	out = false;
 
 return 0;
 }

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -579,10 +579,9 @@ static int comp_id;
         print >>f, "static void extra_inst_cleanup(void);\n"
 
     if not options.get("no_convenience_defines"):
+# capitalised defines removed to enforce lowercase C boolean values
         print >>f, "#undef TRUE"
-        print >>f, "#define TRUE (1)"
         print >>f, "#undef FALSE"
-        print >>f, "#define FALSE (0)"
         print >>f, "#undef true"
         print >>f, "#define true (1)"
         print >>f, "#undef false"


### PR DESCRIPTION
Further to Issue #635
and Fix unsafe type usages - Issue #663 & use of params - Issue #610

hal_bit_t variables in components will only ever hold 0 or 1 and thus are
boolean values
Readability of components will be improved if treated as such

instcomp defines true and false to ensure they are valid for that component
and undefs TRUE and FALSE, which are not valid C defines

Signed-off-by: Mick <arceye@mgware.co.uk>