### PR TITLE
hal: fix up sprintf -> rtapi_snprintf usage

### DIFF
--- a/src/hal/components/lcd.c
+++ b/src/hal/components/lcd.c
@@ -142,7 +142,7 @@ int rtapi_app_main(void){
             
             if (fmt_strings[i][f + 1] =='|' || fmt_strings[i][f + 1] == 0) {
                 inst->pages[p].fmt = hal_malloc(f - f1 + 2);
-                retval = snprintf(inst->pages[p].fmt,
+                retval = rtapi_snprintf(inst->pages[p].fmt,
                                   f - f1 + 2, "%s",
                                   fmt_strings[i] + f1);
                 inst->pages[p].length = f - f1 + 2;

--- a/src/hal/drivers/hal_pru_generic/hal_pru_generic.c
+++ b/src/hal/drivers/hal_pru_generic/hal_pru_generic.c
@@ -374,7 +374,7 @@ int assure_module_loaded(const char *module)
     }
     fclose(fd);
     HPG_DBG("loading module '%s'\n", module);
-    sprintf(line, "/sbin/modprobe %s", module);
+    rtapi_snprintf(line, sizeof(line), "/sbin/modprobe %s", module);
     if ((retval = system(line))) {
         HPG_ERR("ERROR: executing '%s'  %d - %s\n", line, errno, strerror(errno));
         return -1;

--- a/src/hal/drivers/hal_zed_can.c
+++ b/src/hal/drivers/hal_zed_can.c
@@ -388,7 +388,7 @@ static int setup_CAN(int n)
 
     /** \todo error mamagement a palla */
     //
-    sprintf(ifr.ifr_name,"can%d",n); 
+    rtapi_snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "can%d",n); 
     //
     ioctl (sock[n], SIOCGIFINDEX, &ifr);
     //

--- a/src/hal/drivers/mesa-hostmot2/bspi.c
+++ b/src/hal/drivers/mesa-hostmot2/bspi.c
@@ -87,7 +87,7 @@ int hm2_bspi_parse_md(hostmot2_t *hm2, int md_index)
     for (i = 0 ; i < hm2->bspi.num_instances ; i++){
         hm2_bspi_instance_t *chan = &hm2->bspi.instance[i];
         chan->clock_freq = md->clock_freq;
-        r = sprintf(chan->name, "%s.bspi.%01d", hm2->llio->name, i);
+        r = rtapi_snprintf(chan->name, sizeof(chan->name), "%s.bspi.%01d", hm2->llio->name, i);
         HM2_PRINT("created Buffered SPI function %s.\n", chan->name);
         chan->base_address = md->base_address + i * md->instance_stride;
         chan->register_stride = md->register_stride;

--- a/src/hal/drivers/mesa-hostmot2/pins.c
+++ b/src/hal/drivers/mesa-hostmot2/pins.c
@@ -242,13 +242,13 @@ static const char* hm2_get_pin_secondary_name(hm2_pin_t *pin) {
             switch (sec_pin) {
                 case 0x41: return "Strobe";
                 default:
-                    sprintf(unknown, "Data%02x",sec_pin - 1);
+                    rtapi_snprintf(unknown, sizeof(unknown),  "Data%02x",sec_pin - 1);
                     return unknown;
             }
             break;
 
         case HM2_GTAG_BINOSC: // Not Supported Currently
-             sprintf(unknown, "Out%02x",sec_pin -1);
+             rtapi_snprintf(unknown, sizeof(unknown), "Out%02x",sec_pin -1);
              return unknown;
              break;
 
@@ -281,11 +281,11 @@ static const char* hm2_get_pin_secondary_name(hm2_pin_t *pin) {
 
         case HM2_GTAG_TWIDDLER: // Not Supported Currently
              if (sec_pin < 0x20){
-                 sprintf(unknown, "In%02x", sec_pin - 1);
+                 rtapi_snprintf(unknown, sizeof(unknown), "In%02x", sec_pin - 1);
              } else if (sec_pin > 0xC0){
-                 sprintf(unknown, "IO%02x", sec_pin - 1);
+                 rtapi_snprintf(unknown, sizeof(unknown), "IO%02x", sec_pin - 1);
              } else {
-                 sprintf(unknown, "Out%02x", sec_pin - 1);
+                 rtapi_snprintf(unknown, sizeof(unknown), "Out%02x", sec_pin - 1);
              }
              return unknown;
              break;

--- a/src/hal/drivers/mesa-hostmot2/uart.c
+++ b/src/hal/drivers/mesa-hostmot2/uart.c
@@ -95,7 +95,7 @@ int hm2_uart_parse_md(hostmot2_t *hm2, int md_index)
         // For the time being we assume that all UARTS come on pairs
         if (inst->clock_freq == 0){
             inst->clock_freq = md->clock_freq;
-            r = sprintf(inst->name, "%s.uart.%01d", hm2->llio->name, i);
+            r = rtapi_snprintf(inst->name, sizeof(inst->name), "%s.uart.%01d", hm2->llio->name, i);
             HM2_PRINT("created UART Interface function %s.\n", inst->name);
         }
         if (md->gtag == HM2_GTAG_UART_TX){

--- a/src/machinetalk/msgcomponents/ringload.c
+++ b/src/machinetalk/msgcomponents/ringload.c
@@ -41,7 +41,7 @@ int rtapi_app_main(void)
 	flags |= ALLOC_HALMEM;
 
     for (n = 0; n < num_rings; n++) {
-	snprintf(ringname, HAL_NAME_LEN, "ring_%d",n);
+	rtapi_snprintf(ringname, HAL_NAME_LEN, "ring_%d",n);
 	if ((retval = hal_ring_new(ringname, size, spsize,flags))) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 			    "ringload: failed to create new ring %s: %d\n",
@@ -61,7 +61,7 @@ void rtapi_app_exit(void)
     char ringname[HAL_NAME_LEN + 1];
 
     for (n = 0; n < num_rings; n++) {
-	snprintf(ringname, HAL_NAME_LEN, "ring_%d",n);
+	rtapi_snprintf(ringname, HAL_NAME_LEN, "ring_%d",n);
 	if ((retval = hal_ring_delete(ringname))) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 			    "ringload: failed to delete ring %s: %d\n",


### PR DESCRIPTION
this should remove a couple of warnings

I wonder why this is suddenly criticial - is it the switch to gcc 4.9?

