### PR TITLE
travis: use an environment variable for the gitter webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
     on_failure: always
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/8d4ba176d0a87862caa8
+      - $GITTER_IM_URL
     on_success: change
     on_failure: always
     on_start: never


### PR DESCRIPTION
When forks of machinekit/machinekit used Travis, build notifications would show up on machinekit/machinekit's gitter. This is because `.travis.yml` would trigger notifications to machinekit/machinekit's gitter. Now that we have a gitter webhook-url saved as a private environment variable in Travis, we can use that variable in the `.travis.yml` file. That way no-one will know the gitter webhook-url, except for Travis and maintainers.

This patch is similar to what [others](https://github.com/meanjs/mean/pull/1004) have done after finding the same problem.