### PR TITLE
xenomai-user: do not unlock RT memory on module exit

### DIFF
--- a/src/rtapi/xenomai.c
+++ b/src/rtapi/xenomai.c
@@ -60,7 +60,6 @@ int _rtapi_init(const char *modname) {
 }
 
 int _rtapi_exit(int module_id) {
-  munlockall();
   return 0;
 }
 


### PR DESCRIPTION
each RT comp which calls hal_exit() on unload eventually calls on
_rtapi_exit() - which is a per component-exit, not a shutdown-type call

unlocking the RT memory on comp exit is a pretty bad idea as it may make
rtapi_app susceptible to page stealing.

Signed-off-by: Michael Haberler <git@mah.priv.at>