### PR TITLE
Fix Cython build because of enum type

### DIFF
--- a/src/hal/cython/machinekit/hal_const.pxd
+++ b/src/hal/cython/machinekit/hal_const.pxd
@@ -1,12 +1,12 @@
 cdef extern from "hal.h":
-    ctypedef enum comp_type:
+    ctypedef enum comp_type_t:
         TYPE_INVALID
         TYPE_RT
         TYPE_USER
         TYPE_REMOTE
         TYPE_HALLIB
 
-    ctypedef enum comp_state:
+    ctypedef enum comp_state_t:
         COMP_INVALID
         COMP_INITIALIZING
         COMP_UNBOUND
@@ -41,7 +41,7 @@ cdef extern from "hal.h":
        FS_USERLAND
 
 cdef extern from "hal_group.h":
-    ctypedef enum report_phase:
+    ctypedef enum report_phase_t:
         REPORT_BEGIN
         REPORT_SIGNAL
         REPORT_PIN

--- a/src/hal/lib/hal.h
+++ b/src/hal/lib/hal.h
@@ -199,7 +199,7 @@ RTAPI_BEGIN_DECLS
  * linking and unlinking of pins is possible as long as the
  * component state != COMP_INITIALIZING.
  */
-enum comp_type  {
+typedef enum comp_type  {
     TYPE_INVALID = 0,
     TYPE_RT,
     TYPE_USER,
@@ -209,15 +209,15 @@ enum comp_type  {
     // which needs extra care since the HAL shm segment needs to be
     // allocated
     TYPE_HALLIB,
-};
+} comp_type_t;
 
-enum comp_state {
+typedef enum comp_state {
     COMP_INVALID = 0,
     COMP_INITIALIZING,
     COMP_UNBOUND,
     COMP_BOUND,
     COMP_READY
-};
+} comp_state_t;
 
 typedef int (*hal_constructor_t) (const char *name, const int argc, const char**argv);
 typedef int (*hal_destructor_t) (const char *name, void *inst, const int inst_size);

--- a/src/hal/lib/hal_group.h
+++ b/src/hal/lib/hal_group.h
@@ -123,12 +123,12 @@ extern int hal_cgroup_match(hal_compiled_group_t *cgroup);
 // given a cgroup which returned a non-zero value from hal_cgroup_match(),
 // generate a report.
 // the report callback is called for the following phases:
-enum report_phase {
+typedef enum report_phase {
     REPORT_BEGIN,
     REPORT_SIGNAL, // for cgroups only
     REPORT_PIN,    // for ccomp's only
     REPORT_END
-};
+} report_phase_t;
 
 #if 0
 // a sample report callback would have the following structure:


### PR DESCRIPTION
The code generated by Cython failed to build with newer versions of gcc, caused
by function passing wrong enum type:

  Compiling hal/cython/machinekit/hal.c
  hal/cython/machinekit/hal.c:1177:59: error: unknown type name ‘comp_type’
  static CYTHON_INLINE PyObject* __Pyx_PyInt_From_comp_type(comp_type value);

To fix the issue, this patch creates typedef for all enums in HAL, and refer to
the proper type in hal_const.pxd. It just normalize the code, because other
enums were already using a typedef, except comp_type, compt_state and
report_phase.

Fixes https://github.com/machinekit/machinekit/issues/781

Signed-off-by: Francis Giraldeau <francis.giraldeau@gmail.com>