### PR TITLE
Amend sample configs to reflect change in estop_latch component name.

### DIFF
--- a/configs/by_interface/parport/plasma-thc-sim/estop.hal
+++ b/configs/by_interface/parport/plasma-thc-sim/estop.hal
@@ -2,9 +2,9 @@
 #Connect Estop and ChargePump
 
 loadrt estop_latch
-addf estop-latch.0 base-thread
+addf estop_latch.0 base-thread
 
 # External Estop Signal handled by THC
-net EstopRequestEnable iocontrol.0.user-request-enable => estop-latch.0.reset
-net EstopEnableOut iocontrol.0.user-enable-out => estop-latch.0.ok-in
-net EstopOKOut estop-latch.0.ok-out => iocontrol.0.emc-enable-in
+net EstopRequestEnable iocontrol.0.user-request-enable => estop_latch.0.reset
+net EstopEnableOut iocontrol.0.user-enable-out => estop_latch.0.ok-in
+net EstopOKOut estop_latch.0.ok-out => iocontrol.0.emc-enable-in

--- a/configs/by_interface/parport/stepper-gantry/estop.hal
+++ b/configs/by_interface/parport/stepper-gantry/estop.hal
@@ -2,11 +2,11 @@
 #Connect Estop and ChargePump
 
 loadrt estop_latch
-addf estop-latch.0 base-thread
+addf estop_latch.0 base-thread
 
 # External Estop Signal handled by THC
-net ExtEStop parport.0.pin-10-in => estop-latch.0.fault-in
-net EstopLatchWatchDog estop-latch.0.watchdog => parport.0.pin-17-out parport.1.pin-17-out
-net EstopRequestEnable iocontrol.0.user-request-enable => estop-latch.0.reset
-net EstopEnableOut iocontrol.0.user-enable-out => estop-latch.0.ok-in
-net EstopOKOut estop-latch.0.ok-out => iocontrol.0.emc-enable-in
+net ExtEStop parport.0.pin-10-in => estop_latch.0.fault-in
+net EstopLatchWatchDog estop_latch.0.watchdog => parport.0.pin-17-out parport.1.pin-17-out
+net EstopRequestEnable iocontrol.0.user-request-enable => estop_latch.0.reset
+net EstopEnableOut iocontrol.0.user-enable-out => estop_latch.0.ok-in
+net EstopOKOut estop_latch.0.ok-out => iocontrol.0.emc-enable-in

--- a/configs/by_interface/pico/USC_encod/univstep_load.hal
+++ b/configs/by_interface/pico/USC_encod/univstep_load.hal
@@ -26,7 +26,7 @@ addf ppmc.0.read servo-thread
 # then run the motion controller
 addf motion-command-handler servo-thread
 addf and2.0 servo-thread
-addf estop-latch.0 servo-thread
+addf estop_latch.0 servo-thread
 addf motion-controller servo-thread
 # then the PID loops
 addf pid.0.do-pid-calcs servo-thread

--- a/configs/by_interface/pico/ppmc/ppmc_load.hal
+++ b/configs/by_interface/pico/ppmc/ppmc_load.hal
@@ -26,7 +26,7 @@ addf ppmc.0.read servo-thread
 # then run the motion controller
 addf motion-command-handler servo-thread
 addf and2.0 servo-thread
-addf estop-latch.0 servo-thread
+addf estop_latch.0 servo-thread
 addf motion-controller servo-thread
 # then the PID loops
 addf pid.0.do-pid-calcs servo-thread

--- a/configs/by_interface/pico/ppmc_vel/ppmc_load.hal
+++ b/configs/by_interface/pico/ppmc_vel/ppmc_load.hal
@@ -37,7 +37,7 @@ addf ppmc.0.read servo-thread
 # then run the motion controller
 addf motion-command-handler servo-thread
 addf and2.0 servo-thread
-addf estop-latch.0 servo-thread
+addf estop_latch.0 servo-thread
 addf motion-controller servo-thread
 # then the PID loops
 addf pid.0.do-pid-calcs servo-thread

--- a/configs/by_interface/pico/univpwm/univpwm_load.hal
+++ b/configs/by_interface/pico/univpwm/univpwm_load.hal
@@ -25,7 +25,7 @@ addf ppmc.0.read servo-thread
 # then run the motion controller
 addf motion-command-handler servo-thread
 addf and2.0 servo-thread
-addf estop-latch.0 servo-thread
+addf estop_latch.0 servo-thread
 addf motion-controller servo-thread
 # then the PID loops
 addf pid.0.do-pid-calcs servo-thread

--- a/configs/by_interface/pico/univpwmv/univpwm_load.hal
+++ b/configs/by_interface/pico/univpwmv/univpwm_load.hal
@@ -35,7 +35,7 @@ addf ppmc.0.read       servo-thread
 # then run the motion controller
 addf motion-command-handler servo-thread
 addf and2.0            servo-thread
-addf estop-latch.0     servo-thread
+addf estop_latch.0     servo-thread
 addf motion-controller servo-thread
 addf not.0	       servo-thread
 # then the PID loops

--- a/configs/by_interface/pico/univstep/univstep_load.hal
+++ b/configs/by_interface/pico/univstep/univstep_load.hal
@@ -26,7 +26,7 @@ addf ppmc.0.read servo-thread
 # then run the motion controller
 addf motion-command-handler servo-thread
 addf and2.0 servo-thread
-addf estop-latch.0 servo-thread
+addf estop_latch.0 servo-thread
 addf motion-controller servo-thread
 # then the PID loops
 addf pid.0.do-pid-calcs servo-thread

--- a/configs/by_machine/tormach/pcnc-1100.hal
+++ b/configs/by_machine/tormach/pcnc-1100.hal
@@ -9,11 +9,11 @@ setp parport.0.reset-time 4000
 loadrt stepgen step_type=0,0,0,0,0 ctrl_type=p,p,p,p,v
 
 loadrt estop_latch
-net charge-pump <= estop-latch.0.watchdog
+net charge-pump <= estop_latch.0.watchdog
 
 addf parport.0.read base-thread
 addf stepgen.make-pulses base-thread
-addf estop-latch.0 base-thread
+addf estop_latch.0 base-thread
 addf parport.0.write base-thread
 addf parport.0.reset base-thread
 
@@ -148,11 +148,11 @@ net adir <= stepgen.3.dir
 net aenable axis.3.amp-enable-out => stepgen.3.enable
 net home-a => axis.3.home-sw-in
 
-#linksp xenable estop-latch.0.ok-out
+#linksp xenable estop_latch.0.ok-out
 net estop-out <= iocontrol.0.user-enable-out
-net machine-ok => estop-latch.0.ok-in
-net estop estop-latch.0.ok-out => iocontrol.0.emc-enable-in
-net estop-reset iocontrol.0.user-request-enable => estop-latch.0.reset
+net machine-ok => estop_latch.0.ok-in
+net estop estop_latch.0.ok-out => iocontrol.0.emc-enable-in
+net estop-reset iocontrol.0.user-request-enable => estop_latch.0.reset
 
 loadusr -W hal_manualtoolchange
 net tool-change iocontrol.0.tool-change => hal_manualtoolchange.change

--- a/configs/by_machine/tormach/pcnc-770.hal
+++ b/configs/by_machine/tormach/pcnc-770.hal
@@ -9,11 +9,11 @@ setp parport.0.reset-time 4000
 loadrt stepgen step_type=0,0,0,0,0 ctrl_type=p,p,p,p,v
 
 loadrt estop_latch
-net charge-pump <= estop-latch.0.watchdog
+net charge-pump <= estop_latch.0.watchdog
 
 addf parport.0.read base-thread
 addf stepgen.make-pulses base-thread
-addf estop-latch.0 base-thread
+addf estop_latch.0 base-thread
 addf parport.0.write base-thread
 addf parport.0.reset base-thread
 
@@ -148,11 +148,11 @@ net adir <= stepgen.3.dir
 net aenable axis.3.amp-enable-out => stepgen.3.enable
 net home-a => axis.3.home-sw-in
 
-#linksp xenable estop-latch.0.ok-out
+#linksp xenable estop_latch.0.ok-out
 net estop-out <= iocontrol.0.user-enable-out
-net machine-ok => estop-latch.0.ok-in
-net estop estop-latch.0.ok-out => iocontrol.0.emc-enable-in
-net estop-reset iocontrol.0.user-request-enable => estop-latch.0.reset
+net machine-ok => estop_latch.0.ok-in
+net estop estop_latch.0.ok-out => iocontrol.0.emc-enable-in
+net estop-reset iocontrol.0.user-request-enable => estop_latch.0.reset
 
 loadusr -W hal_manualtoolchange
 net tool-change iocontrol.0.tool-change => hal_manualtoolchange.change


### PR DESCRIPTION
instcomp does not convert C style underscores in component names to dashes

This affects 10 components, but only estop_latch is used in sample
configs in a way that requires alteration
The others either actually name the component (shuttlexpress) or having loaded it
do nothing further with it (demo_mazak)

Signed-off-by: Mick <arceye@mgware.co.uk>