### PR TITLE
machinetalk/mkwrapper: adding default INCREMENTS value

### DIFF
--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -705,7 +705,7 @@ class LinuxCNCWrapper():
             value = float(self.ini.find('DISPLAY', 'MIN_ANGULAR_VELOCITY') or 0.01)
             modified |= self.update_config_value('min_angular_velocity', value)
 
-            value = self.ini.find('DISPLAY', 'INCREMENTS') or ''
+            value = self.ini.find('DISPLAY', 'INCREMENTS') or '1.0 0.1 0.01 0.001'
             modified |= self.update_config_value('increments', value)
 
             value = self.ini.find('DISPLAY', 'GRIDS') or ''


### PR DESCRIPTION
Axis has a default `INCREMENTS` value so Mkwrapper should have one too.