### PR TITLE
fix regressions in nosetests, add runtests

### DIFF
--- a/lib/python/machinekit/nosetests/rtapilog.py
+++ b/lib/python/machinekit/nosetests/rtapilog.py
@@ -1,0 +1,34 @@
+from machinekit import rtapi
+import inspect
+
+# helper for logging in nosetests scripts to rtapi
+# to correlate test location with HAL/RTAPI log messages
+
+# see also:
+# http://stackoverflow.com/questions/6810999/how-to-determine-file-function-and-line-number
+
+class Log:
+    def __init__(self, level=rtapi.MSG_DBG,tag="logger"):
+        self.l = None
+        self.level = level
+        self.tag = tag
+
+    def log(self, *args):
+        # defer init until RTAPI known to be up
+        if not self.l:
+            self.l = rtapi.RTAPILogger(level=self.level,tag=self.tag)
+
+        # 0 represents this line
+        # 1 represents line at caller
+
+        callerframerecord = inspect.stack()[1]
+        frame = callerframerecord[0]
+        info = inspect.getframeinfo(frame)
+        print >> self.l, "%s:%s:%s %s" % (info.filename,
+                                          info.function,
+                                          info.lineno,
+                                          " ".join(args)),
+
+if __name__ == "__main__":
+    l = Log(level=rtapi.MSG_ERR,tag="testrun")
+    l.log("foo","bar","baz")

--- a/nosetests/test_mk_hal_basics.py
+++ b/nosetests/test_mk_hal_basics.py
@@ -14,12 +14,18 @@ epsval = 10.0
 epsindex = 1
 signame = "ss32"
 
+c = None  # initialized by test_component_creation
+s1 = None  # initialized by test_signal
+p = None  # initialized by test_pin_attributes
+
+
 def test_component_creation():
     global c
     hal.epsilon[epsindex] = epsval
     c = hal.Component(cname)
     c.newpin(pname, hal.HAL_S32, hal.HAL_OUT, init=42, eps=epsindex)
     c.ready()
+
 
 def test_pin_creation_after_ready():
     try:
@@ -28,24 +34,29 @@ def test_pin_creation_after_ready():
     except RuntimeError:
         pass
     else:
-        raise Exception, "pin creation must fail atfer calling c.ready()"
+        raise(Exception, "pin creation must fail atfer calling c.ready()")
+
 
 def test_component_dictionary():
     assert len(hal.components) > 0  # halcmd and others
     assert cname in hal.components
     assert hal.components[cname].name == cname
 
+
 def test_pins_dictionary():
     assert len(hal.pins) == 1
     assert fqpname in hal.pins
     assert hal.pins[fqpname].name == fqpname
 
+
 def test_pin_initial_value():
     assert c[pname] == 42
+
 
 def test_pin_value_assignment():
     c[pname] = 4711
     assert c[pname] == 4711
+
 
 def test_pin_attributes():
     n = c.pins()    # pin names of this comp
@@ -59,7 +70,8 @@ def test_pin_attributes():
     assert p.eps == epsindex
     assert fnear(p.epsilon, hal.epsilon[epsindex])
     assert p.handle > 0
-    assert p.linked == False
+    assert p.linked is False
+
 
 def test_signal():
     global s1
@@ -75,9 +87,10 @@ def test_signal():
     s1.set(12345)
     assert s1.get() == 12345
 
+
 def test_linking():
     assert s1.writers == 0
-    assert s1.writername == None
+    assert s1.writername is None
 
     s1.link(p)
     assert s1.writers == 1
@@ -89,14 +102,14 @@ def test_linking():
 
     # the name of modifying pins linked to this signal
     assert s1.writername == fqpname
-    assert s1.bidirname == None
+    assert s1.bidirname is None
 
     # verify the pin reflects the signal it's linked to:
-    assert p.linked == True
+    assert p.linked is True
     assert p.signame == s1.name
-    sw = p.signal # access through Signal() wrapper
-    assert sw != None
-    assert isinstance(sw,hal.Signal)
+    sw = p.signal  # access through Signal() wrapper
+    assert sw is not None
+    assert isinstance(sw, hal.Signal)
     assert p.signal.writers == 1
 
     # initial value inheritage
@@ -108,12 +121,14 @@ def test_linking():
     except RuntimeError:
         pass
     else:
-        raise Exception, "setting value of a linked signal succeeded!"
+        raise(Exception, "setting value of a linked signal succeeded!")
+
 
 def test_signals_dictionary():
     assert len(hal.signals) == 1
     assert signame in hal.signals
     assert hal.signals[signame].name == signame
+
 
 def test_ccomp_and_epsilon():
     # custom deltas (leave epsilon[0] - the default - untouched)
@@ -139,12 +154,12 @@ def test_ccomp_and_epsilon():
 
     # report_all=True forces a report of all pins
     # regardless of change status, so 2 pins to report:
-    c.changed(userdata=pinlist,report_all=True)
+    c.changed(userdata=pinlist, report_all=True)
     assert len(pinlist) == 2
 
     # passing a list as 'userdata=<list>' always clears the list before
     # appending pins
-    c.changed(userdata=pinlist,report_all=True)
+    c.changed(userdata=pinlist, report_all=True)
     assert len(pinlist) == 2
 
     c["out1"] += 101  # larger than out1's epsilon value
@@ -163,4 +178,4 @@ def test_ccomp_and_epsilon():
 
 
 (lambda s=__import__('signal'):
-     s.signal(s.SIGTERM, s.SIG_IGN))()
+    s.signal(s.SIGTERM, s.SIG_IGN))()

--- a/nosetests/test_mk_hal_basics.py
+++ b/nosetests/test_mk_hal_basics.py
@@ -63,7 +63,7 @@ def test_pin_attributes():
     assert len(n) == 1
     # access properties through wrapper:
     global p
-    p = hal.Pin(n[0])
+    p = n[0]
     assert p.name == fqpname
     assert p.type == hal.HAL_S32
     assert p.dir == hal.HAL_OUT

--- a/nosetests/test_netcmd.py
+++ b/nosetests/test_netcmd.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+
 from nose import with_setup
 from machinekit.nosetests.realtime import setup_module,teardown_module
 from machinekit.nosetests.support import fnear
@@ -37,6 +38,7 @@ def test_net_existing_signal_with_bad_type():
     except TypeError:
         pass
     del hal.signals["f"]
+    assert 'f' not in hal.signals
 
 
 def test_net_match_nonexistant_signals():
@@ -58,6 +60,7 @@ def test_net_pin2pin():
     hal.pins["c1.s32out"].unlink()
     hal.pins["c2.s32in"].unlink()
     del hal.signals['c1-s32out']
+    assert 'c1-s32out' not in hal.signals
 
     try:
         hal.net("c2.s32out", "c1.s32out")
@@ -68,6 +71,7 @@ def test_net_pin2pin():
     # cleanup
     hal.pins["c2.s32out"].unlink()
     del hal.signals['c2-s32out']
+    assert 'c2-s32out' not in hal.signals
 
 
 def test_net_existing_signal():
@@ -85,6 +89,7 @@ def test_net_existing_signal():
         pass
 
     del hal.signals["s32"]
+    assert 's32' not in hal.signals
 
 
 def test_newsig():
@@ -120,17 +125,29 @@ def test_check_net_args():
     except TypeError:
         pass
 
+    assert 'c1-s32out' not in hal.signals
+
     try:
         hal.net(None, "c1.s32out")
     except TypeError:
         pass
 
+    assert 'c1-s32out' not in hal.signals
+
     # single pin argument
+    assert hal.pins["c1.s32out"].linked is False
+
     try:
         hal.net("c1.s32out")
         # RuntimeError: net: at least one pin name expected
     except RuntimeError:
         pass
+
+    # XXX die beiden gehen daneben:
+    # der pin wird trotz runtime error gelinkt und das signal erzeugt:
+    # offensichtlich hal_net.pyx:39 vor dem test in hal_net.pyx:60
+    assert hal.pins["c1.s32out"].linked is False
+    assert 'c1-s32out' not in hal.signals
 
     # single signal argument
     try:

--- a/nosetests/test_netcmd.py
+++ b/nosetests/test_netcmd.py
@@ -5,28 +5,29 @@ from machinekit.nosetests.realtime import setup_module,teardown_module
 from machinekit.nosetests.support import fnear
 
 from machinekit import hal
-import os
+
 
 def test_component_creation():
-    global c1,c2
+    global c1, c2
     c1 = hal.Component("c1")
     c1.newpin("s32out", hal.HAL_S32, hal.HAL_OUT, init=42)
-    c1.newpin("s32in",  hal.HAL_S32, hal.HAL_IN)
-    c1.newpin("s32io",  hal.HAL_S32, hal.HAL_IO)
+    c1.newpin("s32in", hal.HAL_S32, hal.HAL_IN)
+    c1.newpin("s32io", hal.HAL_S32, hal.HAL_IO)
     c1.newpin("floatout", hal.HAL_FLOAT, hal.HAL_OUT, init=42)
-    c1.newpin("floatin",  hal.HAL_FLOAT, hal.HAL_IN)
-    c1.newpin("floatio",  hal.HAL_FLOAT, hal.HAL_IO)
+    c1.newpin("floatin", hal.HAL_FLOAT, hal.HAL_IN)
+    c1.newpin("floatio", hal.HAL_FLOAT, hal.HAL_IO)
 
     c1.ready()
 
     c2 = hal.Component("c2")
     c2.newpin("s32out", hal.HAL_S32, hal.HAL_OUT, init=4711)
-    c2.newpin("s32in",  hal.HAL_S32, hal.HAL_IN)
-    c2.newpin("s32io",  hal.HAL_S32, hal.HAL_IO)
+    c2.newpin("s32in", hal.HAL_S32, hal.HAL_IN)
+    c2.newpin("s32io", hal.HAL_S32, hal.HAL_IO)
     c2.newpin("floatout", hal.HAL_FLOAT, hal.HAL_OUT, init=4711)
-    c2.newpin("floatin",  hal.HAL_FLOAT, hal.HAL_IN)
-    c2.newpin("floatio",  hal.HAL_FLOAT, hal.HAL_IO)
+    c2.newpin("floatin", hal.HAL_FLOAT, hal.HAL_IN)
+    c2.newpin("floatio", hal.HAL_FLOAT, hal.HAL_IO)
     c2.ready()
+
 
 def test_net_existing_signal_with_bad_type():
     hal.newsig("f", hal.HAL_FLOAT)
@@ -37,16 +38,18 @@ def test_net_existing_signal_with_bad_type():
         pass
     del hal.signals["f"]
 
+
 def test_net_match_nonexistant_signals():
     try:
-        hal.net("nosuchsig", "c1.s32out","c2.s32out")
+        hal.net("nosuchsig", "c1.s32out", "c2.s32out")
         raise "should not happen"
     except TypeError:
         pass
 
+
 def test_net_pin2pin():
     try:
-        hal.net("c1.s32out","c2.s32out")
+        hal.net("c1.s32out", "c2.s32out")
         #TypeError: net: 'c1.s32out' is a pin - first argument must be a signal name
         raise "should not happen"
     except TypeError:
@@ -56,9 +59,9 @@ def test_net_pin2pin():
 def test_net_existing_signal():
     hal.newsig("s32", hal.HAL_S32)
 
-    assert hal.pins["c1.s32out"].linked == False
+    assert hal.pins["c1.s32out"].linked is False
     hal.net("s32", "c1.s32out")
-    assert hal.pins["c1.s32out"].linked == True
+    assert hal.pins["c1.s32out"].linked is True
 
     hal.newsig("s32too", hal.HAL_S32)
     try:
@@ -69,8 +72,9 @@ def test_net_existing_signal():
 
     del hal.signals["s32"]
 
+
 def test_newsig():
-    floatsig1 = hal.newsig("floatsig1", hal.HAL_FLOAT)
+    hal.newsig("floatsig1", hal.HAL_FLOAT)
     try:
         hal.newsig("floatsig1", hal.HAL_FLOAT)
         # RuntimeError: Failed to create signal floatsig1: HAL: ERROR: duplicate signal 'floatsig1'
@@ -78,7 +82,7 @@ def test_newsig():
     except RuntimeError:
         pass
     try:
-        hal.newsig(32423 *32432, hal.HAL_FLOAT)
+        hal.newsig(32423 * 32432, hal.HAL_FLOAT)
         raise "should not happen"
     except TypeError:
         pass
@@ -130,4 +134,4 @@ def test_check_net_args():
         pass
 
 (lambda s=__import__('signal'):
-     s.signal(s.SIGTERM, s.SIG_IGN))()
+    s.signal(s.SIGTERM, s.SIG_IGN))()

--- a/nosetests/test_netcmd.py
+++ b/nosetests/test_netcmd.py
@@ -4,12 +4,18 @@
 from nose import with_setup
 from machinekit.nosetests.realtime import setup_module,teardown_module
 from machinekit.nosetests.support import fnear
+from machinekit.nosetests.rtapilog import Log
 
-from machinekit import hal
+from machinekit import hal,rtapi
+import os
+
+l = Log(level=rtapi.MSG_INFO,tag="nosetest")
+
 
 
 def test_component_creation():
-    global c1, c2
+    l.log()
+    global c1,c2
     c1 = hal.Component("c1")
     c1.newpin("s32out", hal.HAL_S32, hal.HAL_OUT, init=42)
     c1.newpin("s32in", hal.HAL_S32, hal.HAL_IN)
@@ -31,6 +37,7 @@ def test_component_creation():
 
 
 def test_net_existing_signal_with_bad_type():
+    l.log()
     hal.newsig("f", hal.HAL_FLOAT)
     try:
         hal.net("f", "c1.s32out")
@@ -42,6 +49,7 @@ def test_net_existing_signal_with_bad_type():
 
 
 def test_net_match_nonexistant_signals():
+    l.log()
     try:
         hal.net("nosuchsig", "c1.s32out", "c2.s32out")
         raise "should not happen"
@@ -50,6 +58,7 @@ def test_net_match_nonexistant_signals():
 
 
 def test_net_pin2pin():
+    l.log()
     # out to in is okay
     hal.net("c1.s32out", "c2.s32in")
     assert hal.pins["c1.s32out"].linked is True
@@ -75,6 +84,7 @@ def test_net_pin2pin():
 
 
 def test_net_existing_signal():
+    l.log()
     hal.newsig("s32", hal.HAL_S32)
 
     assert hal.pins["c1.s32out"].linked is False
@@ -93,6 +103,7 @@ def test_net_existing_signal():
 
 
 def test_newsig():
+    l.log()
     hal.newsig("floatsig1", hal.HAL_FLOAT)
     try:
         hal.newsig("floatsig1", hal.HAL_FLOAT)
@@ -120,6 +131,7 @@ def test_newsig():
 
 
 def test_check_net_args():
+    l.log()
     try:
         hal.net()
     except TypeError:

--- a/nosetests/test_rtapi.py
+++ b/nosetests/test_rtapi.py
@@ -33,7 +33,7 @@ def test_rtapi_connect():
 
 def test_loadrt_or2():
     global rt
-    rt.loadrt("or2")
+    rt.newinst("or2", "or2.0")
     rt.newthread("servo-thread", 1000000, fp=True)
     hal.addf("or2.0", "servo-thread")
     hal.start_threads()

--- a/nosetests/test_rtapi.py
+++ b/nosetests/test_rtapi.py
@@ -1,30 +1,44 @@
 #!/usr/bin/env python
-import os,time
+import os
+import time
+import sys
 
 from nose import with_setup
 from machinekit.nosetests.realtime import setup_module ,teardown_module
 
-from machinekit import rtapi,hal
+from machinekit import rtapi
+from machinekit import hal
 
-import ConfigParser
+if sys.version_info >= (3, 0):
+    import configparser
+else:
+    import ConfigParser as configparser
+
+
+uuid = None  # initialized by test_get_uuid
+rt = None
+
 
 def test_get_uuid():
     global uuid, rt
-    cfg = ConfigParser.ConfigParser()
+    cfg = configparser.ConfigParser()
     cfg.read(os.getenv("MACHINEKIT_INI"))
     uuid = cfg.get("MACHINEKIT", "MKUUID")
+
 
 def test_rtapi_connect():
     global rt
     rt = rtapi.RTAPIcommand(uuid=uuid)
 
+
 def test_loadrt_or2():
     global rt
     rt.loadrt("or2")
-    rt.newthread("servo-thread",1000000,fp=True)
-    hal.addf("or2.0","servo-thread")
+    rt.newthread("servo-thread", 1000000, fp=True)
+    hal.addf("or2.0", "servo-thread")
     hal.start_threads()
     time.sleep(0.2)
+
 
 def test_unloadrt_or2():
     hal.stop_threads()
@@ -32,4 +46,4 @@ def test_unloadrt_or2():
     rt.unloadrt("or2")
 
 (lambda s=__import__('signal'):
-     s.signal(s.SIGTERM, s.SIG_IGN))()
+    s.signal(s.SIGTERM, s.SIG_IGN))()

--- a/nosetests/unittest_or2.py
+++ b/nosetests/unittest_or2.py
@@ -15,7 +15,7 @@ class TestOr2(TestCase):
         self.cfg.read(os.getenv("MACHINEKIT_INI"))
         self.uuid = self.cfg.get("MACHINEKIT", "MKUUID")
         self.rt = rtapi.RTAPIcommand(uuid=self.uuid)
-        self.rt.loadrt("or2")
+        self.rt.newinst("or2", "or2.0")
         self.rt.newthread("servo-thread",1000000,fp=True)
         hal.addf("or2.0","servo-thread")
         hal.start_threads()

--- a/src/hal/cython/machinekit/hal_net.pyx
+++ b/src/hal/cython/machinekit/hal_net.pyx
@@ -24,6 +24,9 @@ def net(sig,*pinnames):
     writer_name = None
     bidir_name = None
 
+    if len(pinnames) == 0:
+        raise RuntimeError("net: at least one pin name expected")
+
     signame = None
     if isinstance(sig, Pin) \
        or (isinstance(sig, str) and (sig in pins)):
@@ -56,9 +59,6 @@ def net(sig,*pinnames):
 
     if signame in pins:
         raise TypeError("net: '%s' is a pin - first argument must be a signal name" % signame)
-
-    if len(pinnames) == 0:
-        raise RuntimeError("net: at least one pin name expected")
 
     pinlist = []
     for names in pinnames:

--- a/src/hal/cython/machinekit/hal_sigdict.pyx
+++ b/src/hal/cython/machinekit/hal_sigdict.pyx
@@ -63,7 +63,7 @@ cdef class Signals:
 
     def __delitem__(self, char *name):
         hal_required()
-
+        del self.sigs[name]
         r = hal_signal_delete(name)
         if r:
             raise RuntimeError("hal_signal_delete %s failed: %d %s" % (name, r, hal_lasterror()))

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -1132,46 +1132,6 @@ bool inst_name_exists(char *name)
     }
 }
 
-
-int get_tags(char *mod_name)
-{
-    char modpath[PATH_MAX];
-    int result = 0, n = 0;
-    char *cp1 = "";
-
-    flavor_ptr flavor = flavor_byid(global_data->rtapi_thread_flavor);
-
-    if (kernel_threads(flavor)) {
-	if (module_path(modpath, mod_name) < 0) {
-	    halcmd_error("cant determine module_path for %s ?\n", mod_name);
-	    return -1;
-	}
-    } else {
-	if (get_rtapi_config(modpath,"RTLIB_DIR",PATH_MAX) != 0) {
-	    halcmd_error("cant get  RTLIB_DIR ?\n");
-	    return -1;
-	}
-	strcat(modpath,"/");
-	strcat(modpath, flavor->name);
-	strcat(modpath,"/");
-	strcat(modpath,mod_name);
-	strcat(modpath, flavor->mod_ext);
-    }
-    const char **caps = get_caps(modpath);
-
-    char **p = (char **)caps;
-    while (p && *p && strlen(*p)) {
-	cp1 = *p++;
-	if (strncmp(cp1,"HAL=", 4) == 0) {
-	    n = strtol(&cp1[4], NULL, 10);
-	    result |=  n ;
-	}
-    }
-    free(caps);
-    return result;
-}
-
-
 int loadrt(char *mod_name, char *args[])
 {
     char *cp1;
@@ -1218,10 +1178,10 @@ int loadrt(char *mod_name, char *args[])
     return 0;
 }
 
-
-
-
-int do_loadrt_cmd(char *mod_name, char *args[])
+static int loadrt_cmd(const bool instantiate,
+		      char *mod_name,
+		      char *args[])
+// int do_loadrt_cmd(char *mod_name, char *args[])
 {
     char arg_string[MAX_CMD_LEN+1];
     char arg_section[MAX_CMD_LEN+1];
@@ -1239,7 +1199,7 @@ int do_loadrt_cmd(char *mod_name, char *args[])
 	return -EPERM;
     }
 
-    retval = get_tags(mod_name);
+    retval = rtapi_get_tags(mod_name);
     if(retval == -1) {
 	halcmd_error("Error in module tags search");
 	return retval;
@@ -1251,110 +1211,115 @@ int do_loadrt_cmd(char *mod_name, char *args[])
 	    singleton = true;
     }
     // if new component and not a call from do_newinst_cmd()
-    if (instantiable && !autoloading) {
-	// we only process arg[0]
-	if (args[0] != NULL && strlen(args[0])) {
-	    strcpy(arg_string, args[0]);
-	    //// count=N  ////////////////
-	    if ((strncmp(arg_string, "count=", 6) == 0) && !singleton) {
-		strcpy(arg_section, &arg_string[6]);
-		n = strtol(arg_section, &cp1, 10);
-		if (n > 0) {
-		    // check if already loaded, if not load it
-		    if (!module_loaded(mod_name)) {
-			if((retval = (loadrt(mod_name, argv))) )
-			    return retval;
-		    }
-		    for(int y = 0, v = 0; y < n; y++ , v++) {
-			sprintf(buff, "%s.%d", mod_name, v);
-			while(inst_name_exists(buff))
-			    sprintf(buff, "%s.%d", mod_name, ++v);
-			retval = do_newinst_cmd(mod_name, buff, argv);
-			if ( retval != 0 )
-			    return retval;
-		    }
-		} else {
-		    halcmd_error("Invalid value to count= parameter\n");
-		    return -1;
+    if (!(instantiable && instantiate)) {
+	// legacy components
+        return loadrt(mod_name, args);
+    }
+
+    // we only process arg[0]
+    if (args[0] != NULL && strlen(args[0])) {
+	strcpy(arg_string, args[0]);
+	//// count=N  ////////////////
+	if ((strncmp(arg_string, "count=", 6) == 0) && !singleton) {
+	    strcpy(arg_section, &arg_string[6]);
+	    n = strtol(arg_section, &cp1, 10);
+	    if (n > 0) {
+		// check if already loaded, if not load it
+		if (!module_loaded(mod_name)) {
+		    if((retval = (loadrt(mod_name, argv))) )
+			return retval;
 		}
-	    }
-	    //// names="..."  ////////////////
-	    else if ((strncmp(arg_string, "names=", 6) == 0) && !singleton) {
-		strcpy(arg_section, &arg_string[6]);
-		cp1 = strtok(arg_section, ",");
-		list_index = 0;
-		while( cp1 != NULL ) {
-		    cp2 = (char *) malloc(strlen(cp1) + 1);
-		    strcpy(cp2, cp1);
-		    list[list_index++] = cp2;
-		    cp1 = strtok(NULL, ",");
-		}
-		if (list_index) {
-		    if (!module_loaded(mod_name)) {
-			if ((retval = (loadrt(mod_name, argv)))) {
-			    for(p = 0; p < list_index; p++)
-				free(list[p]);
-			    return retval;
-			}
-		    }
-		    for (w = 0; w < list_index; w++) {
-			if (inst_name_exists(list[w])) {
-			    halcmd_error("\nA named instance '%s' already exists\n", list[w]);
-			    for( p = 0; p < list_index; p++)
-				free(list[p]);
-			    return -1;
-			}
-			retval = do_newinst_cmd(mod_name, list[w], argv);
-			if ( retval != 0 ) {
-			    for( p = 0; p < list_index; p++)
-				free(list[p]);
-			    return retval;
-			}
-		    }
-		    for(p = 0; p < list_index; p++)
-			free(list[p]);
+		for(int y = 0, v = 0; y < n; y++ , v++) {
+		    sprintf(buff, "%s.%d", mod_name, v);
+		    while(inst_name_exists(buff))
+			sprintf(buff, "%s.%d", mod_name, ++v);
+		    retval = do_newinst_cmd(mod_name, buff, argv);
+		    if ( retval != 0 )
+			return retval;
 		}
 	    } else {
-		// invalid parameter
-		halcmd_error("\nInvalid argument '%s' to instantiated component\n"
-			     "NB. Use of personality or cfg is deprecated\n"
-			     "Singleton components cannot have multiple instances\n\n", args[x]);
+		halcmd_error("Invalid value to count= parameter\n");
+		return -1;
+	    }
+	} // count=N
+	//// names="..."  ////////////////
+	else if ((strncmp(arg_string, "names=", 6) == 0) && !singleton) {
+	    strcpy(arg_section, &arg_string[6]);
+	    cp1 = strtok(arg_section, ",");
+	    list_index = 0;
+	    while( cp1 != NULL ) {
+		cp2 = (char *) malloc(strlen(cp1) + 1);
+		strcpy(cp2, cp1);
+		list[list_index++] = cp2;
+		cp1 = strtok(NULL, ",");
+	    }
+	    if (list_index) {
+		if (!module_loaded(mod_name)) {
+		    if ((retval = (loadrt(mod_name, argv)))) {
+			for(p = 0; p < list_index; p++)
+			    free(list[p]);
+			return retval;
+		    }
+		}
+		for (w = 0; w < list_index; w++) {
+		    if (inst_name_exists(list[w])) {
+			halcmd_error("\nA named instance '%s' already exists\n", list[w]);
+			for( p = 0; p < list_index; p++)
+			    free(list[p]);
+			return -1;
+		    }
+		    retval = do_newinst_cmd(mod_name, list[w], argv);
+		    if ( retval != 0 ) {
+			for( p = 0; p < list_index; p++)
+			    free(list[p]);
+			return retval;
+		    }
+		}
+		for(p = 0; p < list_index; p++)
+		    free(list[p]);
+	    }
+	} else {
+	    // invalid parameter
+	    halcmd_error("\nInvalid argument '%s' to instantiated component\n"
+			 "NB. Use of personality or cfg is deprecated\n"
+			 "Singleton components cannot have multiple instances\n\n", args[x]);
+	    return -1;
+	}
+    } else {
+	//// no args so equates to count=1
+	// if no args just create a single instance with default number 0, unless singleton.
+	if (!module_loaded(mod_name)) {
+	    if((retval = (loadrt(mod_name, argv))) )
+		return retval;
+	}
+	w = 0;
+	if (singleton) {
+	    sprintf(buff, "%s", mod_name);
+	    hal_comp_t *existing_comp = halpr_find_comp_by_name(mod_name);
+	    if (inst_name_exists(buff) || inst_count(existing_comp)) {
+		halcmd_error("\nError singleton component '%s' already exists\n", buff);
 		return -1;
 	    }
 	} else {
-	    //// no args so equates to count=1
-	    // if no args just create a single instance with default number 0, unless singleton.
-	    if (!module_loaded(mod_name)) {
-		if((retval = (loadrt(mod_name, argv))) )
-		    return retval;
-	    }
-	    w = 0;
-	    if (singleton) {
-		sprintf(buff, "%s", mod_name);
-		hal_comp_t *existing_comp = halpr_find_comp_by_name(mod_name);
-		if (inst_name_exists(buff) || inst_count(existing_comp)) {
-		    halcmd_error("\nError singleton component '%s' already exists\n", buff);
-		    return -1;
-		}
-	    } else {
-		sprintf(buff, "%s.%d", mod_name, w);
-		while(inst_name_exists(buff))
-		    sprintf(buff, "%s.%d", mod_name, ++w);
-	    }
-	    retval = do_newinst_cmd(mod_name, buff, argv);
-	    if ( retval != 0 ) {
-		halcmd_error("rc=%d\n%s", retval, rtapi_rpcerror());
-		return retval;
-	    }
+	    sprintf(buff, "%s.%d", mod_name, w);
+	    while(inst_name_exists(buff))
+		sprintf(buff, "%s.%d", mod_name, ++w);
 	}
-    } else {
-	/////////////////////  legacy components  /////////////////////////////////////////////////////
-        return( retval = loadrt(mod_name, args) );
+	retval = do_newinst_cmd(mod_name, buff, argv);
+	if ( retval != 0 ) {
+	    halcmd_error("rc=%d\n%s", retval, rtapi_rpcerror());
+	    return retval;
+	}
     }
-    autoloading = false;
+    // autoloading = false;
     return 0;
 }
 
+
+int do_loadrt_cmd(char *mod_name, char *args[])
+{
+    return loadrt_cmd(true, mod_name, args);
+}
 
 
 int do_delsig_cmd(char *mod_name)
@@ -3696,10 +3661,10 @@ int do_newinst_cmd(char *comp, char *inst, char *args[])
     switch (status) {
     case CS_NOT_LOADED:
 	if (autoload) {
-	    // flag to prevent do_loadrt_cmd() trying to create an instance too
-	    autoloading = true;
-	    retval = do_loadrt_cmd(comp, argv);
-	    autoloading = false;
+	    /* // flag to prevent do_loadrt_cmd() trying to create an instance too */
+	    /* autoloading = true; */
+	    retval = loadrt_cmd(false, comp, argv);
+	    /* autoloading = false; */
 	    if (retval)
 		return retval;
 	    return do_newinst_cmd(comp, inst,  args);
@@ -3728,7 +3693,7 @@ int do_newinst_cmd(char *comp, char *inst, char *args[])
         return -EPERM;
     }
 
-    retval = get_tags(comp);
+    retval = rtapi_get_tags(comp);
     if (retval == -1) {
         halcmd_error("Error in module tags search");
         return retval;

--- a/src/hal/utils/halcmd_commands.h
+++ b/src/hal/utils/halcmd_commands.h
@@ -114,7 +114,6 @@ extern int do_delinst_cmd(char *inst);
 
 extern bool module_loaded(char *mod_name);
 extern bool inst_name_exists(char *name);
-extern int get_tags(char *mod_name);
 
 // shutdown the RTAPI stack
 extern int do_shutdown_cmd(void);
@@ -130,6 +129,6 @@ int hal_systemv(char *const argv[]);
 
 extern int scriptmode, comp_id;
 
-bool autoloading;
+// bool autoloading;
 
 #endif

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
     char *uri = NULL; // NULL - use service discovery
     char *service_uuid = NULL; // must have a global uuid
 
-    autoloading = false;  // flag to check where a do_loadrt_cmd() is coming from
+    //autoloading = false;  // flag to check where a do_loadrt_cmd() is coming from
 
     inifile = getenv("MACHINEKIT_INI");
     /* use default if not specified by user */

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -86,8 +86,6 @@ int main(int argc, char **argv)
     char *uri = NULL; // NULL - use service discovery
     char *service_uuid = NULL; // must have a global uuid
 
-    //autoloading = false;  // flag to check where a do_loadrt_cmd() is coming from
-
     inifile = getenv("MACHINEKIT_INI");
     /* use default if not specified by user */
     if (inifile == NULL) {
@@ -158,8 +156,6 @@ int main(int argc, char **argv)
 	    case 'P':
                 proto_debug = 1;
 		break;
-
-
 	    case 'C':
                 cl = getenv("COMP_LINE");
                 cw = getenv("COMP_POINT");

--- a/src/rtapi/rtapi_compat.c
+++ b/src/rtapi/rtapi_compat.c
@@ -644,3 +644,41 @@ const char *get_cap(const char *const fname, const char *cap)
     free(cv);
     return NULL;
 }
+
+int rtapi_get_tags(const char *mod_name)
+{
+    char modpath[PATH_MAX];
+    int result = 0, n = 0;
+    char *cp1 = "";
+
+    flavor_ptr flavor = default_flavor();
+
+    if (kernel_threads(flavor)) {
+	if (module_path(modpath, mod_name) < 0) {
+	    perror("module_path");
+	    return -1;
+	}
+    } else {
+	if (get_rtapi_config(modpath,"RTLIB_DIR",PATH_MAX) != 0) {
+	    perror("cant get  RTLIB_DIR ?\n");
+	    return -1;
+	}
+	strcat(modpath,"/");
+	strcat(modpath, flavor->name);
+	strcat(modpath,"/");
+	strcat(modpath,mod_name);
+	strcat(modpath, flavor->mod_ext);
+    }
+    const char **caps = get_caps(modpath);
+
+    char **p = (char **)caps;
+    while (p && *p && strlen(*p)) {
+	cp1 = *p++;
+	if (strncmp(cp1,"HAL=", 4) == 0) {
+	    n = strtol(&cp1[4], NULL, 10);
+	    result |=  n ;
+	}
+    }
+    free(caps);
+    return result;
+}

--- a/src/rtapi/rtapi_compat.h
+++ b/src/rtapi/rtapi_compat.h
@@ -192,6 +192,11 @@ const char **get_caps(const char *const fname);
 const char *get_cap(const char *const fname, const char *cap);
 
 
+// given a module name and the flavor set, return the integer
+// capability mask of tags.
+int rtapi_get_tags(const char *mod_name);
+
+
 SUPPORT_END_DECLS
 
 #endif // MODULE

--- a/tests/nosetests/checkresult
+++ b/tests/nosetests/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/nosetests/test.sh
+++ b/tests/nosetests/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+nt=`which nosetests`
+if [ "$nt" == "" ]; then
+    echo nosetests not installed
+    exit 1
+fi
+
+for t in $EMC2_HOME/nosetests/*.py
+do
+    nosetests  $t
+done


### PR DESCRIPTION
this branch combines: 

- cython bindings - cleanups by Alex
- a runtest which will run the nosetests on every build (requires python-nose to be installed on-target)
- factoring out get_tag into rtapi as rtapi_get_tag (might be used beyond halcmd)
- readability improvements on halcmd:do_loadrt_cmd


this will likely fail until the bot slaves have python-nose installed (!)