### PR TITLE
Mkwrapper and Mklauncher multiprocessing and ZMQ patterns

### DIFF
--- a/src/machinetalk/config-service/configserver.py
+++ b/src/machinetalk/config-service/configserver.py
@@ -123,7 +123,7 @@ class ConfigServer:
         if self.debug:
             print(("send_msg " + str(self.tx)))
         self.tx.Clear()
-        self.socket.send_multipart([dest, txBuffer])
+        self.socket.send_multipart([dest, txBuffer], zmq.NOBLOCK)
 
     def list_apps(self, origin):
         for name in self.cfg.sections():

--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -357,7 +357,7 @@ class LinuxCNCWrapper():
         self.errorPort = self.errorSocket.bind_to_random_port(self.baseUri)
         self.errorDsname = self.errorSocket.get_string(zmq.LAST_ENDPOINT, encoding='utf-8')
         self.errorDsname = self.errorDsname.replace('0.0.0.0', self.host)
-        self.commandSocket = context.socket(zmq.DEALER)
+        self.commandSocket = context.socket(zmq.ROUTER)
         self.commandPort = self.commandSocket.bind_to_random_port(self.baseUri)
         self.commandDsname = self.commandSocket.get_string(zmq.LAST_ENDPOINT, encoding='utf-8')
         self.commandDsname = self.commandDsname.replace('0.0.0.0', self.host)
@@ -1220,11 +1220,11 @@ class LinuxCNCWrapper():
             self.errorSocket.send_multipart([topic, txBuffer], zmq.NOBLOCK)
             self.txError.Clear()
 
-    def send_command_msg(self, type):
+    def send_command_msg(self, identity, type):
         with self.errorLock:
             self.txCommand.type = type
             txBuffer = self.txCommand.SerializeToString()
-            self.commandSocket.send(txBuffer, zmq.NOBLOCK)
+            self.commandSocket.send_multipart([identity, txBuffer], zmq.NOBLOCK)
             self.txCommand.Clear()
 
     def add_pparams(self):
@@ -1354,23 +1354,23 @@ class LinuxCNCWrapper():
                 gcodes.append('G' + str(rawGCode / 10.0))
         return ' '.join(gcodes)
 
-    def send_command_wrong_params(self):
+    def send_command_wrong_params(self, identity):
         self.txCommand.note.append("wrong parameters")
-        self.send_command_msg(MT_ERROR)
+        self.send_command_msg(identity, MT_ERROR)
 
     def process_command(self, socket):
         if self.debug:
             print("process command called")
 
-        message = socket.recv()
+        (identity, message) = socket.recv_multipart()
         self.rx.ParseFromString(message)
 
         try:
             if self.rx.type == MT_PING:
-                self.send_command_msg(MT_PING_ACKNOWLEDGE)
+                self.send_command_msg(identity, MT_PING_ACKNOWLEDGE)
 
             elif self.rx.type == MT_SHUTDOWN:
-                self.send_command_msg(MT_CONFIRM_SHUTDOWN)
+                self.send_command_msg(identity, MT_CONFIRM_SHUTDOWN)
                 self.stop()  # trigger the shutdown event
 
             elif self.rx.type == MT_EMC_TASK_ABORT:
@@ -1380,28 +1380,28 @@ class LinuxCNCWrapper():
                     elif self.rx.interp_name == 'preview':
                         self.preview.abort()
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TASK_PLAN_PAUSE:
                 if self.rx.HasField('interp_name'):
                     if self.rx.interp_name == 'execute':
                         self.command.auto(linuxcnc.AUTO_PAUSE)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TASK_PLAN_RESUME:
                 if self.rx.HasField('interp_name'):
                     if self.rx.interp_name == 'execute':
                         self.command.auto(linuxcnc.AUTO_RESUME)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TASK_PLAN_STEP:
                 if self.rx.HasField('interp_name'):
                     if self.rx.interp_name == 'execute':
                         self.command.auto(linuxcnc.AUTO_STEP)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TASK_PLAN_RUN:
                 if self.rx.HasField('emc_command_params') \
@@ -1414,7 +1414,7 @@ class LinuxCNCWrapper():
                         self.preview.unitcode = "G%d" % (20 + (self.stat.linear_units == 1))
                         self.preview.start()
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_SPINDLE_BRAKE_ENGAGE:
                 self.command.brake(linuxcnc.BRAKE_ENGAGE)
@@ -1428,7 +1428,7 @@ class LinuxCNCWrapper():
                     debugLevel = self.rx.emc_command_params.debug_level
                     self.command.debug(debugLevel)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TRAJ_SET_SCALE:
                 if self.rx.HasField('emc_command_params') \
@@ -1436,7 +1436,7 @@ class LinuxCNCWrapper():
                     feedrate = self.rx.emc_command_params.scale
                     self.command.feedrate(feedrate)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_COOLANT_FLOOD_ON:
                 self.command.flood(linuxcnc.FLOOD_ON)
@@ -1450,7 +1450,7 @@ class LinuxCNCWrapper():
                     axis = self.rx.emc_command_params.index
                     self.command.home(axis)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_AXIS_ABORT:
                 if self.rx.HasField('emc_command_params') \
@@ -1458,7 +1458,7 @@ class LinuxCNCWrapper():
                     axis = self.rx.emc_command_params.index
                     self.command.jog(linuxcnc.JOG_STOP, axis)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_AXIS_JOG:
                 if self.rx.HasField('emc_command_params') \
@@ -1468,7 +1468,7 @@ class LinuxCNCWrapper():
                     velocity = self.rx.emc_command_params.velocity
                     self.command.jog(linuxcnc.JOG_CONTINUOUS, axis, velocity)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_AXIS_INCR_JOG:
                 if self.rx.HasField('emc_command_params') \
@@ -1480,7 +1480,7 @@ class LinuxCNCWrapper():
                     distance = self.rx.emc_command_params.distance
                     self.command.jog(linuxcnc.JOG_INCREMENT, axis, velocity, distance)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TOOL_LOAD_TOOL_TABLE:
                 self.command.load_tool_table()
@@ -1491,7 +1491,7 @@ class LinuxCNCWrapper():
                     velocity = self.rx.emc_command_params.velocity
                     self.command.maxvel(velocity)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TASK_PLAN_EXECUTE:
                 if self.rx.HasField('emc_command_params') \
@@ -1501,7 +1501,7 @@ class LinuxCNCWrapper():
                         command = self.rx.emc_command_params.command
                         self.command.mdi(command)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_COOLANT_MIST_ON:
                 self.command.mist(linuxcnc.MIST_ON)
@@ -1516,7 +1516,7 @@ class LinuxCNCWrapper():
                     if self.rx.interp_name == 'execute':
                         self.command.mode(self.rx.emc_command_params.task_mode)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_AXIS_OVERRIDE_LIMITS:
                 self.command.override_limits()
@@ -1533,14 +1533,14 @@ class LinuxCNCWrapper():
                         elif self.rx.interp_name == 'preview':
                             self.preview.program_open(fileName)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TASK_PLAN_INIT:
                 if self.rx.HasField('interp_name'):
                     if self.rx.interp_name == 'execute':
                         self.command.reset_interpreter()
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_MOTION_ADAPTIVE:
                 if self.rx.HasField('emc_command_params') \
@@ -1548,7 +1548,7 @@ class LinuxCNCWrapper():
                     adaptiveFeed = self.rx.emc_command_params.enable
                     self.command.set_adaptive_feed(adaptiveFeed)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_MOTION_SET_AOUT:
                 if self.rx.HasField('emc_command_params') \
@@ -1558,7 +1558,7 @@ class LinuxCNCWrapper():
                     value = self.rx.emc_command_params.value
                     self.command.set_analog_output(axis, value)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TASK_PLAN_SET_BLOCK_DELETE:
                 if self.rx.HasField('emc_command_params') \
@@ -1566,7 +1566,7 @@ class LinuxCNCWrapper():
                     blockDelete = self.rx.emc_command_params.enable
                     self.command.set_block_delete(blockDelete)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_MOTION_SET_DOUT:
                 if self.rx.HasField('emc_command_params') \
@@ -1576,7 +1576,7 @@ class LinuxCNCWrapper():
                     value = self.rx.emc_command_params.enable
                     self.command.set_digital_output(axis, value)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TRAJ_SET_FH_ENABLE:
                 if self.rx.HasField('emc_command_params') \
@@ -1584,7 +1584,7 @@ class LinuxCNCWrapper():
                     feedHold = self.rx.emc_command_params.enable
                     self.command.set_feed_hold(feedHold)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TRAJ_SET_FO_ENABLE:
                 if self.rx.HasField('emc_command_params') \
@@ -1592,7 +1592,7 @@ class LinuxCNCWrapper():
                     feedOverride = self.rx.emc_command_params.enable
                     self.command.set_feed_override(feedOverride)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_AXIS_SET_MAX_POSITION_LIMIT:
                 if self.rx.HasField('emc_command_params') \
@@ -1602,7 +1602,7 @@ class LinuxCNCWrapper():
                     value = self.rx.emc_command_params.value
                     self.command.set_max_limit(axis, value)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_AXIS_SET_MIN_POSITION_LIMIT:
                 if self.rx.HasField('emc_command_params') \
@@ -1612,7 +1612,7 @@ class LinuxCNCWrapper():
                     value = self.rx.emc_command_params.value
                     self.command.set_min_limit(axis, value)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TASK_PLAN_SET_OPTIONAL_STOP:
                 if self.rx.HasField('emc_command_params') \
@@ -1620,7 +1620,7 @@ class LinuxCNCWrapper():
                     optionalStop = self.rx.emc_command_params.enable
                     self.command.set_optional_stop(optionalStop)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TRAJ_SET_SO_ENABLE:
                 if self.rx.HasField('emc_command_params') \
@@ -1628,7 +1628,7 @@ class LinuxCNCWrapper():
                     spindleOverride = self.rx.emc_command_params.enable
                     self.command.set_spindle_override(spindleOverride)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_SPINDLE_ON:
                 if self.rx.HasField('emc_command_params') \
@@ -1637,7 +1637,7 @@ class LinuxCNCWrapper():
                     direction = linuxcnc.SPINDLE_FORWARD    # always forwward, speed can be signed
                     self.command.spindle(direction, speed)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_SPINDLE_INCREASE:
                 self.command.spindle(linuxcnc.SPINDLE_INCREASE)
@@ -1657,7 +1657,7 @@ class LinuxCNCWrapper():
                     scale = self.rx.emc_command_params.scale
                     self.command.spindleoverride(scale)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TASK_SET_STATE:
                 if self.rx.HasField('emc_command_params') \
@@ -1666,7 +1666,7 @@ class LinuxCNCWrapper():
                     if self.rx.interp_name == 'execute':
                         self.command.state(self.rx.emc_command_params.task_state)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TRAJ_SET_TELEOP_ENABLE:
                 if self.rx.HasField('emc_command_params') \
@@ -1674,7 +1674,7 @@ class LinuxCNCWrapper():
                     teleopEnable = self.rx.emc_command_params.enable
                     self.command.teleop_enable(teleopEnable)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TRAJ_SET_TELEOP_VECTOR:
                 if self.rx.HasField('emc_command_params') \
@@ -1699,7 +1699,7 @@ class LinuxCNCWrapper():
                     else:
                         self.command.teleop_vector(a, b, c)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TOOL_SET_OFFSET:
                 if self.rx.HasField('emc_command_params') \
@@ -1721,14 +1721,14 @@ class LinuxCNCWrapper():
                     self.command.tool_offset(toolno, z_offset, x_offset, diameter,
                         frontangle, backangle, orientation)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_TRAJ_SET_MODE:
                 if self.rx.HasField('emc_command_params') \
                 and self.rx.emc_command_params.HasField('traj_mode'):
                     self.command.traj_mode(self.rx.emc_command_params.traj_mode)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             elif self.rx.type == MT_EMC_AXIS_UNHOME:
                 if self.rx.HasField('emc_command_params') \
@@ -1736,11 +1736,11 @@ class LinuxCNCWrapper():
                     axis = self.rx.emc_command_params.index
                     self.command.unhome(axis)
                 else:
-                    self.send_command_wrong_params()
+                    self.send_command_wrong_params(identity)
 
             else:
                 self.txCommand.note.append("unknown command")
-                self.send_command_msg(MT_ERROR)
+                self.send_command_msg(identity, MT_ERROR)
 
         except linuxcnc.error as detail:
             self.add_error(detail)

--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -1221,7 +1221,7 @@ class LinuxCNCWrapper():
             self.txError.Clear()
 
     def send_command_msg(self, identity, type):
-        with self.errorLock:
+        with self.commandLock:
             self.txCommand.type = type
             txBuffer = self.txCommand.SerializeToString()
             self.commandSocket.send_multipart([identity, txBuffer], zmq.NOBLOCK)


### PR DESCRIPTION
This patch contains following fixes:
- fixes socket types in mklauncher and mkwrapper (ROUTER and not DEALER)
- fixes small lock usage in mkwrapper
- use nonblocking send functions
- adds multiprocessing for the preview service in mkwrapper to fix timeout problems