### PR TITLE
build: apply --no-as-needed to all binaries

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -373,6 +373,7 @@ LDFLAGS := -L$(LIB_DIR) -Wl,-rpath,$(LIB_DIR)
 else
 LDFLAGS := -Wl,-rpath-link,../lib
 endif
+LDFLAGS += -Wl,--no-as-needed
 
 # Rules to make .o (object) files
 $(sort $(CUSEROBJS)) : objects/%.o: %.c


### PR DESCRIPTION
this fixxes the cython bindings on Ubuntu 14.04 and other platforms
which default to as-needed behavior

(repaired previous accidential direct push by undoing the last commit and posting this PR)