### PR TITLE
Enable rsyslog during regression testing.

### DIFF
--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -4,7 +4,7 @@ cd "$(dirname $0)/.."
 CHROOT_PATH="/opt/rootfs"
 MACHINEKIT_PATH="/usr/src/machinekit"
 TRAVIS_PATH="$MACHINEKIT_PATH/.travis"
-CONTAINER="kinsamanka/mkdocker"
+DOCKER_CONTAINER=${DOCKER_CONTAINER:-"kinsamanka/mkdocker"}
 COMMITTER_NAME="$(git log -1 --pretty=format:%an)"
 COMMITTER_EMAIL="$(git log -1 --pretty=format:%ae)"
 COMMIT_TIMESTAMP="$(git log -1 --pretty=format:%at)"
@@ -45,7 +45,7 @@ docker run \
     -e TRAVIS_COMMIT \
     -e TRAVIS_BRANCH \
     -e LC_ALL="POSIX" \
-    ${CONTAINER}:${TAG} \
+    ${DOCKER_CONTAINER}:${TAG} \
     ${CHROOT_PATH}${TRAVIS_PATH}/${cmd}.sh
 
 # tests are run under a new container instead of chrooting

--- a/.travis/mk_runtests/Dockerfile
+++ b/.travis/mk_runtests/Dockerfile
@@ -1,4 +1,9 @@
-FROM scratch
+FROM	scratch
 
-ADD rootfs.tgz /
-ADD run_tests.sh /
+# decompress rootfs
+ADD	rootfs.tgz /
+
+# add helper scripts
+ADD	run_tests.sh /
+ADD 	run_tests_helper.sh /
+

--- a/.travis/mk_runtests/run_tests.sh
+++ b/.travis/mk_runtests/run_tests.sh
@@ -2,24 +2,15 @@
 
 # this script is run inside a docker container
 
+touch /var/log/linuxcnc.log
+cp ${MACHINEKIT_PATH}/src/rtapi/rsyslogd-linuxcnc.conf \
+    /etc/rsyslog.d/linuxcnc.conf
+
 # start required services
 service rsyslog start
 service dbus start
 service avahi-daemon start
 
-# regression test debugging
-if ${MK_DEBUG_TESTS}; then
-    DEBUG=5
-    RUNTESTS_VERBOSE=-v
-fi
+# run tests
+su mk -c /run_tests_helper.sh
 
-# run regressions
-su mk -c '/bin/sh -exc "\
-    . ${MACHINEKIT_PATH}/scripts/rip-environment; \
-    env MSGD_OPTS=-s DEBUG='${DEBUG}' runtests '${RUNTESTS_VERBOSE}'"'
-
-# run nosetests
-su mk -c '/bin/sh -exc "\
-    . ${MACHINEKIT_PATH}/scripts/rip-environment; \
-    cd ${MACHINEKIT_PATH}/src; \
-    make nosetest"'

--- a/.travis/mk_runtests/run_tests_helper.sh
+++ b/.travis/mk_runtests/run_tests_helper.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -ex
+
+. ${MACHINEKIT_PATH}/scripts/rip-environment
+
+# regression test debugging
+if ${MK_DEBUG_TESTS}; then
+    DEBUG=5
+    RUNTESTS_VERBOSE=-v
+fi
+
+# run regressions and dump log on error
+env MSGD_OPTS=-s DEBUG=${DEBUG} runtests ${RUNTESTS_VERBOSE} || \
+    cat /var/log/linuxcnc.log
+
+# run nosetests
+cd ${MACHINEKIT_PATH}/src
+make nosetest || cat /var/log/linuxcnc.log


### PR DESCRIPTION
The contents of the log is then dumped whenever the runtests fails.