### PR TITLE
hal/types: hal_data_u unsigned was signed

### DIFF
--- a/src/hal/i_components/out_to_io.icomp
+++ b/src/hal/i_components/out_to_io.icomp
@@ -9,7 +9,7 @@ pin io float out_float;
 pin io bit out_bit;
 
 variable hal_u32_t last_u32 = 1;
-variable hal_u32_t last_s32 = 1;
+variable hal_s32_t last_s32 = 1;
 variable hal_u32_t last_float = 1;
 variable hal_u32_t last_bit = 1;
 

--- a/src/hal/lib/hal.h
+++ b/src/hal/lib/hal.h
@@ -499,7 +499,7 @@ typedef __u64 ireal_t __attribute__((aligned(8))); // integral type as wide as r
 typedef union {
     hal_bit_t b;
     hal_s32_t s;
-    hal_s32_t u;
+    hal_u32_t u;
     hal_float_t f;
 } hal_data_u;
 

--- a/src/hal/lib/hal_group.c
+++ b/src/hal/lib/hal_group.c
@@ -657,7 +657,7 @@ int hal_cgroup_match(hal_compiled_group_t *cg)
     hal_sig_t *sig;
     hal_bit_t halbit;
     hal_s32_t hals32;
-    hal_s32_t halu32;
+    hal_u32_t halu32;
     hal_float_t halfloat,delta;
 
     HAL_ASSERT(cg->magic ==  CGROUP_MAGIC);

--- a/src/hal/lib/hal_rcomp.c
+++ b/src/hal/lib/hal_rcomp.c
@@ -381,7 +381,7 @@ int hal_ccomp_match(hal_compiled_comp_t *cc)
     int i, nchanged = 0;
     hal_bit_t halbit;
     hal_s32_t hals32;
-    hal_s32_t halu32;
+    hal_u32_t halu32;
     hal_float_t halfloat,delta;
     hal_pin_t *pin;
     hal_sig_t *sig;


### PR DESCRIPTION
see also: https://sourceforge.net/p/emc/bugs/428/

and thanks to type-casting until the cows come home, this was never detected