### PR TITLE
Fix: Beaglebone Black pru_pwm now turns off after setting  hpg.pwmgen.enable to 0 (Cleaned)

### DIFF
--- a/src/hal/drivers/hal_pru_generic/pwmgen.c
+++ b/src/hal/drivers/hal_pru_generic/pwmgen.c
@@ -203,6 +203,7 @@ void hpg_pwmgen_update(hal_pru_generic_t *hpg) {
 
             if (*hpg->pwmgen.instance[i].out[j].hal.pin.enable == 0) {
                 hpg->pwmgen.instance[i].out[j].pru.value = 0;
+                out[j] = hpg->pwmgen.instance[i].out[j].pru;
                 continue;
             }
 


### PR DESCRIPTION
after enabling a pru_pwm on bealebone with:
setp hpg.pwmgen.0x.out.0x.enable 1

Tyinig to disable the pwm again with
setp hpg.pwmgen.0x.out.0x.enable 0
leaves the output on instead

    setp hpg.pwmgen.0x.out.0x.enable 0
    Now turns pwm output off as it should

Tested on BBB + CRAMPS2 board