### PR TITLE
czmq-watch.c/h: change license to MPL 2.0

### DIFF
--- a/src/machinetalk/include/czmq-watch.h
+++ b/src/machinetalk/include/czmq-watch.h
@@ -1,3 +1,8 @@
+/* avahi event loopt adapter for czmq
+ *
+ * Copyright Michael Haberler 2013-2015
+ * License: Mozilla Public License Version 2.0
+ */
 #ifndef _czmq_watch_h
 #define _czmq_watch_h
 

--- a/src/machinetalk/include/ll-zeroconf.hh
+++ b/src/machinetalk/include/ll-zeroconf.hh
@@ -1,6 +1,9 @@
 /*
  * minimalistic zeroconf publish interface
  * low-level Avahi interface, avahi poll loop integration
+ *
+ * Copyright Michael Haberler 2013-2015
+ * License: Mozilla Public License Version 2.0
  */
 
 #ifndef _LL_ZEROCONF_H

--- a/src/machinetalk/include/mk-zeroconf-types.h
+++ b/src/machinetalk/include/mk-zeroconf-types.h
@@ -1,3 +1,10 @@
+/**
+ * machinekit SRV record types
+ *
+ * Copyright Michael Haberler 2013-2015
+ * License: Mozilla Public License Version 2.0
+*/
+
 #ifndef _MK_ZEROCONF_TYPES_H
 #define _MK_ZEROCONF_TYPES_H
 

--- a/src/machinetalk/include/mk-zeroconf.hh
+++ b/src/machinetalk/include/mk-zeroconf.hh
@@ -1,4 +1,7 @@
 /* zeroconf announce/withdraw tailored for machinekit purposes
+ *
+ * Copyright Michael Haberler 2013-2015
+ * License: Mozilla Public License Version 2.0
  */
 
 #ifndef _MK_ZEROCONF_HH

--- a/src/machinetalk/lib/czmq-watch.c
+++ b/src/machinetalk/lib/czmq-watch.c
@@ -1,3 +1,9 @@
+/* avahi event loopt adapter for czmq
+ *
+ * Copyright Michael Haberler 2013-2015
+ * License: Mozilla Public License Version 2.0
+ */
+
 #include <avahi-common/llist.h>
 #include <avahi-common/malloc.h>
 #include <avahi-common/timeval.h>
@@ -129,7 +135,6 @@ static void watch_free(AvahiWatch *w)
     assert(w);
     if (w->poller.fd > -1) {
 	zloop_poller_end(w->czmq_poll->loop, &w->poller);
-	// w->czmq_poll->loop = 0;
     }
     w->poller.fd = -1;
 }

--- a/src/machinetalk/lib/ll_zeroconf_register.cc
+++ b/src/machinetalk/lib/ll_zeroconf_register.cc
@@ -2,8 +2,8 @@
  * zeroconf register interface / low level register/unregister
  * czmq reactor compatible
  *
- * Michael Haberler 2014
- * based on distcc code by Lennart Poettering,  Copyright (C) 2007
+ * Copyright Michael Haberler 2014-2015
+ * License: Mozilla Public License Version 2.0
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/machinetalk/lib/mk_zeroconf.cc
+++ b/src/machinetalk/lib/mk_zeroconf.cc
@@ -1,6 +1,8 @@
 /* zeroconf announce/withdraw tailored for machinekit purposes
+ *
+ * Copyright Michael Haberler 2014-2015
+ * License: Mozilla Public License Version 2.0
  */
-
 #include "mk-zeroconf.hh"
 
 

--- a/src/machinetalk/lib/zeroconf_resolve.cc
+++ b/src/machinetalk/lib/zeroconf_resolve.cc
@@ -1,21 +1,9 @@
 //   client resolve API for the rest of us
 //   blocking API with timout, no czmq integration
 //
-//   Michael Haberler, 2014
+//   Copyright Michael Haberler, 2014
+//   License: Mozilla Public License Version 2.0
 //
-//   avahi is free software; you can redistribute it and/or modify it
-//   under the terms of the GNU Lesser General Public License as
-//   published by the Free Software Foundation; either version 2.1 of the
-//   License, or (at your option) any later version.
-//
-//   avahi is distributed in the hope that it will be useful, but WITHOUT
-//   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-//   or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
-//   Public License for more details.
-//
-//   You should have received a copy of the GNU Lesser General Public
-//   License along with avahi; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
 
 #include <stdio.h>
 #include <assert.h>

--- a/src/machinetalk/lib/zeroconf_resolve_test.cc
+++ b/src/machinetalk/lib/zeroconf_resolve_test.cc
@@ -1,21 +1,7 @@
 //   client resolve API test program using ll_zeroconf_resolve();
 //
-//   Michael Haberler, 2014
-//
-//   avahi is free software; you can redistribute it and/or modify it
-//   under the terms of the GNU Lesser General Public License as
-//   published by the Free Software Foundation; either version 2.1 of the
-//   License, or (at your option) any later version.
-//
-//   avahi is distributed in the hope that it will be useful, but WITHOUT
-//   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-//   or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
-//   Public License for more details.
-//
-//   You should have received a copy of the GNU Lesser General Public
-//   License along with avahi; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
-
+//   Copyright Michael Haberler, 2014
+//   License: Mozilla Public License Version 2.0
 #include <stdio.h>
 #include <assert.h>
 #include <stdlib.h>


### PR DESCRIPTION
I was asked to relicense as non-GPL
while at it, relicense as MPL2.0 so it could be integrated into czmq