### PR TITLE
added TravisCI instructions for regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+
+language: bash
+
+services:
+- docker
+
+env:
+  global:
+    - ROOT=/opt/rootfs
+    - JOBS=2
+  matrix:
+    - TAG=wheezy-64    CMD=run_tests
+
+script:
+- .travis/docker_run.sh

--- a/.travis/build_rip.sh
+++ b/.travis/build_rip.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -ex
+
+cd /usr/src/build/${MK_DIR}/machinekit/src
+
+./autogen.sh
+
+./configure \
+     --with-posix \
+     --without-rt-preempt \
+     --without-xenomai \
+     --without-xenomai-kernel \
+     --without-rtai-kernel
+
+make -j${JOBS}
+
+# needs this otherwise regression tests fails
+useradd mk
+chown -R mk:mk ../
+
+make setuid

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+cd "$(dirname $0)/.."
+
+CHROOT_PATH="/opt/rootfs"
+MACHINEKIT_PATH="/usr/src/machinekit"
+TRAVIS_PATH="$MACHINEKIT_PATH/.travis"
+
+docker run \
+    --privileged=true \
+    -v $(pwd):${CHROOT_PATH}${MACHINEKIT_PATH} \
+    -e FLAV="${FLAV}" \
+    -e MK_DIR=${TAG}_${CMD} \
+    -e JOBS=${JOBS} \
+    -e TAG=${TAG} \
+    -e ROOT=${CHROOT_PATH} \
+    kinsamanka/mkdocker:${TAG} \
+    ${CHROOT_PATH}${TRAVIS_PATH}/${CMD}.sh

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+PROOT_OPTS="-b /dev/shm -r ${ROOT}"
+if echo ${TAG} | grep -iq arm; then
+    PROOT_OPTS="${PROOT_OPTS} -q qemu-arm-static"
+fi
+
+# copy source
+mkdir -p ${ROOT}/usr/src/build/${MK_DIR}
+cp -a ${ROOT}/usr/src/machinekit ${ROOT}/usr/src/build/${MK_DIR}
+
+# rip build
+proot ${PROOT_OPTS} /usr/src/machinekit/.travis/build_rip.sh
+
+# disable avahi
+echo "ANNOUNCE_IPV4=0\nANNOUNCE_IPV6=0" >> \
+    ${ROOT}/usr/src/build/${MK_DIR}/machinekit/etc/linuxcnc/machinekit.ini
+
+# runtests needs full access, must use chroot
+mount -o bind /proc /opt/rootfs/proc
+mount -o bind /dev /opt/rootfs/dev
+mount -o bind /dev/shm /opt/rootfs/dev/shm
+mount -o bind /dev/pts /opt/rootfs/dev/pts
+
+chroot --userspec=mk:mk ${ROOT} /usr/src/machinekit/.travis/runtests.sh

--- a/.travis/runtests.sh
+++ b/.travis/runtests.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -ex
+. /usr/src/build/${MK_DIR}/machinekit/scripts/rip-environment
+runtests /usr/src/build/${MK_DIR}/machinekit/tests


### PR DESCRIPTION
This allows TravisCI to build Machinekit on an amd64 environment and run
the regression tests.

It does this using a Docker container to get a reproducable build
environment for a 64-bit host. Inside the container it uses proot/chroot
to actually do the building and testing.

The current structure is set up this way to have a general structure
that runs on x86_64 hosts which can build for amd64, i386 and ARM
environments.

Many thanks to @kinsamanka for making this possible.

Relates to #791.

Please do not merge this change yet. Travis should show up in this PR once it has been set up correctly (and I do another dummy push).