### PR TITLE
machinetalk: using FQDN for service announcements

### DIFF
--- a/lib/python/machinekit/service.py
+++ b/lib/python/machinekit/service.py
@@ -34,13 +34,18 @@ class ZeroconfService:
                            server.EntryGroupNew()),
             avahi.DBUS_INTERFACE_ENTRY_GROUP)
 
+        # insert fqdn in announcement
+        fqdn = str(server.GetHostNameFqdn())
+        text = [t % {'fqdn': fqdn} for t in self.text]
+        name = self.name % {'fqdn': fqdn}
+
         iface = avahi.IF_UNSPEC
         if self.loopback:
             iface = 0
 
         g.AddService(iface, avahi.PROTO_INET, dbus.UInt32(0),
-                     self.name, self.stype, self.domain, self.host,
-                     dbus.UInt16(self.port), self.text)
+                     name, self.stype, self.domain, self.host,
+                     dbus.UInt16(self.port), text)
 
         if self.subtype:
             g.AddServiceSubtype(iface,

--- a/src/machinetalk/config-service/configserver.py
+++ b/src/machinetalk/config-service/configserver.py
@@ -7,7 +7,6 @@ import threading
 import signal
 import time
 import argparse
-import socket
 
 import ConfigParser
 from machinekit import service
@@ -249,7 +248,7 @@ def main():
     configService = None
 
     try:
-        hostname = socket.gethostname().split('.')[0] + '.local.'
+        hostname = '%(fqdn)s'  # replaced by service announcement
         configService = ConfigServer(context,
                                      svcUuid=uuid,
                                      topdir=".",

--- a/src/machinetalk/mklauncher/mklauncher.py
+++ b/src/machinetalk/mklauncher/mklauncher.py
@@ -10,7 +10,6 @@ import math
 import subprocess
 import fcntl
 import shlex
-import socket
 
 from machinekit import service
 from machinekit import config
@@ -484,7 +483,7 @@ def main():
 
     register_exit_handler()
 
-    hostname = socket.gethostname().split('.')[0] + '.local.'
+    hostname = '%(fqdn)s'  # replaced by service announcement
     mklauncher = Mklauncher(context,
                             svcUuid=uuid,
                             topDir='.',

--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -2393,7 +2393,7 @@ def main():
     fileService = None
     mkwrapper = None
     try:
-        hostname = socket.gethostname().split('.')[0] + '.local.'
+        hostname = '%(fqdn)s'  # replaced by service announcement
         fileService = FileService(iniFile=iniFile,
                                   svcUuid=mkUuid,
                                   host=hostname,

--- a/src/machinetalk/videoserver/videoserver.py
+++ b/src/machinetalk/videoserver/videoserver.py
@@ -173,7 +173,7 @@ def main():
     if debug:
         print ("announcing videoserver")
 
-    hostname = socket.gethostname().split('.')[0] + '.local.'
+    hostname = '%(fqdn)s'  # replaced by service announcement
     video = VideoServer(args.ini,
                         svc_uuid=mkUuid,
                         host=hostname,


### PR DESCRIPTION
As discovered here https://github.com/strahlex/QtQuickVcp/issues/34#issuecomment-119962509 Avahi announces its own FQDN instead of the systems hostname. In case the local hostname does not match the Avahi hostname the client is never able to resolve correctly. 

This PR fixes the problem by using the FQDN reported by Avahi.