### PR TITLE
Remove debug info forgotten in e5fe2053

### DIFF
--- a/tests/hm2-idrom/skip
+++ b/tests/hm2-idrom/skip
@@ -4,6 +4,4 @@
 # Skip the hm2-idrom test if not running kernel threads and the
 # hostmot2.so module doesn't exist for this flavor
 
-echo $EMC2_HOME/rtlib/$(flavor)/hostmot2.so
-ls -l $EMC2_HOME/rtlib/$(flavor)/hostmot2.so
 test "$(flavor -b)" = kbuild -o -f $EMC2_HOME/rtlib/$(flavor)/hostmot2.so


### PR DESCRIPTION
I left some debug cruft in e5fe2053; this patch removes it.