### PR TITLE
Launcher updates

### DIFF
--- a/lib/python/machinekit/launcher.py
+++ b/lib/python/machinekit/launcher.py
@@ -108,11 +108,22 @@ def stop_processes():
 def load_hal_file(filename, ini=None):
     sys.stdout.write("loading " + filename + '... ')
     sys.stdout.flush()
-    command = 'halcmd'
-    if ini is not None:
-        command += ' -i ' + ini
-    command += ' -f ' + filename
-    subprocess.check_call(command, shell=True)
+
+    _, ext = os.path.splitext(filename)
+    if ext == '.py':
+        from machinekit import rtapi
+        if not rtapi.__rtapicmd:
+            rtapi.init_RTAPI()
+        if ini is not None:
+            from machinekit import config
+            config.load_ini(ini)
+        execfile(filename)
+    else:
+        command = 'halcmd'
+        if ini is not None:
+            command += ' -i ' + ini
+        command += ' -f ' + filename
+        subprocess.check_call(command, shell=True)
     sys.stdout.write('done\n')
 
 

--- a/lib/python/machinekit/launcher.py
+++ b/lib/python/machinekit/launcher.py
@@ -7,6 +7,7 @@ from machinekit import compat
 
 _processes = []
 _realtimeStarted = False
+_exiting = False
 
 
 # ends a running Machinekit session
@@ -234,8 +235,12 @@ def register_exit_handler():
 def _exitHandler(signum, frame):
     del signum  # unused
     del frame  # unused
-    end_session()
-    sys.exit(0)
+    global _exiting
+
+    if not _exiting:
+        _exiting = True  # prevent double execution
+        end_session()
+        sys.exit(0)
 
 
 # set the Machinekit debug level

--- a/src/hal/cython/machinekit/rtapi.pyx
+++ b/src/hal/cython/machinekit/rtapi.pyx
@@ -297,8 +297,8 @@ def init_RTAPI(**kwargs):
     if not __rtapicmd:
         __rtapicmd = RTAPIcommand(**kwargs)
         for method in dir(__rtapicmd):
-            if callable(getattr(__rtapicmd, method)) and method is not '__init__':
-                setattr(sys.modules[__name__], method, getattr(__rtapicmd, method))
+            if callable(getattr(__rtapicmd, method)) and not method.startswith('__'):
+                 setattr(sys.modules[__name__], method, getattr(__rtapicmd, method))
     else:
         raise RuntimeError('RTAPIcommand already initialized')
     if not __rtapicmd:


### PR DESCRIPTION
A set of patches that fix problems and add features related to launching Python HAL configurations
- added support for .py files to lluncher.load_hal_file()
- prevent double execution of exit handler
- fix adding system functions to module when running rtapi.init_RTAPI()