### PR TITLE
Fix machinekit-rt-preempt package kernel deps

### DIFF
--- a/debian/control.rt-preempt.in
+++ b/debian/control.rt-preempt.in
@@ -5,7 +5,7 @@ Depends: machinekit (= ${binary:Version}), ${shlibs:Depends},
 # These Debian-style RT_PREEMPT package names are restricted by
 # architecture; ARM arch SOCs are all incompatible, so this can't be
 # easily done for ARM.
- linux-image-rt.x86-686-pae [i386], linux-image-rt.x86-amd64 [amd64]
+ linux-image-rt-686-pae [i386], linux-image-rt-amd64 [amd64]
 Provides:  machinekit-rt-threads
 Suggests: hostmot2-firmware-all [!armhf]
 Enhances: machinekit


### PR DESCRIPTION
Copy and paste error