### PR TITLE
Build setsserial utility for Mesa boards

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1327,7 +1327,7 @@ endif
 endif
 
 ifeq ($(BUILD_HOSTMOT2),yes)
-obj-$(CONFIG_HOSTMOT2) += hostmot2.o hm2_7i43.o hm2_7i90.o hm2_pci.o hm2_test.o
+obj-$(CONFIG_HOSTMOT2) += hostmot2.o hm2_7i43.o hm2_7i90.o hm2_pci.o hm2_test.o setsserial.o
 ifeq ($(BUILD_SYS),user-dso)
 obj-$(CONFIG_HOSTMOT2) += hm2_eth.o
 hm2_eth-objs  :=			  \
@@ -1374,6 +1374,9 @@ hm2_test-objs :=			  \
     $(MATHSTUB)
 setsserial-objs :=			  \
     hal/drivers/mesa-hostmot2/setsserial.o  \
+    rtapi/userpci/firmware.o  \
+    rtapi/userpci/string.o  \
+    rtapi/userpci/device.o  \
     $(MATHSTUB)
 endif
 
@@ -1595,6 +1598,7 @@ $(RTLIBDIR)/hostmot2$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hostmot2-objs))
 $(RTLIBDIR)/hm2_7i43$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hm2_7i43-objs))
 $(RTLIBDIR)/hm2_7i90$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hm2_7i90-objs))
 $(RTLIBDIR)/hm2_pci$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hm2_pci-objs))
+$(RTLIBDIR)/setsserial$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(setsserial-objs))
 ifeq ($(BUILD_SYS),user-dso)
 $(RTLIBDIR)/hm2_eth$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hm2_eth-objs))
 endif

--- a/src/hal/drivers/mesa-hostmot2/setsserial.c
+++ b/src/hal/drivers/mesa-hostmot2/setsserial.c
@@ -18,7 +18,8 @@
 //
 //    The code in this file is based on UFLBP.PAS by Peter C. Wallace.  
 
-#include <linux/firmware.h>
+#include "userpci/string.h"
+#include "userpci/gfp.h"
 #include "rtapi.h"
 #include "rtapi_app.h"
 #include "hal.h"


### PR DESCRIPTION
Modify Makefile to build setsserial module
linking with required objects

Update header #includes in setsserial.c

Signed-off-by: Mick <arceye@mgware.co.uk>