### PR TITLE
canon: fix bug , non-NCD arcs on machines with ABCUVW axes

### DIFF
--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -1518,18 +1518,18 @@ void ARC_FEED(int line_number,
 
         get_last_pos(lx, ly, lz);
 
-        a = FROM_PROG_ANG(a);
-        b = FROM_PROG_ANG(b);
-        c = FROM_PROG_ANG(c);
-        u = FROM_PROG_LEN(u);
-        v = FROM_PROG_LEN(v);
-        w = FROM_PROG_LEN(w);
-
         double fe=FROM_PROG_LEN(first_end), se=FROM_PROG_LEN(second_end), ae=FROM_PROG_LEN(axis_end_point);
         double fa=FROM_PROG_LEN(first_axis), sa=FROM_PROG_LEN(second_axis);
         rotate_and_offset_pos(fe, se, ae, unused, unused, unused, unused, unused, unused);
         rotate_and_offset_pos(fa, sa, unused, unused, unused, unused, unused, unused, unused);
         if (chord_deviation(lx, ly, fe, se, fa, sa, rotation, mx, my) < canonNaivecamTolerance) {
+	    a = FROM_PROG_ANG(a);
+	    b = FROM_PROG_ANG(b);
+	    c = FROM_PROG_ANG(c);
+	    u = FROM_PROG_LEN(u);
+	    v = FROM_PROG_LEN(v);
+	    w = FROM_PROG_LEN(w);
+	    
             rotate_and_offset_pos(unused, unused, unused, a, b, c, u, v, w);
             see_segment(line_number, _tag, mx, my,
                         (lz + ae)/2, 


### PR DESCRIPTION
canon: fix bug , non-NCD arcs on machines with ABCUVW axes

    Arcs in the XY plane that fail Naive CAM collapsing would
accidentally convert the ABCUVW destination from program coordinates to
canonical coordinates twice, and get ridiculous endpoints as a result.

    Thanks to Todd Zuercher for the bug report.