### PR TITLE
Cleaning up #ifdefs that break statements

### DIFF
--- a/src/hal/classicladder/files_project.c
+++ b/src/hal/classicladder/files_project.c
@@ -108,19 +108,19 @@ void VerifyDirectorySelected( char * NewDir )
 void InitTempDir( void )
 {
 	char * TmpEnv = getenv("TMP");
-    int TempDir;
+	int TempDir;
 	if ( TmpEnv==NULL )
 		TmpEnv = "/tmp";
 
 	// get a single name directory
 	sprintf( TmpDirectory, "%s/classicladder_tmp_XXXXXX", TmpEnv );
 #ifndef __WIN32__
-    TempDir = ( mkdtemp( TmpDirectory )==NULL );
+	TempDir = ( mkdtemp( TmpDirectory )==NULL );
 #else
-    TempDir = ( mktemp( TmpDirectory )==NULL );
+	TempDir = ( mktemp( TmpDirectory )==NULL );
 #endif
 	if (TempDir)
-    {
+	{
 		sprintf( TmpDirectory, "%s/classicladder_tmp", TmpEnv );
 #ifndef __WIN32__
 		mkdir( TmpDirectory, S_IRWXU );

--- a/src/hal/classicladder/files_project.c
+++ b/src/hal/classicladder/files_project.c
@@ -108,17 +108,19 @@ void VerifyDirectorySelected( char * NewDir )
 void InitTempDir( void )
 {
 	char * TmpEnv = getenv("TMP");
+    int TempDir;
 	if ( TmpEnv==NULL )
 		TmpEnv = "/tmp";
 
 	// get a single name directory
 	sprintf( TmpDirectory, "%s/classicladder_tmp_XXXXXX", TmpEnv );
 #ifndef __WIN32__
-	if ( mkdtemp( TmpDirectory )==NULL )
+    TempDir = ( mkdtemp( TmpDirectory )==NULL );
 #else
-	if ( mktemp( TmpDirectory )==NULL )
+    TempDir = ( mktemp( TmpDirectory )==NULL );
 #endif
-	{
+	if (TempDir)
+    {
 		sprintf( TmpDirectory, "%s/classicladder_tmp", TmpEnv );
 #ifndef __WIN32__
 		mkdir( TmpDirectory, S_IRWXU );
@@ -127,7 +129,7 @@ void InitTempDir( void )
 #endif
 	}
 #ifdef __WIN32__
-	else
+	if (!TempDir)
 	{
 		mkdir( TmpDirectory );
 	}


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.