### PR TITLE
Make symbolic links for PRINT_FILE and DEBUG_FILE

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -102,6 +102,8 @@ MODULE_EXT=@MODEXT@ # module extension, used when insmod'ing
 
 DEBUG_FILE=$(mktemp /tmp/linuxcnc.debug.XXXXXX)
 PRINT_FILE=$(mktemp /tmp/linuxcnc.print.XXXXXX)
+ln -sf $PRINT_FILE /tmp/linuxcnc.print
+ln -sf $DEBUG_FILE /tmp/linuxcnc.debug
 
 program_available () {
     type -path "$1" > /dev/null 2>&1


### PR DESCRIPTION
The PRINT_FILE and DEBUG_FILE are generated by mktemp. Add symbolic links for them to /tmp/linuxcnc.print and /tmp/linuxcnc.debug to access current running status.

Also, the other process may access the INI file of current running Machinekit through /tmp/linuxcnc.print.
For example:
```python
inifile = None
lprint = open("/tmp/linuxcnc.print", "r")
for line in lprint:
    m = re.match("^INIFILE=(.*)", line)
    if (m):
        inifile = m.group(1)

if (inifile):
    ini = linuxcnc.ini(inifile)
else:
    print "No valid INI_FILE_NAME, please launch Machinekit"
    exit(1)
```
