### PR TITLE
improve examples for instantiable components, instcomp fixes

### DIFF
--- a/lib/python/machinekit/nosetests/rtapilog.py
+++ b/lib/python/machinekit/nosetests/rtapilog.py
@@ -1,0 +1,34 @@
+from machinekit import rtapi
+import inspect
+
+# helper for logging in nosetests scripts to rtapi
+# to correlate test location with HAL/RTAPI log messages
+
+# see also:
+# http://stackoverflow.com/questions/6810999/how-to-determine-file-function-and-line-number
+
+class Log:
+    def __init__(self, level=rtapi.MSG_DBG,tag="logger"):
+        self.l = None
+        self.level = level
+        self.tag = tag
+
+    def log(self, *args):
+        # defer init until RTAPI known to be up
+        if not self.l:
+            self.l = rtapi.RTAPILogger(level=self.level,tag=self.tag)
+
+        # 0 represents this line
+        # 1 represents line at caller
+
+        callerframerecord = inspect.stack()[1]
+        frame = callerframerecord[0]
+        info = inspect.getframeinfo(frame)
+        print >> self.l, "%s:%s:%s %s" % (info.filename,
+                                          info.function,
+                                          info.lineno,
+                                          " ".join(args)),
+
+if __name__ == "__main__":
+    l = Log(level=rtapi.MSG_ERR,tag="testrun")
+    l.log("foo","bar","baz")

--- a/nosetests/test_mk_hal_basics.py
+++ b/nosetests/test_mk_hal_basics.py
@@ -14,12 +14,18 @@ epsval = 10.0
 epsindex = 1
 signame = "ss32"
 
+c = None  # initialized by test_component_creation
+s1 = None  # initialized by test_signal
+p = None  # initialized by test_pin_attributes
+
+
 def test_component_creation():
     global c
     hal.epsilon[epsindex] = epsval
     c = hal.Component(cname)
     c.newpin(pname, hal.HAL_S32, hal.HAL_OUT, init=42, eps=epsindex)
     c.ready()
+
 
 def test_pin_creation_after_ready():
     try:
@@ -28,24 +34,29 @@ def test_pin_creation_after_ready():
     except RuntimeError:
         pass
     else:
-        raise Exception, "pin creation must fail atfer calling c.ready()"
+        raise(Exception, "pin creation must fail atfer calling c.ready()")
+
 
 def test_component_dictionary():
     assert len(hal.components) > 0  # halcmd and others
     assert cname in hal.components
     assert hal.components[cname].name == cname
 
+
 def test_pins_dictionary():
     assert len(hal.pins) == 1
     assert fqpname in hal.pins
     assert hal.pins[fqpname].name == fqpname
 
+
 def test_pin_initial_value():
     assert c[pname] == 42
+
 
 def test_pin_value_assignment():
     c[pname] = 4711
     assert c[pname] == 4711
+
 
 def test_pin_attributes():
     n = c.pins()    # pin names of this comp
@@ -59,7 +70,8 @@ def test_pin_attributes():
     assert p.eps == epsindex
     assert fnear(p.epsilon, hal.epsilon[epsindex])
     assert p.handle > 0
-    assert p.linked == False
+    assert p.linked is False
+
 
 def test_signal():
     global s1
@@ -75,9 +87,10 @@ def test_signal():
     s1.set(12345)
     assert s1.get() == 12345
 
+
 def test_linking():
     assert s1.writers == 0
-    assert s1.writername == None
+    assert s1.writername is None
 
     s1.link(p)
     assert s1.writers == 1
@@ -89,14 +102,14 @@ def test_linking():
 
     # the name of modifying pins linked to this signal
     assert s1.writername == fqpname
-    assert s1.bidirname == None
+    assert s1.bidirname is None
 
     # verify the pin reflects the signal it's linked to:
-    assert p.linked == True
+    assert p.linked is True
     assert p.signame == s1.name
-    sw = p.signal # access through Signal() wrapper
-    assert sw != None
-    assert isinstance(sw,hal.Signal)
+    sw = p.signal  # access through Signal() wrapper
+    assert sw is not None
+    assert isinstance(sw, hal.Signal)
     assert p.signal.writers == 1
 
     # initial value inheritage
@@ -108,12 +121,14 @@ def test_linking():
     except RuntimeError:
         pass
     else:
-        raise Exception, "setting value of a linked signal succeeded!"
+        raise(Exception, "setting value of a linked signal succeeded!")
+
 
 def test_signals_dictionary():
     assert len(hal.signals) == 1
     assert signame in hal.signals
     assert hal.signals[signame].name == signame
+
 
 def test_ccomp_and_epsilon():
     # custom deltas (leave epsilon[0] - the default - untouched)
@@ -139,12 +154,12 @@ def test_ccomp_and_epsilon():
 
     # report_all=True forces a report of all pins
     # regardless of change status, so 2 pins to report:
-    c.changed(userdata=pinlist,report_all=True)
+    c.changed(userdata=pinlist, report_all=True)
     assert len(pinlist) == 2
 
     # passing a list as 'userdata=<list>' always clears the list before
     # appending pins
-    c.changed(userdata=pinlist,report_all=True)
+    c.changed(userdata=pinlist, report_all=True)
     assert len(pinlist) == 2
 
     c["out1"] += 101  # larger than out1's epsilon value
@@ -163,4 +178,4 @@ def test_ccomp_and_epsilon():
 
 
 (lambda s=__import__('signal'):
-     s.signal(s.SIGTERM, s.SIG_IGN))()
+    s.signal(s.SIGTERM, s.SIG_IGN))()

--- a/nosetests/test_mk_hal_basics.py
+++ b/nosetests/test_mk_hal_basics.py
@@ -63,7 +63,7 @@ def test_pin_attributes():
     assert len(n) == 1
     # access properties through wrapper:
     global p
-    p = hal.Pin(n[0])
+    p = n[0]
     assert p.name == fqpname
     assert p.type == hal.HAL_S32
     assert p.dir == hal.HAL_OUT

--- a/nosetests/test_netcmd.py
+++ b/nosetests/test_netcmd.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+
 from nose import with_setup
 from machinekit.nosetests.realtime import setup_module,teardown_module
 from machinekit.nosetests.support import fnear
@@ -37,6 +38,7 @@ def test_net_existing_signal_with_bad_type():
     except TypeError:
         pass
     del hal.signals["f"]
+    assert 'f' not in hal.signals
 
 
 def test_net_match_nonexistant_signals():
@@ -58,6 +60,7 @@ def test_net_pin2pin():
     hal.pins["c1.s32out"].unlink()
     hal.pins["c2.s32in"].unlink()
     del hal.signals['c1-s32out']
+    assert 'c1-s32out' not in hal.signals
 
     try:
         hal.net("c2.s32out", "c1.s32out")
@@ -68,6 +71,7 @@ def test_net_pin2pin():
     # cleanup
     hal.pins["c2.s32out"].unlink()
     del hal.signals['c2-s32out']
+    assert 'c2-s32out' not in hal.signals
 
 
 def test_net_existing_signal():
@@ -85,6 +89,7 @@ def test_net_existing_signal():
         pass
 
     del hal.signals["s32"]
+    assert 's32' not in hal.signals
 
 
 def test_newsig():
@@ -120,17 +125,29 @@ def test_check_net_args():
     except TypeError:
         pass
 
+    assert 'c1-s32out' not in hal.signals
+
     try:
         hal.net(None, "c1.s32out")
     except TypeError:
         pass
 
+    assert 'c1-s32out' not in hal.signals
+
     # single pin argument
+    assert hal.pins["c1.s32out"].linked is False
+
     try:
         hal.net("c1.s32out")
         # RuntimeError: net: at least one pin name expected
     except RuntimeError:
         pass
+
+    # XXX die beiden gehen daneben:
+    # der pin wird trotz runtime error gelinkt und das signal erzeugt:
+    # offensichtlich hal_net.pyx:39 vor dem test in hal_net.pyx:60
+    assert hal.pins["c1.s32out"].linked is False
+    assert 'c1-s32out' not in hal.signals
 
     # single signal argument
     try:

--- a/nosetests/test_netcmd.py
+++ b/nosetests/test_netcmd.py
@@ -5,28 +5,29 @@ from machinekit.nosetests.realtime import setup_module,teardown_module
 from machinekit.nosetests.support import fnear
 
 from machinekit import hal
-import os
+
 
 def test_component_creation():
-    global c1,c2
+    global c1, c2
     c1 = hal.Component("c1")
     c1.newpin("s32out", hal.HAL_S32, hal.HAL_OUT, init=42)
-    c1.newpin("s32in",  hal.HAL_S32, hal.HAL_IN)
-    c1.newpin("s32io",  hal.HAL_S32, hal.HAL_IO)
+    c1.newpin("s32in", hal.HAL_S32, hal.HAL_IN)
+    c1.newpin("s32io", hal.HAL_S32, hal.HAL_IO)
     c1.newpin("floatout", hal.HAL_FLOAT, hal.HAL_OUT, init=42)
-    c1.newpin("floatin",  hal.HAL_FLOAT, hal.HAL_IN)
-    c1.newpin("floatio",  hal.HAL_FLOAT, hal.HAL_IO)
+    c1.newpin("floatin", hal.HAL_FLOAT, hal.HAL_IN)
+    c1.newpin("floatio", hal.HAL_FLOAT, hal.HAL_IO)
 
     c1.ready()
 
     c2 = hal.Component("c2")
     c2.newpin("s32out", hal.HAL_S32, hal.HAL_OUT, init=4711)
-    c2.newpin("s32in",  hal.HAL_S32, hal.HAL_IN)
-    c2.newpin("s32io",  hal.HAL_S32, hal.HAL_IO)
+    c2.newpin("s32in", hal.HAL_S32, hal.HAL_IN)
+    c2.newpin("s32io", hal.HAL_S32, hal.HAL_IO)
     c2.newpin("floatout", hal.HAL_FLOAT, hal.HAL_OUT, init=4711)
-    c2.newpin("floatin",  hal.HAL_FLOAT, hal.HAL_IN)
-    c2.newpin("floatio",  hal.HAL_FLOAT, hal.HAL_IO)
+    c2.newpin("floatin", hal.HAL_FLOAT, hal.HAL_IN)
+    c2.newpin("floatio", hal.HAL_FLOAT, hal.HAL_IO)
     c2.ready()
+
 
 def test_net_existing_signal_with_bad_type():
     hal.newsig("f", hal.HAL_FLOAT)
@@ -37,16 +38,18 @@ def test_net_existing_signal_with_bad_type():
         pass
     del hal.signals["f"]
 
+
 def test_net_match_nonexistant_signals():
     try:
-        hal.net("nosuchsig", "c1.s32out","c2.s32out")
+        hal.net("nosuchsig", "c1.s32out", "c2.s32out")
         raise "should not happen"
     except TypeError:
         pass
 
+
 def test_net_pin2pin():
     try:
-        hal.net("c1.s32out","c2.s32out")
+        hal.net("c1.s32out", "c2.s32out")
         #TypeError: net: 'c1.s32out' is a pin - first argument must be a signal name
         raise "should not happen"
     except TypeError:
@@ -56,9 +59,9 @@ def test_net_pin2pin():
 def test_net_existing_signal():
     hal.newsig("s32", hal.HAL_S32)
 
-    assert hal.pins["c1.s32out"].linked == False
+    assert hal.pins["c1.s32out"].linked is False
     hal.net("s32", "c1.s32out")
-    assert hal.pins["c1.s32out"].linked == True
+    assert hal.pins["c1.s32out"].linked is True
 
     hal.newsig("s32too", hal.HAL_S32)
     try:
@@ -69,8 +72,9 @@ def test_net_existing_signal():
 
     del hal.signals["s32"]
 
+
 def test_newsig():
-    floatsig1 = hal.newsig("floatsig1", hal.HAL_FLOAT)
+    hal.newsig("floatsig1", hal.HAL_FLOAT)
     try:
         hal.newsig("floatsig1", hal.HAL_FLOAT)
         # RuntimeError: Failed to create signal floatsig1: HAL: ERROR: duplicate signal 'floatsig1'
@@ -78,7 +82,7 @@ def test_newsig():
     except RuntimeError:
         pass
     try:
-        hal.newsig(32423 *32432, hal.HAL_FLOAT)
+        hal.newsig(32423 * 32432, hal.HAL_FLOAT)
         raise "should not happen"
     except TypeError:
         pass
@@ -130,4 +134,4 @@ def test_check_net_args():
         pass
 
 (lambda s=__import__('signal'):
-     s.signal(s.SIGTERM, s.SIG_IGN))()
+    s.signal(s.SIGTERM, s.SIG_IGN))()

--- a/nosetests/test_netcmd.py
+++ b/nosetests/test_netcmd.py
@@ -103,6 +103,7 @@ def test_net_existing_signal():
 
 
 def test_newsig():
+    l.log()
     hal.newsig("floatsig1", hal.HAL_FLOAT)
     try:
         hal.newsig("floatsig1", hal.HAL_FLOAT)

--- a/nosetests/test_netcmd.py
+++ b/nosetests/test_netcmd.py
@@ -4,12 +4,18 @@
 from nose import with_setup
 from machinekit.nosetests.realtime import setup_module,teardown_module
 from machinekit.nosetests.support import fnear
+from machinekit.nosetests.rtapilog import Log
 
-from machinekit import hal
+from machinekit import hal,rtapi
+import os
+
+l = Log(level=rtapi.MSG_INFO,tag="nosetest")
+
 
 
 def test_component_creation():
-    global c1, c2
+    l.log()
+    global c1,c2
     c1 = hal.Component("c1")
     c1.newpin("s32out", hal.HAL_S32, hal.HAL_OUT, init=42)
     c1.newpin("s32in", hal.HAL_S32, hal.HAL_IN)
@@ -31,6 +37,7 @@ def test_component_creation():
 
 
 def test_net_existing_signal_with_bad_type():
+    l.log()
     hal.newsig("f", hal.HAL_FLOAT)
     try:
         hal.net("f", "c1.s32out")
@@ -42,6 +49,7 @@ def test_net_existing_signal_with_bad_type():
 
 
 def test_net_match_nonexistant_signals():
+    l.log()
     try:
         hal.net("nosuchsig", "c1.s32out", "c2.s32out")
         raise "should not happen"
@@ -50,6 +58,7 @@ def test_net_match_nonexistant_signals():
 
 
 def test_net_pin2pin():
+    l.log()
     # out to in is okay
     hal.net("c1.s32out", "c2.s32in")
     assert hal.pins["c1.s32out"].linked is True
@@ -75,6 +84,7 @@ def test_net_pin2pin():
 
 
 def test_net_existing_signal():
+    l.log()
     hal.newsig("s32", hal.HAL_S32)
 
     assert hal.pins["c1.s32out"].linked is False
@@ -120,6 +130,7 @@ def test_newsig():
 
 
 def test_check_net_args():
+    l.log()
     try:
         hal.net()
     except TypeError:

--- a/nosetests/test_rtapi.py
+++ b/nosetests/test_rtapi.py
@@ -33,7 +33,7 @@ def test_rtapi_connect():
 
 def test_loadrt_or2():
     global rt
-    rt.loadrt("or2")
+    rt.newinst("or2", "or2.0")
     rt.newthread("servo-thread", 1000000, fp=True)
     hal.addf("or2.0", "servo-thread")
     hal.start_threads()

--- a/nosetests/test_rtapi.py
+++ b/nosetests/test_rtapi.py
@@ -1,30 +1,44 @@
 #!/usr/bin/env python
-import os,time
+import os
+import time
+import sys
 
 from nose import with_setup
 from machinekit.nosetests.realtime import setup_module ,teardown_module
 
-from machinekit import rtapi,hal
+from machinekit import rtapi
+from machinekit import hal
 
-import ConfigParser
+if sys.version_info >= (3, 0):
+    import configparser
+else:
+    import ConfigParser as configparser
+
+
+uuid = None  # initialized by test_get_uuid
+rt = None
+
 
 def test_get_uuid():
     global uuid, rt
-    cfg = ConfigParser.ConfigParser()
+    cfg = configparser.ConfigParser()
     cfg.read(os.getenv("MACHINEKIT_INI"))
     uuid = cfg.get("MACHINEKIT", "MKUUID")
+
 
 def test_rtapi_connect():
     global rt
     rt = rtapi.RTAPIcommand(uuid=uuid)
 
+
 def test_loadrt_or2():
     global rt
     rt.loadrt("or2")
-    rt.newthread("servo-thread",1000000,fp=True)
-    hal.addf("or2.0","servo-thread")
+    rt.newthread("servo-thread", 1000000, fp=True)
+    hal.addf("or2.0", "servo-thread")
     hal.start_threads()
     time.sleep(0.2)
+
 
 def test_unloadrt_or2():
     hal.stop_threads()
@@ -32,4 +46,4 @@ def test_unloadrt_or2():
     rt.unloadrt("or2")
 
 (lambda s=__import__('signal'):
-     s.signal(s.SIGTERM, s.SIG_IGN))()
+    s.signal(s.SIGTERM, s.SIG_IGN))()

--- a/nosetests/unittest_or2.py
+++ b/nosetests/unittest_or2.py
@@ -15,7 +15,7 @@ class TestOr2(TestCase):
         self.cfg.read(os.getenv("MACHINEKIT_INI"))
         self.uuid = self.cfg.get("MACHINEKIT", "MKUUID")
         self.rt = rtapi.RTAPIcommand(uuid=self.uuid)
-        self.rt.loadrt("or2")
+        self.rt.newinst("or2", "or2.0")
         self.rt.newthread("servo-thread",1000000,fp=True)
         hal.addf("or2.0","servo-thread")
         hal.start_threads()

--- a/src/hal/cython/machinekit/hal_net.pyx
+++ b/src/hal/cython/machinekit/hal_net.pyx
@@ -24,6 +24,9 @@ def net(sig,*pinnames):
     writer_name = None
     bidir_name = None
 
+    if len(pinnames) == 0:
+        raise RuntimeError("net: at least one pin name expected")
+
     signame = None
     if isinstance(sig, Pin) \
        or (isinstance(sig, str) and (sig in pins)):
@@ -56,9 +59,6 @@ def net(sig,*pinnames):
 
     if signame in pins:
         raise TypeError("net: '%s' is a pin - first argument must be a signal name" % signame)
-
-    if len(pinnames) == 0:
-        raise RuntimeError("net: at least one pin name expected")
 
     pinlist = []
     for names in pinnames:

--- a/src/hal/cython/machinekit/hal_sigdict.pyx
+++ b/src/hal/cython/machinekit/hal_sigdict.pyx
@@ -63,7 +63,7 @@ cdef class Signals:
 
     def __delitem__(self, char *name):
         hal_required()
-
+        del self.sigs[name]
         r = hal_signal_delete(name)
         if r:
             raise RuntimeError("hal_signal_delete %s failed: %d %s" % (name, r, hal_lasterror()))

--- a/src/hal/icomp-example/README
+++ b/src/hal/icomp-example/README
@@ -1,3 +1,6 @@
-demonstrates the HAL instantiation API
+demonstrates the HAL instantiation API, and the 'extended thread
+function' API which makes extra context available to a thread funct,
+see lutn.c:lut()
 
-doubles as unit test - see nosetests/unittest_icomp.py
+
+icomp.c doubles as unit test - see nosetests/unittest_icomp.py

--- a/src/hal/lib/hal_instance.c
+++ b/src/hal/lib/hal_instance.c
@@ -337,7 +337,12 @@ void free_inst_struct(hal_inst_t * inst)
 	//NB - pins, params etc still intact
 	// this instance is owned by this comp, call destructor
 	HALDBG("calling custom destructor(%s,%s)", comp->name, inst->name);
+
+	// for the time being (until the halg_ API is fully merged), unlock HAL
+	// while calling the dtor
+	rtapi_mutex_give(&(hal_data->mutex));
 	comp->dtor(inst->name, SHMPTR(inst->inst_data_ptr), inst->inst_size);
+	rtapi_mutex_get(&(hal_data->mutex));
     }
 #endif /* RTAPI */
 

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -1132,46 +1132,6 @@ bool inst_name_exists(char *name)
     }
 }
 
-
-int get_tags(char *mod_name)
-{
-    char modpath[PATH_MAX];
-    int result = 0, n = 0;
-    char *cp1 = "";
-
-    flavor_ptr flavor = flavor_byid(global_data->rtapi_thread_flavor);
-
-    if (kernel_threads(flavor)) {
-	if (module_path(modpath, mod_name) < 0) {
-	    halcmd_error("cant determine module_path for %s ?\n", mod_name);
-	    return -1;
-	}
-    } else {
-	if (get_rtapi_config(modpath,"RTLIB_DIR",PATH_MAX) != 0) {
-	    halcmd_error("cant get  RTLIB_DIR ?\n");
-	    return -1;
-	}
-	strcat(modpath,"/");
-	strcat(modpath, flavor->name);
-	strcat(modpath,"/");
-	strcat(modpath,mod_name);
-	strcat(modpath, flavor->mod_ext);
-    }
-    const char **caps = get_caps(modpath);
-
-    char **p = (char **)caps;
-    while (p && *p && strlen(*p)) {
-	cp1 = *p++;
-	if (strncmp(cp1,"HAL=", 4) == 0) {
-	    n = strtol(&cp1[4], NULL, 10);
-	    result |=  n ;
-	}
-    }
-    free(caps);
-    return result;
-}
-
-
 int loadrt(char *mod_name, char *args[])
 {
     char *cp1;
@@ -1218,10 +1178,10 @@ int loadrt(char *mod_name, char *args[])
     return 0;
 }
 
-
-
-
-int do_loadrt_cmd(char *mod_name, char *args[])
+static int loadrt_cmd(const bool instantiate,
+		      char *mod_name,
+		      char *args[])
+// int do_loadrt_cmd(char *mod_name, char *args[])
 {
     char arg_string[MAX_CMD_LEN+1];
     char arg_section[MAX_CMD_LEN+1];
@@ -1239,7 +1199,7 @@ int do_loadrt_cmd(char *mod_name, char *args[])
 	return -EPERM;
     }
 
-    retval = get_tags(mod_name);
+    retval = rtapi_get_tags(mod_name);
     if(retval == -1) {
 	halcmd_error("Error in module tags search");
 	return retval;
@@ -1251,110 +1211,115 @@ int do_loadrt_cmd(char *mod_name, char *args[])
 	    singleton = true;
     }
     // if new component and not a call from do_newinst_cmd()
-    if (instantiable && !autoloading) {
-	// we only process arg[0]
-	if (args[0] != NULL && strlen(args[0])) {
-	    strcpy(arg_string, args[0]);
-	    //// count=N  ////////////////
-	    if ((strncmp(arg_string, "count=", 6) == 0) && !singleton) {
-		strcpy(arg_section, &arg_string[6]);
-		n = strtol(arg_section, &cp1, 10);
-		if (n > 0) {
-		    // check if already loaded, if not load it
-		    if (!module_loaded(mod_name)) {
-			if((retval = (loadrt(mod_name, argv))) )
-			    return retval;
-		    }
-		    for(int y = 0, v = 0; y < n; y++ , v++) {
-			sprintf(buff, "%s.%d", mod_name, v);
-			while(inst_name_exists(buff))
-			    sprintf(buff, "%s.%d", mod_name, ++v);
-			retval = do_newinst_cmd(mod_name, buff, argv);
-			if ( retval != 0 )
-			    return retval;
-		    }
-		} else {
-		    halcmd_error("Invalid value to count= parameter\n");
-		    return -1;
+    if (!(instantiable && instantiate)) {
+	// legacy components
+        return loadrt(mod_name, args);
+    }
+
+    // we only process arg[0]
+    if (args[0] != NULL && strlen(args[0])) {
+	strcpy(arg_string, args[0]);
+	//// count=N  ////////////////
+	if ((strncmp(arg_string, "count=", 6) == 0) && !singleton) {
+	    strcpy(arg_section, &arg_string[6]);
+	    n = strtol(arg_section, &cp1, 10);
+	    if (n > 0) {
+		// check if already loaded, if not load it
+		if (!module_loaded(mod_name)) {
+		    if((retval = (loadrt(mod_name, argv))) )
+			return retval;
 		}
-	    }
-	    //// names="..."  ////////////////
-	    else if ((strncmp(arg_string, "names=", 6) == 0) && !singleton) {
-		strcpy(arg_section, &arg_string[6]);
-		cp1 = strtok(arg_section, ",");
-		list_index = 0;
-		while( cp1 != NULL ) {
-		    cp2 = (char *) malloc(strlen(cp1) + 1);
-		    strcpy(cp2, cp1);
-		    list[list_index++] = cp2;
-		    cp1 = strtok(NULL, ",");
-		}
-		if (list_index) {
-		    if (!module_loaded(mod_name)) {
-			if ((retval = (loadrt(mod_name, argv)))) {
-			    for(p = 0; p < list_index; p++)
-				free(list[p]);
-			    return retval;
-			}
-		    }
-		    for (w = 0; w < list_index; w++) {
-			if (inst_name_exists(list[w])) {
-			    halcmd_error("\nA named instance '%s' already exists\n", list[w]);
-			    for( p = 0; p < list_index; p++)
-				free(list[p]);
-			    return -1;
-			}
-			retval = do_newinst_cmd(mod_name, list[w], argv);
-			if ( retval != 0 ) {
-			    for( p = 0; p < list_index; p++)
-				free(list[p]);
-			    return retval;
-			}
-		    }
-		    for(p = 0; p < list_index; p++)
-			free(list[p]);
+		for(int y = 0, v = 0; y < n; y++ , v++) {
+		    sprintf(buff, "%s.%d", mod_name, v);
+		    while(inst_name_exists(buff))
+			sprintf(buff, "%s.%d", mod_name, ++v);
+		    retval = do_newinst_cmd(mod_name, buff, argv);
+		    if ( retval != 0 )
+			return retval;
 		}
 	    } else {
-		// invalid parameter
-		halcmd_error("\nInvalid argument '%s' to instantiated component\n"
-			     "NB. Use of personality or cfg is deprecated\n"
-			     "Singleton components cannot have multiple instances\n\n", args[x]);
+		halcmd_error("Invalid value to count= parameter\n");
+		return -1;
+	    }
+	} // count=N
+	//// names="..."  ////////////////
+	else if ((strncmp(arg_string, "names=", 6) == 0) && !singleton) {
+	    strcpy(arg_section, &arg_string[6]);
+	    cp1 = strtok(arg_section, ",");
+	    list_index = 0;
+	    while( cp1 != NULL ) {
+		cp2 = (char *) malloc(strlen(cp1) + 1);
+		strcpy(cp2, cp1);
+		list[list_index++] = cp2;
+		cp1 = strtok(NULL, ",");
+	    }
+	    if (list_index) {
+		if (!module_loaded(mod_name)) {
+		    if ((retval = (loadrt(mod_name, argv)))) {
+			for(p = 0; p < list_index; p++)
+			    free(list[p]);
+			return retval;
+		    }
+		}
+		for (w = 0; w < list_index; w++) {
+		    if (inst_name_exists(list[w])) {
+			halcmd_error("\nA named instance '%s' already exists\n", list[w]);
+			for( p = 0; p < list_index; p++)
+			    free(list[p]);
+			return -1;
+		    }
+		    retval = do_newinst_cmd(mod_name, list[w], argv);
+		    if ( retval != 0 ) {
+			for( p = 0; p < list_index; p++)
+			    free(list[p]);
+			return retval;
+		    }
+		}
+		for(p = 0; p < list_index; p++)
+		    free(list[p]);
+	    }
+	} else {
+	    // invalid parameter
+	    halcmd_error("\nInvalid argument '%s' to instantiated component\n"
+			 "NB. Use of personality or cfg is deprecated\n"
+			 "Singleton components cannot have multiple instances\n\n", args[x]);
+	    return -1;
+	}
+    } else {
+	//// no args so equates to count=1
+	// if no args just create a single instance with default number 0, unless singleton.
+	if (!module_loaded(mod_name)) {
+	    if((retval = (loadrt(mod_name, argv))) )
+		return retval;
+	}
+	w = 0;
+	if (singleton) {
+	    sprintf(buff, "%s", mod_name);
+	    hal_comp_t *existing_comp = halpr_find_comp_by_name(mod_name);
+	    if (inst_name_exists(buff) || inst_count(existing_comp)) {
+		halcmd_error("\nError singleton component '%s' already exists\n", buff);
 		return -1;
 	    }
 	} else {
-	    //// no args so equates to count=1
-	    // if no args just create a single instance with default number 0, unless singleton.
-	    if (!module_loaded(mod_name)) {
-		if((retval = (loadrt(mod_name, argv))) )
-		    return retval;
-	    }
-	    w = 0;
-	    if (singleton) {
-		sprintf(buff, "%s", mod_name);
-		hal_comp_t *existing_comp = halpr_find_comp_by_name(mod_name);
-		if (inst_name_exists(buff) || inst_count(existing_comp)) {
-		    halcmd_error("\nError singleton component '%s' already exists\n", buff);
-		    return -1;
-		}
-	    } else {
-		sprintf(buff, "%s.%d", mod_name, w);
-		while(inst_name_exists(buff))
-		    sprintf(buff, "%s.%d", mod_name, ++w);
-	    }
-	    retval = do_newinst_cmd(mod_name, buff, argv);
-	    if ( retval != 0 ) {
-		halcmd_error("rc=%d\n%s", retval, rtapi_rpcerror());
-		return retval;
-	    }
+	    sprintf(buff, "%s.%d", mod_name, w);
+	    while(inst_name_exists(buff))
+		sprintf(buff, "%s.%d", mod_name, ++w);
 	}
-    } else {
-	/////////////////////  legacy components  /////////////////////////////////////////////////////
-        return( retval = loadrt(mod_name, args) );
+	retval = do_newinst_cmd(mod_name, buff, argv);
+	if ( retval != 0 ) {
+	    halcmd_error("rc=%d\n%s", retval, rtapi_rpcerror());
+	    return retval;
+	}
     }
-    autoloading = false;
+    // autoloading = false;
     return 0;
 }
 
+
+int do_loadrt_cmd(char *mod_name, char *args[])
+{
+    return loadrt_cmd(true, mod_name, args);
+}
 
 
 int do_delsig_cmd(char *mod_name)
@@ -3696,10 +3661,10 @@ int do_newinst_cmd(char *comp, char *inst, char *args[])
     switch (status) {
     case CS_NOT_LOADED:
 	if (autoload) {
-	    // flag to prevent do_loadrt_cmd() trying to create an instance too
-	    autoloading = true;
-	    retval = do_loadrt_cmd(comp, argv);
-	    autoloading = false;
+	    /* // flag to prevent do_loadrt_cmd() trying to create an instance too */
+	    /* autoloading = true; */
+	    retval = loadrt_cmd(false, comp, argv);
+	    /* autoloading = false; */
 	    if (retval)
 		return retval;
 	    return do_newinst_cmd(comp, inst,  args);
@@ -3728,7 +3693,7 @@ int do_newinst_cmd(char *comp, char *inst, char *args[])
         return -EPERM;
     }
 
-    retval = get_tags(comp);
+    retval = rtapi_get_tags(comp);
     if (retval == -1) {
         halcmd_error("Error in module tags search");
         return retval;

--- a/src/hal/utils/halcmd_commands.h
+++ b/src/hal/utils/halcmd_commands.h
@@ -114,7 +114,6 @@ extern int do_delinst_cmd(char *inst);
 
 extern bool module_loaded(char *mod_name);
 extern bool inst_name_exists(char *name);
-extern int get_tags(char *mod_name);
 
 // shutdown the RTAPI stack
 extern int do_shutdown_cmd(void);
@@ -130,6 +129,6 @@ int hal_systemv(char *const argv[]);
 
 extern int scriptmode, comp_id;
 
-bool autoloading;
+// bool autoloading;
 
 #endif

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
     char *uri = NULL; // NULL - use service discovery
     char *service_uuid = NULL; // must have a global uuid
 
-    autoloading = false;  // flag to check where a do_loadrt_cmd() is coming from
+    //autoloading = false;  // flag to check where a do_loadrt_cmd() is coming from
 
     inifile = getenv("MACHINEKIT_INI");
     /* use default if not specified by user */

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -86,8 +86,6 @@ int main(int argc, char **argv)
     char *uri = NULL; // NULL - use service discovery
     char *service_uuid = NULL; // must have a global uuid
 
-    //autoloading = false;  // flag to check where a do_loadrt_cmd() is coming from
-
     inifile = getenv("MACHINEKIT_INI");
     /* use default if not specified by user */
     if (inifile == NULL) {
@@ -158,8 +156,6 @@ int main(int argc, char **argv)
 	    case 'P':
                 proto_debug = 1;
 		break;
-
-
 	    case 'C':
                 cl = getenv("COMP_LINE");
                 cw = getenv("COMP_POINT");

--- a/src/machinetalk/msgcomponents/pbring-demo.hal
+++ b/src/machinetalk/msgcomponents/pbring-demo.hal
@@ -1,12 +1,34 @@
 # load the protobuf message definitions support component
 loadrt pbmsgs
 
-# this will create the 'command' and 'response' rings if they dont exist
-loadrt pbring count=2
-#msgsize=200
+# create two pairs of in and out rings
+newring first.in 16384
+newring first.out 16384
 
-loadrt threads  period1=100000000
-addf pbring.0.update thread1
-addf pbring.1.update thread1
+newring second.in 16384
+newring second.out 16384
+
+# instantiate pbring, as needed
+# which will make it attach to <instname>.{i, out} respectively
+newinst pbring first
+newinst pbring second
+
+
+newthread servo 1000000 fp
+addf first.update  servo
+addf second.update servo
 
 start
+
+
+# NB: you can now exit an instance selectively by
+# delinst <instancename>, e.g. 'delinst first'
+# see 'halcmd show' for the effect:
+#   all pins, params and functs of this instance are gone
+#   the 'second.in' and 'second.out' rings have no reader/writer id's any more
+#   since the instance detached from them
+#
+# now try to bring it back with:
+# newinst pbring second
+# and have a look at 'halcmd show' to see what happened
+

--- a/src/machinetalk/msgcomponents/pbring-demo.py
+++ b/src/machinetalk/msgcomponents/pbring-demo.py
@@ -26,8 +26,8 @@ timeout = 50.0
 interval = 0.1
 
 try:
-    c = hal.Ring("pbring.0.in")
-    r = hal.Ring("pbring.0.out")
+    c = hal.Ring("first.in")
+    r = hal.Ring("first.out")
 except Exception,e:
     print e
 

--- a/src/machinetalk/msgcomponents/pbring.c
+++ b/src/machinetalk/msgcomponents/pbring.c
@@ -3,6 +3,7 @@
 #include "rtapi_app.h"		/* RTAPI realtime module decls */
 #include "hal.h"		/* HAL public API decls */
 #include "hal_ring.h"
+#include "hal_priv.h"
 
 // the nanopb library and compiled message definitions are brought in once by
 // 'halcmd loadrt pbmsgs' (message descriptors for parsing and generating pb msgs)
@@ -20,6 +21,7 @@ typedef struct {
     hal_u32_t *decodefail;	// number of messages which failed to protobuf decode
     ringbuffer_t to_rt_rb;      // incoming ringbuffer
     ringbuffer_t from_rt_rb;    // outgoing ringbuffer
+    pb_Container rx, tx;
 } pbring_inst_t;
 
 enum {
@@ -30,32 +32,15 @@ enum {
     RB_WRITE_FAIL   = -104,
 } rtmsg_errors_t;
 
-#define MAX_INST 16
+static int comp_id;
+static char *compname = "pbring";
 
 MODULE_AUTHOR("Michael Haberler");
 MODULE_DESCRIPTION("Actor Test Component");
 MODULE_LICENSE("GPL");
 
-static int count = 1;
-RTAPI_MP_INT(count, "number of instances");
-
-static char *name = "pbring";
-RTAPI_MP_STRING(name,  "component name");
-
-static char *command = "command";
-RTAPI_MP_STRING(command,  "name of command ring");
-
-static int csize = 65536;
-RTAPI_MP_INT(csize, "size of command ring");
-
-static char *response = "response";
-RTAPI_MP_STRING(response,  "name of response ring");
-
-static int rsize = 65536;
-RTAPI_MP_INT(rsize, "size of response ring");
-
-static int msgsize = 0;
-RTAPI_MP_INT(msgsize, "ringbuffer allocation for outgoing messages");
+// marks this comp as instantiable so halcmd/cython API can do the right thing:
+RTAPI_TAG(HAL, HC_INSTANTIABLE);
 
 static int txnoencode = 0;
 RTAPI_MP_INT(txnoencode, "pass unencoded pb_Container struct instead of pb message");
@@ -63,16 +48,6 @@ RTAPI_MP_INT(txnoencode, "pass unencoded pb_Container struct instead of pb messa
 static int rxnodecode = 0;
 RTAPI_MP_INT(rxnodecode, "expect unencoded pb_Container struct instead of pb message");
 
-static pbring_inst_t *pbring_array; // instance data array
-static int comp_id;
-
-// if the thread function is called by different threads, rx and tx will have
-// to move to the instance data structure
-static pb_Container rx, tx;
-
-
-
-static int export_pbring(const char *name, int num, pbring_inst_t *p);
 
 static void rtapi_format_pose(char *buf, unsigned long int size,  pb_EmcPose *p)
 {
@@ -103,38 +78,28 @@ bool npb_encode_string(pb_ostream_t *stream, const pb_field_t *field, void * con
 // encode message struct in msg according to 'fields', and send off via rb
 // return 0 on success or < 0 on failure; see rtmsg_errors_t
 //
-// runtime optimization:
-// if prealloc > 0, skip the message sizing step, and allocate
-// prealloc bytes in the ringbuffer, assuming the result will fit
-// record_write_end() will prune the allocation to actual needs so
-// nothing is lost except temporarily larger buffer requirements
-// if prealloc was insufficient to hold the result, fail.
-//
 static int npb_send_msg(const void *msg, const pb_field_t *fields,
-			ringbuffer_t *rb, size_t prealloc)
+			ringbuffer_t *rb,  const hal_funct_args_t *fa)
 {
     void *buffer;
     int retval;
     size_t size;
 
-    if (prealloc == 0) {
-	// determine size
-	pb_ostream_t sstream = PB_OSTREAM_SIZING;
-	if (!pb_encode(&sstream, fields,  msg)) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-			    "%s: sizing pb_encode(): %s written=%zu\n",
-			    name, PB_GET_ERROR(&sstream), sstream.bytes_written);
-	    return NBP_SIZE_FAIL;
-	}
-	size = sstream.bytes_written;
-    } else
-	size = prealloc;
+    // determine size
+    pb_ostream_t sstream = PB_OSTREAM_SIZING;
+    if (!pb_encode(&sstream, fields,  msg)) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: sizing pb_encode(): %s written=%zu\n",
+			fa_funct_name(fa), PB_GET_ERROR(&sstream), sstream.bytes_written);
+	return NBP_SIZE_FAIL;
+    }
+    size = sstream.bytes_written;
 
     // preallocate memory in ringbuffer
     if ((retval = record_write_begin(rb, (void **)&buffer, size)) != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
-			"%s: record_write_begin(%d/%zu) failed: %d\n",
-			name, msgsize, size, retval);
+			"%s: record_write_begin(%zu) failed: %d\n",
+			fa_funct_name(fa), size, retval);
 	return RB_RESERVE_FAIL;
     }
 
@@ -142,44 +107,46 @@ static int npb_send_msg(const void *msg, const pb_field_t *fields,
     pb_ostream_t rstream = pb_ostream_from_buffer(buffer, size);
     if (!pb_encode(&rstream, fields,  msg)) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
-			"%s: pb_encode failed: %s, msgsize=%d written=%zu\n",
-			name, PB_GET_ERROR(&rstream), msgsize, rstream.bytes_written);
+			"%s: pb_encode failed: %s, size=%zu written=%zu\n",
+			fa_funct_name(fa),
+			PB_GET_ERROR(&rstream),
+			size,
+			rstream.bytes_written);
 	return NBP_ENCODE_FAIL;
     }
 
     // send it off
     if ((retval = record_write_end(rb, buffer, rstream.bytes_written))) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
-			"%s: record_write_end(%d) failed: %d\n",
-			name,  msgsize, retval);
+			"%s: record_write_end(%zu) failed: %d\n",
+			fa_funct_name(fa), size, retval);
 	return RB_WRITE_FAIL;
     }
     return 0;
 }
 
-static int decode_msg(pbring_inst_t *p,  pb_istream_t *stream)
+static int decode_msg(pbring_inst_t *p,  pb_istream_t *stream,  const hal_funct_args_t *fa)
 {
-
-    if (!pb_decode(stream, pb_Container_fields, &rx)) {
+    if (!pb_decode(stream, pb_Container_fields, &p->rx)) {
 	*(p->decodefail) += 1;
 	rtapi_print_msg(RTAPI_MSG_ERR, "%s: pb_decode(Container) failed: '%s'\n",
-			name, PB_GET_ERROR(stream));
+			fa_funct_name(fa), PB_GET_ERROR(stream));
 	return -1;
     }
 
-    if (rx.has_motcmd) {
+    if (p->rx.has_motcmd) {
 	rtapi_print_msg(RTAPI_MSG_ERR, "Container.motcmd command=%d num=%d\n",
-			rx.motcmd.command,rx.motcmd.commandNum);
-	if (rx.motcmd.has_pos) {
+			p->rx.motcmd.command,p->rx.motcmd.commandNum);
+	if (p->rx.motcmd.has_pos) {
 	    char buf[200];
-	    rtapi_format_pose(buf, sizeof(buf), &rx.motcmd.pos);
+	    rtapi_format_pose(buf, sizeof(buf), &p->rx.motcmd.pos);
 	    rtapi_print_msg(RTAPI_MSG_ERR, "motcmd: %s\n", buf);
 	}
     }
     return 0;
 }
 
-static void update_pbring(void *arg, long l)
+static int update_pbring(void *arg, const hal_funct_args_t *fa)
 {
     pbring_inst_t *p = (pbring_inst_t *) arg;
 
@@ -187,24 +154,24 @@ static void update_pbring(void *arg, long l)
     if (cmdsize < 0) {
 	// command ring empty
 	*(p->underrun) += 1;
-	return;
+	return 0;
     }
     const void *cmdbuffer = record_next(&p->to_rt_rb);
     pb_istream_t stream = pb_istream_from_buffer((void *) cmdbuffer, cmdsize);
     int retval;
 
-    if (!decode_msg(p, &stream)) {
+    if (!decode_msg(p, &stream, fa)) {
 
 	// process command here
 	// prepare reply
-	tx.has_motstat = true;
-	tx.type =  pb_ContainerType_MT_MOTSTATUS;
-	tx.note.funcs.encode = npb_encode_string;
-	tx.note.arg = "hi there!";
+	p->tx.has_motstat = true;
+	p->tx.type =  pb_ContainerType_MT_MOTSTATUS;
+	p->tx.note.funcs.encode = npb_encode_string;
+	p->tx.note.arg = "hi there!";
 
-	tx.motstat = (pb_MotionStatus) {
-	    .commandEcho = rx.motcmd.command,
-	    .commandNumEcho = rx.motcmd.commandNum,
+	p->tx.motstat = (pb_MotionStatus) {
+	    .commandEcho = p->rx.motcmd.command,
+	    .commandNumEcho = p->rx.motcmd.commandNum,
 	    .commandStatus = pb_cmd_status_t_EMCMOT_COMMAND_OK,
 	    .has_carte_pos_fb = true,
 	    .carte_pos_fb = {
@@ -219,8 +186,8 @@ static void update_pbring(void *arg, long l)
 		.a = 3.14
 	    }
 	};
-	if ((retval = npb_send_msg(&tx, pb_Container_fields,
-				   &p->from_rt_rb, msgsize))) {
+	if ((retval = npb_send_msg(&p->tx, pb_Container_fields,
+				   &p->from_rt_rb, 0))) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,"error reply failed %d", retval);
 	    *(p->sendfailed) +=1;
 	} else
@@ -228,17 +195,20 @@ static void update_pbring(void *arg, long l)
     } else {
 	char errmsg[255];
 
-	snprintf(errmsg, sizeof(errmsg), "%s: failed to decode (size %d): %s",
-		 name, cmdsize, PB_GET_ERROR(&stream));
+	rtapi_snprintf(errmsg, sizeof(errmsg),
+		       "%s: failed to decode (size %d): %s",
+		       fa_funct_name(fa),
+		       cmdsize,
+		       PB_GET_ERROR(&stream));
 
-	tx = (pb_Container) {
+	p->tx = (pb_Container) {
 	    .type = pb_ContainerType_MT_MOTSTATUS, // FIXME
 	    .note.funcs.encode = npb_encode_string,
 	    .note.arg = (void *) errmsg
 	};
 	int retval;
-	if ((retval = npb_send_msg(&tx, pb_Container_fields,
-				   &p->from_rt_rb, msgsize))) {
+	if ((retval = npb_send_msg(&p->tx, pb_Container_fields,
+				   &p->from_rt_rb, 0))) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,"error reply failed %d", retval);
 	    *(p->sendfailed) += 1;
 	} else
@@ -246,64 +216,102 @@ static void update_pbring(void *arg, long l)
     }
     record_shift(&p->to_rt_rb);
     *(p->received) += 1;
+    return 0;
 }
 
-static int create_or_attach(const char *ringname, int size, ringbuffer_t * rb)
-{
-    int retval;
 
-    // for messaging with protobuf, use record mode
-    // default mode 0 = record mode
-    if ((retval = hal_ring_new(ringname, size, 0, 0))) {
-	if (retval == -EEXIST) {
-	    rtapi_print_msg(RTAPI_MSG_INFO,
-			    "%s: using existing ring '%s'\n", name, ringname);
-	} else {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-			    "%s: failed to create new ring %s\n", name, ringname);
-	    return retval;
-	}
-    }
-    if ((retval = hal_ring_attach(ringname, rb, NULL))) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-			"%s: hal_ring_attach(%s) failed - %d\n",
-			name, command, retval);
+// constructor - init all HAL pins, params, funct etc here
+static int instantiate(const char *name, const int argc, const char**argv)
+{
+    struct inst_data *inst;
+    int retval, inst_id;
+
+    // allocate a named instance, and some HAL memory for the instance data
+    if ((inst_id = hal_inst_create(name, comp_id,
+				   sizeof(pbring_inst_t),
+				   (void **)&inst)) < 0)
+	return inst_id; // HAL library will log the failure cause
+
+    pbring_inst_t *p = (pbring_inst_t *)inst;
+    if ((retval = hal_pin_u32_newf(HAL_OUT, &(p->underrun),
+				   inst_id, "%s.underrun", name)))
 	return retval;
+    if ((retval = hal_pin_u32_newf(HAL_OUT, &(p->received),
+				   inst_id, "%s.received", name)))
+	return retval;
+    if ((retval = hal_pin_u32_newf(HAL_OUT, &(p->sent),
+				   inst_id, "%s.sent", name)))
+	return retval;
+    if ((retval = hal_pin_u32_newf(HAL_OUT, &(p->sendfailed),
+				   inst_id, "%s.sendfailed", name)))
+	return retval;
+    if ((retval = hal_pin_u32_newf(HAL_OUT, &(p->decodefail),
+				   inst_id, "%s.decodefail", name)))
+	return retval;
+    *(p->underrun) = 0;
+    *(p->received) = 0;
+    *(p->sent) = 0;
+    *(p->sendfailed) = 0;
+    *(p->decodefail) = 0;
+
+    unsigned flags;
+    if ((retval = hal_ring_attachf(&(p->to_rt_rb), &flags,  "%s.in", name)) < 0)
+	return retval;
+    if ((flags & RINGTYPE_MASK) != RINGTYPE_RECORD) {
+	HALERR("ring %s.in not a record mode ring: mode=%d",name, flags & RINGTYPE_MASK);
+	return -EINVAL;
     }
-    return 0;
+    if ((retval = hal_ring_attachf(&(p->from_rt_rb), &flags,  "%s.out", name)) < 0)
+	return retval;
+    if ((flags & RINGTYPE_MASK) != RINGTYPE_RECORD) {
+	HALERR("ring %s.out not a record mode ring: mode=%d",name, flags & RINGTYPE_MASK);
+	return -EINVAL;
+    }
+    p->to_rt_rb.header->reader = inst_id;
+    p->from_rt_rb.header->writer = inst_id;
+
+    // exporting as extended thread function:
+    hal_export_xfunct_args_t update_xf = {
+        .type = FS_XTHREADFUNC,
+        .funct.x = update_pbring,
+        .arg = inst,
+        .uses_fp = 1,
+        .reentrant = 0,
+        .owner_id = inst_id
+    };
+    return hal_export_xfunctf(&update_xf, "%s.update", name);
+}
+
+static int delete(const char *name, void *inst, const int inst_size)
+{
+    pbring_inst_t *p = (pbring_inst_t *)inst;
+    int retval;
+    char ringname[HAL_NAME_LEN + 1];
+
+    rtapi_snprintf(ringname, sizeof(ringname), "%s.in", name);
+    p->to_rt_rb.header->reader = 0;
+    if ((retval = hal_ring_detach(ringname, &p->to_rt_rb)) < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: hal_ring_detach(%s) failed: %d\n",
+			name, ringname, retval);
+    }
+    p->from_rt_rb.header->writer = 0;
+    rtapi_snprintf(ringname, sizeof(ringname), "%s.out", name);
+    if ((retval = hal_ring_detach(ringname, &p->from_rt_rb)) < 0)
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: hal_ring_detach(%s) failed: %d\n",
+			name, ringname, retval);
+    return retval;
 }
 
 int rtapi_app_main(void)
 {
-    int i, retval;
-
-    if ((count <= 0) || (count > MAX_INST)) {
+    comp_id = hal_xinit(TYPE_RT, 0, 0, instantiate, delete, compname);
+    if (comp_id  < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
-			"%s: ERROR: invalid count: %d\n", name, count);
-	return -1;
-    }
-    if ((comp_id = hal_init(name)) < 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-			"%s: ERROR: hal_init(%s) failed: %d\n",
-			name, name, comp_id);
+			"%s: ERROR: hal_xinit(%s) failed: %d\n",
+			compname, compname, comp_id);
 	return comp_id;
-    }
-
-    pbring_array = hal_malloc(count * sizeof(pbring_inst_t));
-    if (pbring_array == 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-			"%s: ERROR: hal_malloc() failed\n", name);
-	hal_exit(comp_id);
-	return -1;
-    }
-
-    for (i = 0; i < count; i++) {
-	if ((retval = export_pbring(name, i, &pbring_array[i]))) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-			    "%s: ERROR: var export failed\n", name);
-	    hal_exit(comp_id);
-	    return -1;
-	}
     }
 
     hal_ready(comp_id);
@@ -312,80 +320,5 @@ int rtapi_app_main(void)
 
 void rtapi_app_exit(void)
 {
-    int i, retval;
-    char ringname[HAL_NAME_LEN + 1];
-
-    for (i = 0; i < count; i++) {
-	pbring_inst_t *p = &pbring_array[i];
-
-	rtapi_snprintf(ringname, sizeof(ringname), "%s.%d.in", name, i);
-	p->to_rt_rb.header->reader = 0;
-	if ((retval = hal_ring_detach(ringname, &p->to_rt_rb)) < 0)
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-			    "%s: hal_ring_detach(%s) failed: %d\n",
-			    name, ringname, retval);
-	// hal_ring_delete(ringname, comp_id);
-
-	p->from_rt_rb.header->writer = 0;
-	rtapi_snprintf(ringname, sizeof(ringname), "%s.%d.out", name, i);
-	if ((retval = hal_ring_detach(ringname, &p->from_rt_rb)) < 0)
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-			    "%s: hal_ring_detach(%s) failed: %d\n",
-			    name, ringname, retval);
-	// hal_ring_delete(ringname, comp_id);
-    }
     hal_exit(comp_id);
-}
-
-static int export_pbring(const char *comp, int n, pbring_inst_t *p)
-{
-    int retval;
-    char name[HAL_NAME_LEN + 1];
-
-    if ((retval = hal_pin_u32_newf(HAL_OUT, &(p->underrun),
-				      comp_id, "%s.%d.underrun", comp, n)))
-	return retval;
-
-    if ((retval = hal_pin_u32_newf(HAL_OUT, &(p->received),
-				      comp_id, "%s.%d.received", comp, n)))
-	return retval;
-
-    if ((retval = hal_pin_u32_newf(HAL_OUT, &(p->sent),
-				      comp_id, "%s.%d.sent", comp, n)))
-	return retval;
-
-    if ((retval = hal_pin_u32_newf(HAL_OUT, &(p->sendfailed),
-				      comp_id, "%s.%d.sendfailed", comp, n)))
-	return retval;
-
-    if ((retval = hal_pin_u32_newf(HAL_OUT, &(p->decodefail),
-				      comp_id, "%s.%d.decodefail", comp, n)))
-	return retval;
-
-    *(p->underrun) = 0;
-    *(p->received) = 0;
-    *(p->sent) = 0;
-    *(p->sendfailed) = 0;
-    *(p->decodefail) = 0;
-
-    rtapi_snprintf(name, sizeof(name), "%s.%d.in", comp, n);
-    if ((retval = create_or_attach(name, csize, &(p->to_rt_rb))))
-	return retval;
-
-    rtapi_snprintf(name, sizeof(name), "%s.%d.out", comp, n);
-    if ((retval = create_or_attach(name, rsize, &(p->from_rt_rb))))
-	return retval;
-
-    p->to_rt_rb.header->reader = comp_id;
-    p->from_rt_rb.header->writer = comp_id;
-
-    rtapi_snprintf(name, sizeof(name), "%s.%d.update", comp, n);
-    if ((retval = hal_export_funct(name, update_pbring, &(pbring_array[n]),
-				   1, 0, comp_id))) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-			"%s: ERROR: %s funct export failed\n", comp, name);
-	hal_exit(comp_id);
-	return -1;
-    }
-    return 0;
 }

--- a/src/rtapi/rtapi_compat.c
+++ b/src/rtapi/rtapi_compat.c
@@ -644,3 +644,41 @@ const char *get_cap(const char *const fname, const char *cap)
     free(cv);
     return NULL;
 }
+
+int rtapi_get_tags(const char *mod_name)
+{
+    char modpath[PATH_MAX];
+    int result = 0, n = 0;
+    char *cp1 = "";
+
+    flavor_ptr flavor = default_flavor();
+
+    if (kernel_threads(flavor)) {
+	if (module_path(modpath, mod_name) < 0) {
+	    perror("module_path");
+	    return -1;
+	}
+    } else {
+	if (get_rtapi_config(modpath,"RTLIB_DIR",PATH_MAX) != 0) {
+	    perror("cant get  RTLIB_DIR ?\n");
+	    return -1;
+	}
+	strcat(modpath,"/");
+	strcat(modpath, flavor->name);
+	strcat(modpath,"/");
+	strcat(modpath,mod_name);
+	strcat(modpath, flavor->mod_ext);
+    }
+    const char **caps = get_caps(modpath);
+
+    char **p = (char **)caps;
+    while (p && *p && strlen(*p)) {
+	cp1 = *p++;
+	if (strncmp(cp1,"HAL=", 4) == 0) {
+	    n = strtol(&cp1[4], NULL, 10);
+	    result |=  n ;
+	}
+    }
+    free(caps);
+    return result;
+}

--- a/src/rtapi/rtapi_compat.h
+++ b/src/rtapi/rtapi_compat.h
@@ -192,6 +192,11 @@ const char **get_caps(const char *const fname);
 const char *get_cap(const char *const fname, const char *cap);
 
 
+// given a module name and the flavor set, return the integer
+// capability mask of tags.
+int rtapi_get_tags(const char *mod_name);
+
+
 SUPPORT_END_DECLS
 
 #endif // MODULE


### PR DESCRIPTION
this branch does:

- fix instcomp - issue with extra_inst_delete fixed thanks to Mick
- improve on the hal/icomp-examples
- make the machinetalk/msgcomponents/pbring,c/pbring-demo.hal use the instantiation feature
- fix a few nits in the Cython bindings, thanks to Alex
- fix a nit with instance deletion and HAL locking

this is basically the cython-fixes branch plus example improvements, but with the nosetest runtest deleted because it makes the RTAI build slave unhappy.
