### PR TITLE
Travis CI:  Jessie builds + minor updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,12 @@ env:
     - TAG=wheezy-armhf CMD=build_deb FLAV=posix
     - TAG=wheezy-armhf CMD=build_deb FLAV=xenomai
     - TAG=wheezy-armhf CMD=build_deb FLAV=rt_preempt
+    - TAG=jessie-64    CMD=run_tests
+    - TAG=jessie-64    CMD=build_deb
+    - TAG=jessie-32    CMD=build_deb
+    - TAG=jessie-armhf CMD=build_deb FLAV=posix
+    - TAG=jessie-armhf CMD=build_deb FLAV=xenomai
+    - TAG=jessie-armhf CMD=build_deb FLAV=rt_preempt
 
 script:
   - .travis/docker_run.sh

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -54,22 +54,20 @@ docker run \
     ${DOCKER_CONTAINER}:${TAG} \
     ${CHROOT_PATH}${TRAVIS_PATH}/${cmd}.sh
 
-if ${IS_PR}; then
-    if test ${cmd} = build_rip; then
-        # PR:  Run regression tests
-        #
-        # tests are run under a new container instead of chrooting
-        # this will allow us to run docker without using privileged mode
+if test ${cmd} = build_rip; then
+    # PR:  Run regression tests
+    #
+    # tests are run under a new container instead of chrooting
+    # this will allow us to run docker without using privileged mode
 
-        # create container using RIP rootfs
-        docker build -t mk_runtest .travis/mk_runtests
+    # create container using RIP rootfs
+    docker build -t mk_runtest .travis/mk_runtests
 
-        # run regressions
-        docker run --rm=true \
-            -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
-            -e MK_DEBUG_TESTS=${MK_DEBUG_TESTS} \
-            -e LC_ALL="POSIX" \
-             mk_runtest /run_tests.sh
-    fi
+    # run regressions
+    docker run --rm=true \
+	-e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
+	-e MK_DEBUG_TESTS=${MK_DEBUG_TESTS} \
+	-e LC_ALL="POSIX" \
+	 mk_runtest /run_tests.sh
 fi
 

--- a/.travis/upload_packagecloud.sh
+++ b/.travis/upload_packagecloud.sh
@@ -8,10 +8,16 @@ if [ "${CMD}" = "run_tests" ]; then
     exit 0
 fi
 
-# skip upload on failure
+# skip .deb package upload when:
+# - tests fail
+# - building a PR
+# - no packagecloude.io account configured
+# - not building .debs
+# - not building the configured $DEPLOY_BRANCH
 if [ "${TRAVIS_TEST_RESULT}" -eq 0 ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] \
         && [ ! -z ${PACKAGECLOUD_USER+x} ] && [ ! -z ${PACKAGECLOUD_TOKEN+x} ] \
-        && [ "${CMD}" = "build_deb" ]; then
+        && [ "${CMD}" = "build_deb" ] \
+        && [ "${TRAVIS_BRANCH}" == "${DEPLOY_BRANCH:-master}" ]; then
     PACKAGECLOUD_REPO=${PACKAGECLOUD_REPO:-machinekit}
     repo=${PACKAGECLOUD_USER}/${PACKAGECLOUD_REPO}/debian/${DISTRO}
 


### PR DESCRIPTION
This PR introduces Travis CI builds for Jessie.  This completes the final flow for updating the deb.dovetail-automata.com package repo; see #791.

I have updated the Travis CI `machinekit/machinekit` settings to point to an updated set of Docker containers built from [my modifications][1] to @kinsamanka's repo; the most notable change is addition of Jessie containers.  [Docker Registry link][2]

The other changes in this commit are minor:
- Only push to packagecloud.io when building from the `master` branch (safety measure)
- Always run regression tests in the `run_tests` matrix (duh on my part)

[1]: https://github.com/zultron/mkdocker
[2]: https://hub.docker.com/r/zultron/mkdocker/builds/