### PR TITLE
Travis CI:  package versions; debug output

### DIFF
--- a/.travis/build_deb.sh
+++ b/.travis/build_deb.sh
@@ -1,11 +1,53 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 # this script is run inside a docker container
+cd ${CHROOT_PATH}${MACHINEKIT_PATH}
 
 # Verbose build
 if ${MK_PACKAGE_VERBOSE}; then
     DEBUILD_OPTS+=" -eDH_VERBOSE=1"
 fi
+
+# Supplied variables for package configuration
+MAJOR_MINOR_VERSION="${MAJOR_MINOR_VERSION:-0.1}"
+PKGSOURCE="${PKGSOURCE:-travis.${TRAVIS_REPO_SLUG/\//.}}"
+DISTRO="${DISTRO:-${TAG%-*}}"
+DEBIAN_SUITE="${DEBIAN_SUITE:-experimental}"
+REPO_URL="${REPO_URL:-https://github.com/machinekit/machinekit}"
+
+# Compute version
+if test "$TRAVIS_PULL_REQUEST" = "false"; then
+    # Use build timestamp (now) as pkg version patchlevel
+    TIMESTAMP="$(date +%s)"
+    PR_OR_BRANCH="${TRAVIS_BRANCH}"
+    COMMIT_URL="${REPO_URL}/commit/${TRAVIS_COMMIT:0:8}"
+else
+    # Use merge commit timestamp as pkg version patchlevel
+    TIMESTAMP="$COMMIT_TIMESTAMP"
+    PR_OR_BRANCH="pr${TRAVIS_PULL_REQUEST}"
+    COMMIT_URL="${REPO_URL}/pull/${TRAVIS_PULL_REQUEST}"
+fi
+VERSION="${MAJOR_MINOR_VERSION}.${TIMESTAMP}"
+
+# Compute release
+SHA1SHORT="${TRAVIS_COMMIT:0:8}"
+RELEASE="1${PKGSOURCE}.${PR_OR_BRANCH}.git${SHA1SHORT}~1${DISTRO}"
+
+# Generate debian/changelog entry
+#
+# https://www.debian.org/doc/debian-policy/ch-source.html#s-dpkgchangelog
+mv debian/changelog debian/changelog.old
+cat > debian/changelog <<EOF
+machinekit (${VERSION}-${RELEASE}) ${DEBIAN_SUITE}; urgency=low
+
+  * Travis CI rebuild for ${DISTRO}, ${PR_OR_BRANCH}, commit ${SHA1SHORT}
+    - ${COMMIT_URL}
+
+ -- ${COMMITTER_NAME} <${COMMITTER_EMAIL}>  $(date -R)
+
+EOF
+cat debian/changelog # debug output
+cat debian/changelog.old >> debian/changelog
 
 # build unsigned packages
 DEBUILD_OPTS+=" -eDEB_BUILD_OPTIONS=parallel=${JOBS} -us -uc -j${JOBS} -b"

--- a/.travis/build_deb.sh
+++ b/.travis/build_deb.sh
@@ -2,8 +2,13 @@
 
 # this script is run inside a docker container
 
+# Verbose build
+if ${MK_PACKAGE_VERBOSE}; then
+    DEBUILD_OPTS+=" -eDH_VERBOSE=1"
+fi
+
 # build unsigned packages
-DEBUILD_OPTS="-eDEB_BUILD_OPTIONS="parallel=${JOBS}" -us -uc -j${JOBS} -b"
+DEBUILD_OPTS+=" -eDEB_BUILD_OPTIONS=parallel=${JOBS} -us -uc -j${JOBS} -b"
 
 PROOT_OPTS="-b /dev/shm -r ${CHROOT_PATH}"
 if echo ${TAG} | grep -iq arm; then

--- a/.travis/build_rip_helper.sh
+++ b/.travis/build_rip_helper.sh
@@ -1,5 +1,10 @@
 #!/bin/sh -ex
 
+# Verbose build
+if ${MK_BUILD_VERBOSE}; then
+    VERBOSE="V=1"
+fi
+
 cd ${MACHINEKIT_PATH}/src
 ./autogen.sh
 ./configure \
@@ -8,7 +13,7 @@ cd ${MACHINEKIT_PATH}/src
      --without-xenomai \
      --without-xenomai-kernel \
      --without-rtai-kernel
-make -j${JOBS}
+make -j${JOBS} ${VERBOSE}
 useradd -m -s /bin/bash mk
 chown -R mk:mk ../
-make setuid
+make setuid ${VERBOSE}

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -5,6 +5,9 @@ CHROOT_PATH="/opt/rootfs"
 MACHINEKIT_PATH="/usr/src/machinekit"
 TRAVIS_PATH="$MACHINEKIT_PATH/.travis"
 CONTAINER="kinsamanka/mkdocker"
+COMMITTER_NAME="$(git log -1 --pretty=format:%an)"
+COMMITTER_EMAIL="$(git log -1 --pretty=format:%ae)"
+COMMIT_TIMESTAMP="$(git log -1 --pretty=format:%at)"
 # Verbose RIP build output:  "true" or "false"
 MK_BUILD_VERBOSE=${MK_BUILD_VERBOSE:-"false"}
 # Verbose package build output:  "true" or "false"
@@ -27,8 +30,20 @@ docker run \
     -e CHROOT_PATH=${CHROOT_PATH} \
     -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
     -e TRAVIS_PATH=${TRAVIS_PATH} \
-    -e MK_BUILD_VERBOSE \
-    -e MK_PACKAGE_VERBOSE \
+    -e COMMITTER_NAME="${COMMITTER_NAME}" \
+    -e COMMITTER_EMAIL="${COMMITTER_EMAIL}" \
+    -e COMMIT_TIMESTAMP=${COMMIT_TIMESTAMP} \
+    -e MK_BUILD_VERBOSE="${MK_BUILD_VERBOSE}" \
+    -e MK_PACKAGE_VERBOSE="${MK_PACKAGE_VERBOSE}" \
+    -e MAJOR_MINOR_VERSION \
+    -e PKGSOURCE \
+    -e DISTRO \
+    -e DEBIAN_SUITE \
+    -e GITHUB_URL \
+    -e TRAVIS_REPO_SLUG \
+    -e TRAVIS_PULL_REQUEST \
+    -e TRAVIS_COMMIT \
+    -e TRAVIS_BRANCH \
     ${CONTAINER}:${TAG} \
     ${CHROOT_PATH}${TRAVIS_PATH}/${cmd}.sh
 

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -44,6 +44,7 @@ docker run \
     -e TRAVIS_PULL_REQUEST \
     -e TRAVIS_COMMIT \
     -e TRAVIS_BRANCH \
+    -e LC_ALL="POSIX" \
     ${CONTAINER}:${TAG} \
     ${CHROOT_PATH}${TRAVIS_PATH}/${cmd}.sh
 
@@ -58,5 +59,6 @@ then
     docker run \
         -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
         -e MK_DEBUG_TESTS=${MK_DEBUG_TESTS} \
+        -e LC_ALL="POSIX" \
         --rm=true mk_runtest /run_tests.sh
 fi

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -5,6 +5,12 @@ CHROOT_PATH="/opt/rootfs"
 MACHINEKIT_PATH="/usr/src/machinekit"
 TRAVIS_PATH="$MACHINEKIT_PATH/.travis"
 CONTAINER="kinsamanka/mkdocker"
+# Verbose RIP build output:  "true" or "false"
+MK_BUILD_VERBOSE=${MK_BUILD_VERBOSE:-"false"}
+# Verbose package build output:  "true" or "false"
+MK_PACKAGE_VERBOSE=${MK_PACKAGE_VERBOSE:-"false"}
+# Verbose regression test debug output:  "true" or "false"
+MK_DEBUG_TESTS=${MK_DEBUG_TESTS:-"false"}
 
 cmd=${CMD}
 if [ ${CMD} == "run_tests" ];
@@ -21,6 +27,8 @@ docker run \
     -e CHROOT_PATH=${CHROOT_PATH} \
     -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
     -e TRAVIS_PATH=${TRAVIS_PATH} \
+    -e MK_BUILD_VERBOSE \
+    -e MK_PACKAGE_VERBOSE \
     ${CONTAINER}:${TAG} \
     ${CHROOT_PATH}${TRAVIS_PATH}/${cmd}.sh
 
@@ -34,5 +42,6 @@ then
     # run regressions
     docker run \
         -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
+        -e MK_DEBUG_TESTS=${MK_DEBUG_TESTS} \
         --rm=true mk_runtest /run_tests.sh
 fi

--- a/.travis/mk_runtests/run_tests.sh
+++ b/.travis/mk_runtests/run_tests.sh
@@ -7,10 +7,16 @@ service rsyslog start
 service dbus start
 service avahi-daemon start
 
+# regression test debugging
+if ${MK_DEBUG_TESTS}; then
+    DEBUG=5
+    RUNTESTS_VERBOSE=-v
+fi
+
 # run regressions
 su mk -c '/bin/sh -exc "\
     . ${MACHINEKIT_PATH}/scripts/rip-environment; \
-    runtests"'
+    env MSGD_OPTS=-s DEBUG='${DEBUG}' runtests '${RUNTESTS_VERBOSE}'"'
 
 # run nosetests
 su mk -c '/bin/sh -exc "\


### PR DESCRIPTION
- Set package version and release to meet [requirements][1] 1b and 1d in #791
- New environment variables to enable debug output in Travis CI logs

[1]: https://github.com/machinekit/machinekit/issues/791#issuecomment-158891001