### PR TITLE
Minor alteration to instcomp to correct man file component names.

### DIFF
--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -1040,7 +1040,7 @@ def document(filename, outfilename):
     print >>f, ".SH PINS"
     for _, name, type, array, dir, doc, value in finddocs('pin'):
         print >>f, lead
-        print >>f, ".B %s\\fR" % to_hal_man(name),
+        print >>f, ".B %s.%s\\fR" % (comp_name, name),
         print >>f, type, dir,
         if array:
             sz = name.count("#")


### PR DESCRIPTION
Change pin printout to use comp_name, so that where C style underscore
is present in name, it matches actual component and pin names.

2nd stage to #772 (b470e9ac360b50c8bbdd87cc4717957d7862a433)

Signed-off-by: Mick <arceye@mgware.co.uk>