### PR TITLE
rtapi/rtai: robustify handling of HAL_NR_FAULTS

### DIFF
--- a/src/rtapi/rtai-kernel.c
+++ b/src/rtapi/rtai-kernel.c
@@ -123,7 +123,7 @@ int _rtapi_task_new_hook(task_data *task, int task_id) {
     if (retval) return retval;
 
     /* request to handle traps in the new task */
-#if RTAI_VERSION <= 400
+#ifdef HAL_NR_FAULTS
     for(v=0; v<HAL_NR_FAULTS; v++)
         rt_set_task_trap_handler(ostask_array[task_id], v, _rtapi_trap_handler);
 #else


### PR DESCRIPTION
not sure where this is coming from:

RTAI_VERSION <= 400 does not get me there with these includes:

mah@nwheezy:~/machinekit-tutorial/src$ grep -R _NR_FAULTS /usr/src
/usr/src/linux-headers-3.8-1-common-rtai.x86/arch/x86/include/asm/ipipe_base.h:#define IPIPE_NR_FAULTS		34
/usr/src/linux-headers-3.8-1-common-rtai.x86/arch/x86/include/asm/ipipe_base.h:#define IPIPE_NR_FAULTS		33
/usr/src/linux-headers-3.8-1-common-rtai.x86/include/linux/ipipe_base.h:#define IPIPE_FIRST_EVENT	IPIPE_NR_FAULTS
/usr/src/linux-headers-3.8-1-common-xenomai.x86/arch/x86/include/asm/ipipe_base.h:#define IPIPE_NR_FAULTS		34
/usr/src/linux-headers-3.8-1-common-xenomai.x86/arch/x86/include/asm/ipipe_base.h:#define IPIPE_NR_FAULTS		33
/usr/src/linux-headers-3.8-1-common-xenomai.x86/include/asm-generic/xenomai/hal.h:#define RTHAL_NR_FAULTS		IPIPE_NR_FAULTS
/usr/src/linux-headers-3.8-1-common-xenomai.x86/include/asm-generic/xenomai/hal.h:extern unsigned int rthal_realtime_faults[RTHAL_NR_CPUS][RTHAL_NR_FAULTS];
/usr/src/linux-headers-3.8-1-common-xenomai.x86/include/linux/ipipe_base.h:#define IPIPE_FIRST_EVENT	IPIPE_NR_FAULTS
