### PR TITLE
Implement dio_mask with RTAPI_BITOPS for 64+ bits of DIOs

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -172,6 +172,7 @@ do_tcl_tk_version() {
 	TCL_TK_VER=8.6
 	case "$DISTRO_ID" in
 	    Debian)  test "${DISTRO_RELEASE/.*/}" -lt 8 && TCL_TK_VER=8.5 ;;
+	    Raspbian)test "${DISTRO_RELEASE/.*/}" -lt 8 && TCL_TK_VER=8.5 ;;
 	    Ubuntu)  test "${DISTRO_RELEASE/.*/}" -lt 14 && TCL_TK_VER=8.5 ;;
 	    *)  usage "Unknown distro '${DISTRO_ID}'" ;;
 	esac

--- a/src/emc/motion/emcmotcfg.h
+++ b/src/emc/motion/emcmotcfg.h
@@ -28,10 +28,10 @@
 /* number of axes defined by the interp */ //FIXME: shouldn't be here..
 #define EMCMOT_MAX_AXIS 9
 
-#define EMCMOT_MAX_DIO 64
+#define EMCMOT_MAX_DIO 128
 #define EMCMOT_MAX_AIO 64
 
-#if (EMCMOT_MAX_DIO > 64) || (EMCMOT_MAX_AIO > 64)
+#if (EMCMOT_MAX_AIO > 64)
 #error A 64 bit bitmask is used in the planner.  Don't increase these until that's fixed.
 #endif
 

--- a/src/emc/tp/tc_types.h
+++ b/src/emc/tp/tc_types.h
@@ -20,6 +20,7 @@
 #include "emcpos.h"
 #include "emcmotcfg.h"  // EMCMOT_MAX_DIO, EMCMOT_MAX_AIO
 #include "state_tag.h"
+#include "rtapi_bitops.h"
 
 #define BLEND_DIST_FRACTION 0.5
 /* values for endFlag */
@@ -94,7 +95,7 @@ typedef unsigned long long iomask_t; // 64 bits on both x86 and x86_64
 
 typedef struct {
     char anychanged;
-    iomask_t dio_mask;
+    RTAPI_DECLARE_BITMAP(dio_mask, EMCMOT_MAX_DIO);
     iomask_t aio_mask;
     signed char dios[EMCMOT_MAX_DIO];
     double aios[EMCMOT_MAX_AIO];

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -383,7 +383,7 @@ int tpClearDIOs(TP_STRUCT * const tp) {
     //XXX: All IO's will be flushed on next synced aio/dio! Is it ok?
     unsigned int i;
     tp->syncdio.anychanged = 0;
-    tp->syncdio.dio_mask = 0ull;
+    RTAPI_ZERO_BITMAP(tp->syncdio.dio_mask, EMCMOT_MAX_DIO);
     tp->syncdio.aio_mask = 0ull;
     for (i = 0; i < get_num_dio(tp->shared); i++) {
         tp->syncdio.dios[i] = 0;
@@ -2327,7 +2327,7 @@ void tpToggleDIOs(TP_STRUCT const * const tp,
     unsigned int i = 0;
     if (tc->syncdio.anychanged != 0) { // we have DIO's to turn on or off
         for (i=0; i < get_num_dio(tp->shared); i++) {
-            if (!(tc->syncdio.dio_mask & (1ull << i))) continue;
+            if (!(RTAPI_BIT_TEST(tc->syncdio.dio_mask, i))) continue;
             if (tc->syncdio.dios[i] > 0) dioWrite(tp->shared, i, 1); // turn DIO[i] on
             if (tc->syncdio.dios[i] < 0) dioWrite(tp->shared, i, 0); // turn DIO[i] off
         }
@@ -3395,7 +3395,7 @@ int tpSetDout(TP_STRUCT * const tp, unsigned int index, unsigned char start, uns
         return TP_ERR_FAIL;
     }
     tp->syncdio.anychanged = 1; //something has changed
-    tp->syncdio.dio_mask |= (1ull << index);
+    RTAPI_BIT_SET(tp->syncdio.dio_mask, index);
     if (start > 0)
         tp->syncdio.dios[index] = 1; // the end value can't be set from canon currently, and has the same value as start
     else


### PR DESCRIPTION
tc_types.h, tp.c:
Original dio_mask is with type of iomask_t, which is 64 bits.
For system with more than 64 bits of DIOs, we need to replace it
with RTAPI_BITIOPS defined at rtapi_bitops.h

emcmotcfg.h: set EMCMOT_MAX_DIO as 128