### PR TITLE
Support for sftp deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,19 @@ notifications:
 language: bash
 
 services:
-- docker
+  - docker
 
 before_install:
   - gem install package_cloud
+  - .travis/get_sftp_key.sh 
 
 env:
   global:
     - ROOT=/opt/rootfs
     - JOBS=2
+    - SFTP_DEPLOY_PORT="${SFTP_DEPLOY_PORT:-22}"
+    - SFTP_DEPLOY_USER="${SFTP_DEPLOY_USER:-travis}"
+    - SFTP_DEPLOY_ADDR="${SFTP_DEPLOY_ADDR:-empty}"
   matrix:
     - TAG=wheezy-64    CMD=run_tests
     - TAG=wheezy-64    CMD=build_deb
@@ -32,5 +36,11 @@ env:
     - TAG=wheezy-armhf CMD=build_deb FLAV=rt_preempt
 
 script:
-- .travis/docker_run.sh
+  - .travis/docker_run.sh
+
+after_success:
+  - .travis/send_binaries.sh
+
+after_script:
+  - .travis/send_status.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
 
 after_success:
   - .travis/send_binaries.sh
+  - .travis/upload_packagecloud.sh
 
 after_script:
   - .travis/send_status.sh

--- a/.travis/build_deb.sh
+++ b/.travis/build_deb.sh
@@ -95,20 +95,14 @@ proot ${PROOT_OPTS} /bin/sh -exc 'cd ${MACHINEKIT_PATH}; \
 
 # copy results
 mkdir ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy
-cp ${CHROOT_PATH}/${MACHINEKIT_PATH}/../*deb \
-    ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy
+chmod 0777 ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy
+cd ${CHROOT_PATH}/${MACHINEKIT_PATH}/../
+cp *deb *changes ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy
 
 # copy source
 if test ${MARCH} = 64; then
-(
-    cd ${CHROOT_PATH}/${MACHINEKIT_PATH}/../
-    cp *bz2 *dsc *changes ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy
-)
+    cp *bz2 *dsc ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy
 fi
 
-# delete extra debs as packagecloud fails if files have the same name
-if [ "${FLAV}" == "rt_preempt" ] || [ "${FLAV}" == "xenomai" ]; then
-    rm ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy/machinekit_*
-    rm ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy/machinekit-dev*
-fi
+chmod 0666 ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy/*
 

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -56,31 +56,20 @@ docker run \
 
 if ${IS_PR}; then
     if test ${cmd} = build_rip; then
-	# PR:  Run regression tests
-	#
-	# tests are run under a new container instead of chrooting
-	# this will allow us to run docker without using privileged mode
+        # PR:  Run regression tests
+        #
+        # tests are run under a new container instead of chrooting
+        # this will allow us to run docker without using privileged mode
 
-	# create container using RIP rootfs
-	docker build -t mk_runtest .travis/mk_runtests
+        # create container using RIP rootfs
+        docker build -t mk_runtest .travis/mk_runtests
 
-	# run regressions
-	docker run \
-	    -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
-	    -e MK_DEBUG_TESTS=${MK_DEBUG_TESTS} \
-	    -e LC_ALL="POSIX" \
-	    --rm=true mk_runtest /run_tests.sh
-    fi
-else
-    if test ${cmd} != build_rip; then
-	# Merge:  Upload packages to packagecloud, if applicable
-	if test -n "${PACKAGECLOUD_USER}"; then
-	    PACKAGECLOUD_REPO=${PACKAGECLOUD_REPO:-machinekit}
-	    repo=${PACKAGECLOUD_USER}/${PACKAGECLOUD_REPO}/debian/${DISTRO}
-	    package_cloud push ${repo} ${TRAVIS_BUILD_DIR}/deploy/*deb
-	    if test ${MARCH} = 64; then
-		package_cloud push ${repo} ${TRAVIS_BUILD_DIR}/deploy/*dsc
-	    fi
-	fi	
+        # run regressions
+        docker run --rm=true \
+            -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
+            -e MK_DEBUG_TESTS=${MK_DEBUG_TESTS} \
+            -e LC_ALL="POSIX" \
+             mk_runtest /run_tests.sh
     fi
 fi
+

--- a/.travis/get_sftp_key.sh
+++ b/.travis/get_sftp_key.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -e
+# do not enable verbosity as the decryption keys will be visible on the logs
+
+die () {
+    echo $1
+    touch ~/no_sftp
+    exit 0
+}
+
+# make sure SFTP_DEPLOY_ADDR is defined and not empty
+if [ "${SFTP_DEPLOY_ADDR}" != "empty" ] && \
+   [ "${TRAVIS_SECURE_ENV_VARS}" = "true" ]; 
+then
+    curl http://${SFTP_DEPLOY_ADDR}/travis/${TRAVIS_REPO_SLUG//\//.}/access_key.enc \
+        -o access_key.enc || die "Cannot download access_key!"
+    openssl aes-256-cbc -K $encrypted_sftp_key -iv $encrypted_sftp_iv \
+        -in access_key.enc -out id_rsa -d || \
+            die "Cannot decrypt access_key!" 
+    chmod 0600 id_rsa
+    mv id_rsa ~/.ssh
+    
+    # test conection
+    FILE="${TRAVIS_REPO_SLUG//\//.}_${TRAVIS_BRANCH}_${TRAVIS_JOB_NUMBER}"
+
+    cat >${FILE} << EOF 
+TRAVIS_BRANCH=${TRAVIS_BRANCH}
+TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}
+TRAVIS_BUILD_ID=${TRAVIS_BUILD_ID}
+TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER}
+TRAVIS_COMMIT=${TRAVIS_COMMIT}
+TRAVIS_COMMIT_RANGE=${TRAVIS_COMMIT_RANGE}
+TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
+TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}
+TAG=${TAG}
+CMD=${CMD}
+FLAV=${FLAV}
+EOF
+
+    cat >sftp_cmds <<EOF
+cd shared/info
+put ${FILE}
+bye
+EOF
+
+    err=0
+    sftp -P ${SFTP_DEPLOY_PORT} -o StrictHostKeyChecking=no -oBatchMode=no \
+        -b sftp_cmds ${SFTP_DEPLOY_USER}@${SFTP_DEPLOY_ADDR} || err=$?
+
+    # cleanups
+    rm sftp_cmds access_key.enc ${FILE} 
+
+    if [ $err -ne 0 ]; then
+        die "Error connecting with sftp. Exit code: ${err}"
+    fi
+
+    exit 0
+fi
+
+# cannot use sftp
+die "SFTP not available"

--- a/.travis/send_binaries.sh
+++ b/.travis/send_binaries.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+FILE="${TRAVIS_REPO_SLUG//\//.}_${TRAVIS_BRANCH}_${TRAVIS_JOB_NUMBER}.tgz"
+
+if [ "${CMD}" = "run_tests" ]; then
+    exit 0
+fi
+
+# skip upload on failure
+if [ "${TRAVIS_TEST_RESULT}" -eq 0 ] && [ ! -f ~/no_sftp ]; then
+    cd ${TRAVIS_BUILD_DIR}
+    tar cvzf ${FILE} -C deploy .
+
+cat >sftp_cmds <<EOF
+cd shared/incoming
+put ${FILE}
+bye
+EOF
+
+    sftp -P ${SFTP_DEPLOY_PORT} -o StrictHostKeyChecking=no -oBatchMode=no \
+        -b sftp_cmds ${SFTP_DEPLOY_USER}@${SFTP_DEPLOY_ADDR}
+    
+fi
+

--- a/.travis/send_status.sh
+++ b/.travis/send_status.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+cd ~/
+if [ ! -f ~/no_sftp ]; then
+    FILE="${TRAVIS_REPO_SLUG//\//.}_${TRAVIS_BRANCH}_${TRAVIS_JOB_NUMBER}_"
+    if [ ${TRAVIS_TEST_RESULT} ]; then
+        FILE+="passed"
+    else
+        FILE+="failed"
+    fi
+
+    touch ${FILE}
+    cat >sftp_cmds <<EOF
+cd shared/info
+put ${FILE}
+bye
+EOF
+
+    sftp -P ${SFTP_DEPLOY_PORT} -o StrictHostKeyChecking=no -oBatchMode=no \
+        -b sftp_cmds ${SFTP_DEPLOY_USER}@${SFTP_DEPLOY_ADDR}
+fi
+

--- a/.travis/upload_packagecloud.sh
+++ b/.travis/upload_packagecloud.sh
@@ -8,7 +8,8 @@ if [ "${CMD}" = "run_tests" ]; then
 fi
 
 # skip upload on failure
-if [ "${TRAVIS_TEST_RESULT}" -eq 0 ] && [ "${CMD}" = "build_deb" ]; then
+if [ "${TRAVIS_TEST_RESULT}" -eq 0 ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] \
+        && [ "${CMD}" = "build_deb" ]; then
     PACKAGECLOUD_REPO=${PACKAGECLOUD_REPO:-machinekit}
     repo=${PACKAGECLOUD_USER}/${PACKAGECLOUD_REPO}/debian/${DISTRO}
 

--- a/.travis/upload_packagecloud.sh
+++ b/.travis/upload_packagecloud.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -x
+#!/bin/bash -e
+# do not enable verbosity as the PACKAGECLOUD_TOKEN will be visible
 
 DISTRO=${TAG%-*}
 MARCH=${TAG#*-}
@@ -9,6 +10,7 @@ fi
 
 # skip upload on failure
 if [ "${TRAVIS_TEST_RESULT}" -eq 0 ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] \
+        && [ ! -z ${PACKAGECLOUD_USER+x} ] && [ ! -z ${PACKAGECLOUD_TOKEN+x} ] \
         && [ "${CMD}" = "build_deb" ]; then
     PACKAGECLOUD_REPO=${PACKAGECLOUD_REPO:-machinekit}
     repo=${PACKAGECLOUD_USER}/${PACKAGECLOUD_REPO}/debian/${DISTRO}

--- a/.travis/upload_packagecloud.sh
+++ b/.travis/upload_packagecloud.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -x
+
+DISTRO=${TAG%-*}
+MARCH=${TAG#*-}
+
+if [ "${CMD}" = "run_tests" ]; then
+    exit 0
+fi
+
+# skip upload on failure
+if [ "${TRAVIS_TEST_RESULT}" -eq 0 ] && [ "${CMD}" = "build_deb" ]; then
+    PACKAGECLOUD_REPO=${PACKAGECLOUD_REPO:-machinekit}
+    repo=${PACKAGECLOUD_USER}/${PACKAGECLOUD_REPO}/debian/${DISTRO}
+
+    # delete extra debs as packagecloud fails if the same files
+    # have already been uploaded
+    if [ "${FLAV}" == "rt_preempt" ] || [ "${FLAV}" == "xenomai" ]; then
+        rm -f ${TRAVIS_BUILD_DIR}/deploy/machinekit_*
+        rm -f ${TRAVIS_BUILD_DIR}/deploy/machinekit-dev*
+    fi
+
+    package_cloud push ${repo} ${TRAVIS_BUILD_DIR}/deploy/*deb
+    if [ "${MARCH}" = "64" ]; then
+        package_cloud push ${repo} ${TRAVIS_BUILD_DIR}/deploy/*dsc
+    fi
+fi    
+


### PR DESCRIPTION
This patch needs the following Travis-CI environment variables in order to work properly:

- `SFTP_DEPLOY_ADDR`
- `SFTP_DEPLOY_PORT` (default: **22**)
- `SFTP_DEPLOY_USER` (default: **travis**)
- `encrypted_sftp_key`
- `encrypted_sftp_iv`