### PR TITLE
Bug-fix, fix typo of trailing period in scripts/linuxcnc.in

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -57,7 +57,7 @@ if [ ! -d "$HOME/machinekit" ]; then
     else
         mkdir -p $HOME/machinekit
 	echo "Creating machinekit directory"
-        chown -R $USER:$USER $HOME/machinekit.
+        chown -R $USER:$USER $HOME/machinekit
     fi
 fi
 


### PR DESCRIPTION
Will prevent chown operation from succeeding

Signed-off-by: Mick <arceye@mgware.co.uk>