### PR TITLE
Only allow x64 builds for PR's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ env:
     - SFTP_DEPLOY_ADDR="${SFTP_DEPLOY_ADDR:-empty}"
   matrix:
     - TAG=wheezy-64    CMD=run_tests
+    - TAG=jessie-64    CMD=run_tests
     - TAG=wheezy-64    CMD=build_deb
     - TAG=wheezy-32    CMD=build_deb
     - TAG=wheezy-armhf CMD=build_deb FLAV=posix
     - TAG=wheezy-armhf CMD=build_deb FLAV=xenomai
     - TAG=wheezy-armhf CMD=build_deb FLAV=rt_preempt
-    - TAG=jessie-64    CMD=run_tests
     - TAG=jessie-64    CMD=build_deb
     - TAG=jessie-32    CMD=build_deb
     - TAG=jessie-armhf CMD=build_deb FLAV=posix

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -24,6 +24,13 @@ then
     cmd=build_rip
 fi
 
+# only allow x64 builds for PR's to speed up the process
+if test ${TRAVIS_PULL_REQUEST} != 'false'; then
+    if test ${MARCH} != '64'; then
+        exit 0
+    fi
+fi
+
 # run build step
 docker run \
     -v $(pwd):${CHROOT_PATH}${MACHINEKIT_PATH} \


### PR DESCRIPTION
This helps speed up the checks and reduces the load on travis-ci.