### PR TITLE
machinetalk-protobuf: added default PKG-CONFIG variable

### DIFF
--- a/src/machinetalk/proto/Makefile
+++ b/src/machinetalk/proto/Makefile
@@ -43,6 +43,9 @@ PROTOBUFJS_GEN := js
 # the proto2js compiler
 PROTOJS := $(shell which proto2js)
 
+# pkg-config
+PKG_CONFIG := $(shell which pkg-config)
+
 # proto2js options - namespace
 #PROTOBUFJS_OPT := -commonjs=pb
 # http://en.wikipedia.org/wiki/Asynchronous_module_definition


### PR DESCRIPTION
to make upstream merge of machinetalk-protobuf possible