### PR TITLE
added gitter integration for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ notifications:
   email: 
     on_success: never
     on_failure: always
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/8d4ba176d0a87862caa8
+    on_success: change
+    on_failure: always
+    on_start: never
+
 
 language: bash
 


### PR DESCRIPTION
This will notify about Travis build status on
https://gitter.im/machinekit/machinekit

An example of this can be found here (to the right under 'Activity'): https://gitter.im/bobvanderlinden/machinekit