### PR TITLE
rtapi_app/msgd:  Fix logging to stderr

### DIFF
--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -90,6 +90,12 @@ if [ "$SHMDRV_OPTS" != "" ]  ; then
     MSGD_OPTS="$MSGD_OPTS --shmdrv_opts=$SHMDRV_OPTS"
 fi
 
+# SYSLOG_TO_STDERR:  when set, log to stdout instead of syslog
+if test -n "$SYSLOG_TO_STDERR"; then
+    MSGD_OPTS+=" -s"
+    RTAPI_APP_OPTS+=" -s"
+fi
+
 # set the default instance, if not already set
 INSTANCE=`printf '%d' $INSTANCE`
 if [ "$INSTANCE_NAME" != "" ]  ; then

--- a/src/rtapi/rtapi_msgd.cc
+++ b/src/rtapi/rtapi_msgd.cc
@@ -698,7 +698,8 @@ static struct option long_options[] = {
 int main(int argc, char **argv)
 {
     int c, i, retval;
-    int option = LOG_NDELAY;
+    int syslog_async_option = LOG_NDELAY;
+    int syslog_async_delay = 1000;
     pid_t pid, sid;
     size_t argv0_len, procname_len, max_procname_len;
 
@@ -768,7 +769,8 @@ int main(int argc, char **argv)
 	    break;
 	case 's':
 	    log_stderr++;
-	    option |= LOG_PERROR;
+	    syslog_async_option |= LOG_PERROR;
+	    syslog_async_delay = 0;
 	    break;
 	case 'R':
 	    netopts.service_uuid = strdup(optarg);
@@ -880,9 +882,9 @@ int main(int argc, char **argv)
     snprintf(proctitle, sizeof(proctitle), "msgd:%d",rtapi_instance);
     backtrace_init(proctitle);
 
-    openlog_async(proctitle, option , SYSLOG_FACILITY);
-    // max out async syslog buffers for slow system in debug mode
-    tunelog_async(99,1000);
+    openlog_async(proctitle, syslog_async_option, SYSLOG_FACILITY);
+    // tune async syslog buffers:  max buffer size; 0 delay for stdout, else 1s
+    tunelog_async(99,syslog_async_delay);
 
     // set new process name
     argv0_len = strlen(argv[0]);


### PR DESCRIPTION
`syslog_async()` behaves strangely when logging to stderr with a 1s
`log_delay` and no syslog daemon: Initial logs are printed as
expected, but once the backlog buffer fills, a single log message is
printed only once per second.

This patch papers over the problem by setting `log_delay` to 0 when
logging to stderr.  If timing in sections of code calling
`syslog_async()` are at all critical, then this isn't a general fix,
since a slow syslog daemon would introduce latency into the call.

This patch also plumbs a `rtapi_app -s` option like `rtapi_msgd -s`,
and when the `SYSLOG_TO_STDERR` environment variable is set, the
`realtime` script adds that option to both daemons.

This problem can be reproduced by running a HAL configuration in debug
mode with no running syslog daemon, a common scenario in containerized
build environments.

Also see issue #169.