### PR TITLE
hal/components/lgantry: bug fix

### DIFF
--- a/src/hal/i_components/lgantry.icomp
+++ b/src/hal/i_components/lgantry.icomp
@@ -186,6 +186,13 @@ FUNCTION(write)
             }
         }
     }
+    else
+    {
+        // save prev command when not homing or we will get a big delta
+        // and joint following errors or more when we switching to homing mode
+        // on a high joint positon
+        prev_cmd = position_cmd;
+    }
 
     // Update each joint's commanded position
     for (i = 0; i < localpincount; i++) {


### PR DESCRIPTION
Fix for a dangerous bug that can occur when homing is started at high
joint position. prev_cmd was initialized with 0 and therefore a resulted
in big position delta when switching to homing mode.