### PR TITLE
Travis CI Packagecloud integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ language: bash
 services:
 - docker
 
+before_install:
+  - gem install package_cloud
+
 env:
   global:
     - ROOT=/opt/rootfs

--- a/.travis/build_deb.sh
+++ b/.travis/build_deb.sh
@@ -15,16 +15,16 @@ DEBIAN_SUITE="${DEBIAN_SUITE:-experimental}"
 REPO_URL="${REPO_URL:-https://github.com/machinekit/machinekit}"
 
 # Compute version
-if test "$TRAVIS_PULL_REQUEST" = "false"; then
+if ${IS_PR}; then
     # Use build timestamp (now) as pkg version patchlevel
     TIMESTAMP="$(date +%s)"
-    PR_OR_BRANCH="${TRAVIS_BRANCH}"
-    COMMIT_URL="${REPO_URL}/commit/${TRAVIS_COMMIT:0:8}"
+    PR_OR_BRANCH="pr${TRAVIS_PULL_REQUEST}"
+    COMMIT_URL="${REPO_URL}/pull/${TRAVIS_PULL_REQUEST}"
 else
     # Use merge commit timestamp as pkg version patchlevel
     TIMESTAMP="$COMMIT_TIMESTAMP"
-    PR_OR_BRANCH="pr${TRAVIS_PULL_REQUEST}"
-    COMMIT_URL="${REPO_URL}/pull/${TRAVIS_PULL_REQUEST}"
+    PR_OR_BRANCH="${TRAVIS_BRANCH}"
+    COMMIT_URL="${REPO_URL}/commit/${TRAVIS_COMMIT:0:8}"
 fi
 
 # sanitize upstream version

--- a/.travis/build_rip.sh
+++ b/.travis/build_rip.sh
@@ -3,7 +3,7 @@
 # this script is run inside a docker container
 
 PROOT_OPTS="-b /dev/shm -r ${CHROOT_PATH}"
-if echo ${TAG} | grep -iq arm; then
+if test ${MARCH} = armhf; then
     PROOT_OPTS="${PROOT_OPTS} -q qemu-arm-static"
 fi
 

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -10,6 +10,7 @@ COMMITTER_EMAIL="$(git log -1 --pretty=format:%ae)"
 COMMIT_TIMESTAMP="$(git log -1 --pretty=format:%at)"
 DISTRO=${TAG%-*}
 MARCH=${TAG#*-}
+test ${TRAVIS_PULL_REQUEST} = false && IS_PR=false || IS_PR=true
 # Verbose RIP build output:  "true" or "false"
 MK_BUILD_VERBOSE=${MK_BUILD_VERBOSE:-"false"}
 # Verbose package build output:  "true" or "false"
@@ -39,6 +40,7 @@ docker run \
     -e COMMIT_TIMESTAMP=${COMMIT_TIMESTAMP} \
     -e MK_BUILD_VERBOSE="${MK_BUILD_VERBOSE}" \
     -e MK_PACKAGE_VERBOSE="${MK_PACKAGE_VERBOSE}" \
+    -e IS_PR="${IS_PR}" \
     -e MAJOR_MINOR_VERSION \
     -e PKGSOURCE \
     -e DISTRO \
@@ -52,17 +54,33 @@ docker run \
     ${DOCKER_CONTAINER}:${TAG} \
     ${CHROOT_PATH}${TRAVIS_PATH}/${cmd}.sh
 
-# tests are run under a new container instead of chrooting
-# this will allow us to run docker without using privileged mode
-if [ ${CMD} == "run_tests" ];
-then
-    # create container using RIP rootfs
-    docker build -t mk_runtest .travis/mk_runtests
-    
-    # run regressions
-    docker run \
-        -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
-        -e MK_DEBUG_TESTS=${MK_DEBUG_TESTS} \
-        -e LC_ALL="POSIX" \
-        --rm=true mk_runtest /run_tests.sh
+if ${IS_PR}; then
+    if test ${cmd} = build_rip; then
+	# PR:  Run regression tests
+	#
+	# tests are run under a new container instead of chrooting
+	# this will allow us to run docker without using privileged mode
+
+	# create container using RIP rootfs
+	docker build -t mk_runtest .travis/mk_runtests
+
+	# run regressions
+	docker run \
+	    -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
+	    -e MK_DEBUG_TESTS=${MK_DEBUG_TESTS} \
+	    -e LC_ALL="POSIX" \
+	    --rm=true mk_runtest /run_tests.sh
+    fi
+else
+    if test ${cmd} != build_rip; then
+	# Merge:  Upload packages to packagecloud, if applicable
+	if test -n "${PACKAGECLOUD_USER}"; then
+	    PACKAGECLOUD_REPO=${PACKAGECLOUD_REPO:-machinekit}
+	    repo=${PACKAGECLOUD_USER}/${PACKAGECLOUD_REPO}/debian/${DISTRO}
+	    package_cloud push ${repo} ${TRAVIS_BUILD_DIR}/deploy/*deb
+	    if test ${MARCH} = 64; then
+		package_cloud push ${repo} ${TRAVIS_BUILD_DIR}/deploy/*dsc
+	    fi
+	fi	
+    fi
 fi

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -8,6 +8,8 @@ DOCKER_CONTAINER=${DOCKER_CONTAINER:-"kinsamanka/mkdocker"}
 COMMITTER_NAME="$(git log -1 --pretty=format:%an)"
 COMMITTER_EMAIL="$(git log -1 --pretty=format:%ae)"
 COMMIT_TIMESTAMP="$(git log -1 --pretty=format:%at)"
+DISTRO=${TAG%-*}
+MARCH=${TAG#*-}
 # Verbose RIP build output:  "true" or "false"
 MK_BUILD_VERBOSE=${MK_BUILD_VERBOSE:-"false"}
 # Verbose package build output:  "true" or "false"
@@ -27,6 +29,8 @@ docker run \
     -e FLAV="${FLAV}" \
     -e JOBS=${JOBS} \
     -e TAG=${TAG} \
+    -e DISTRO=${DISTRO} \
+    -e MARCH=${MARCH} \
     -e CHROOT_PATH=${CHROOT_PATH} \
     -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
     -e TRAVIS_PATH=${TRAVIS_PATH} \


### PR DESCRIPTION
This is @kinsamanka's Travis CI Packagecloud integration.

If the Travis CI repo settings contain the `PACKAGECLOUD_USER`, `PACKAGECLOUD_REPO` and (private) `PACKAGECLOUD_TOKEN` variables, then Travis CI will upload packages to the packagecloud.io repository after a merge to master and successful package build.

The parent commit is a no-op variable cleanup commit.