### PR TITLE
Added building debian packages as part of testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - JOBS=2
   matrix:
     - TAG=wheezy-64    CMD=run_tests
+    - TAG=wheezy-64    CMD=build_deb
 
 script:
 - .travis/docker_run.sh

--- a/.travis/build_deb.sh
+++ b/.travis/build_deb.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -ex
+
+# this script is run inside a docker container
+
+# build unsigned packages
+DEBUILD_OPTS="-eDEB_BUILD_OPTIONS="parallel=${JOBS}" -us -uc -j${JOBS} -b"
+
+PROOT_OPTS="-b /dev/shm -r ${CHROOT_PATH}"
+if echo ${TAG} | grep -iq arm; then
+    PROOT_OPTS="${PROOT_OPTS} -q qemu-arm-static"
+fi
+
+# build debs
+export DEBUILD_OPTS
+proot ${PROOT_OPTS} /bin/sh -exc 'cd ${MACHINEKIT_PATH}; \
+    ./debian/configure -prx ; \
+    debuild ${DEBUILD_OPTS}'


### PR DESCRIPTION
This ensures that xenomai and rt_preempt builds are tested. There's no deployment of finished builds yet.

