### PR TITLE
Travis-CI Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - SFTP_DEPLOY_PORT="${SFTP_DEPLOY_PORT:-22}"
     - SFTP_DEPLOY_USER="${SFTP_DEPLOY_USER:-travis}"
     - SFTP_DEPLOY_ADDR="${SFTP_DEPLOY_ADDR:-empty}"
+    - CCACHE_REPO="${CCACHE_REPO:-kinsamanka/mk-ccache}"
   matrix:
     - TAG=wheezy-64    CMD=run_tests
     - TAG=jessie-64    CMD=run_tests
@@ -41,13 +42,16 @@ env:
     - TAG=jessie-armhf CMD=build_deb FLAV=xenomai
     - TAG=jessie-armhf CMD=build_deb FLAV=rt_preempt
 
+before_script:
+  - .travis/get_ccache.sh
+
 script:
   - .travis/docker_run.sh
 
 after_success:
+  - .travis/save_ccache.sh
   - .travis/send_binaries.sh
   - .travis/upload_packagecloud.sh
 
 after_script:
   - .travis/send_status.sh
-

--- a/.travis/build_deb.sh
+++ b/.travis/build_deb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # this script is run inside a docker container
-cd ${CHROOT_PATH}${MACHINEKIT_PATH}
+cd ${ROOTFS}${MACHINEKIT_PATH}
 
 # Verbose build
 if ${MK_PACKAGE_VERBOSE}; then
@@ -61,18 +61,13 @@ DEBUILD_OPTS+=" -eDEB_BUILD_OPTIONS=parallel=${JOBS} -us -uc -j${JOBS}"
 if test ${MARCH} = 64; then
     # create upstream tarball only on amd64
     (
-	cd ${CHROOT_PATH}${MACHINEKIT_PATH}
+	cd ${ROOTFS}${MACHINEKIT_PATH}
 	git archive HEAD | bzip2 -z > \
             ../machinekit_${VERSION}.orig.tar.bz2
     )
 else
     # the rest will be binaries only
     DEBUILD_OPTS+=" -b"
-fi
-
-PROOT_OPTS="-b /dev/shm -r ${CHROOT_PATH}"
-if test ${MARCH} = armhf; then
-    PROOT_OPTS="${PROOT_OPTS} -q qemu-arm-static"
 fi
 
 case "${FLAV}" in
@@ -89,20 +84,19 @@ export FLAV_OPTS
 
 # build debs
 export DEBUILD_OPTS
-proot ${PROOT_OPTS} /bin/sh -exc 'cd ${MACHINEKIT_PATH}; \
+proot-helper /bin/sh -exc 'cd ${MACHINEKIT_PATH}; \
     ./debian/configure ${FLAV_OPTS} ; \
     debuild ${DEBUILD_OPTS}'
 
 # copy results
-mkdir ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy
-chmod 0777 ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy
-cd ${CHROOT_PATH}/${MACHINEKIT_PATH}/../
-cp *deb *changes ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy
+mkdir ${ROOTFS}/${MACHINEKIT_PATH}/deploy
+chmod 0777 ${ROOTFS}/${MACHINEKIT_PATH}/deploy
+cd ${ROOTFS}/${MACHINEKIT_PATH}/../
+cp *deb *changes ${ROOTFS}/${MACHINEKIT_PATH}/deploy
 
 # copy source
 if test ${MARCH} = 64; then
-    cp *bz2 *dsc ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy
+    cp *bz2 *dsc ${ROOTFS}/${MACHINEKIT_PATH}/deploy
 fi
 
-chmod 0666 ${CHROOT_PATH}/${MACHINEKIT_PATH}/deploy/*
-
+chmod 0666 ${ROOTFS}/${MACHINEKIT_PATH}/deploy/*

--- a/.travis/build_deb.sh
+++ b/.travis/build_deb.sh
@@ -8,6 +8,9 @@ if ${MK_PACKAGE_VERBOSE}; then
     DEBUILD_OPTS+=" -eDH_VERBOSE=1"
 fi
 
+# enable ccache
+DEBUILD_OPTS+=" -eCCACHE_DIR=/ccache --prepend-path=/usr/lib/ccache"
+
 # Supplied variables for package configuration
 MAJOR_MINOR_VERSION="${MAJOR_MINOR_VERSION:-0.1}"
 PKGSOURCE="${PKGSOURCE:-travis.${TRAVIS_REPO_SLUG/\//.}}"
@@ -100,3 +103,8 @@ if test ${MARCH} = 64; then
 fi
 
 chmod 0666 ${ROOTFS}/${MACHINEKIT_PATH}/deploy/*
+
+# display ccache stats
+CCACHE_DIR=/ccache proot-helper ccache -s
+# reset ccache stats
+CCACHE_DIR=/ccache proot-helper ccache -z > /dev/null

--- a/.travis/build_rip.sh
+++ b/.travis/build_rip.sh
@@ -8,3 +8,8 @@ proot-helper ${TRAVIS_PATH}/build_rip_helper.sh
 # tar the chroot directory
 tar czf /tmp/rootfs.tgz -C ${ROOTFS} .
 cp /tmp/rootfs.tgz ${ROOTFS}${TRAVIS_PATH}/mk_runtests
+
+# display ccache stats
+CCACHE_DIR=/ccache proot-helper ccache -s
+# reset ccache stats
+CCACHE_DIR=/ccache proot-helper ccache -z > /dev/null

--- a/.travis/build_rip.sh
+++ b/.travis/build_rip.sh
@@ -2,14 +2,9 @@
 
 # this script is run inside a docker container
 
-PROOT_OPTS="-b /dev/shm -r ${CHROOT_PATH}"
-if test ${MARCH} = armhf; then
-    PROOT_OPTS="${PROOT_OPTS} -q qemu-arm-static"
-fi
-
 # rip build
-proot ${PROOT_OPTS} ${TRAVIS_PATH}/build_rip_helper.sh
+proot-helper ${TRAVIS_PATH}/build_rip_helper.sh
 
 # tar the chroot directory
-tar czf /tmp/rootfs.tgz -C ${CHROOT_PATH} .
-cp /tmp/rootfs.tgz ${CHROOT_PATH}${TRAVIS_PATH}/mk_runtests
+tar czf /tmp/rootfs.tgz -C ${ROOTFS} .
+cp /tmp/rootfs.tgz ${ROOTFS}${TRAVIS_PATH}/mk_runtests

--- a/.travis/build_rip_helper.sh
+++ b/.travis/build_rip_helper.sh
@@ -5,6 +5,10 @@ if ${MK_BUILD_VERBOSE}; then
     VERBOSE="V=1"
 fi
 
+# enable ccache
+export CCACHE_DIR=/ccache 
+export PATH=/usr/lib/ccache:$PATH
+
 cd ${MACHINEKIT_PATH}/src
 ./autogen.sh
 ./configure \

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -34,6 +34,7 @@ fi
 docker run \
     -v $(pwd):/opt/rootfs/${MACHINEKIT_PATH} \
     -v $(pwd)/.travis:/travis \
+    -v $(pwd)/../ccache:/opt/rootfs/ccache \
     -e FLAV="${FLAV}" \
     -e JOBS=${JOBS} \
     -e TAG=${TAG} \

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -3,7 +3,7 @@ cd "$(dirname $0)/.."
 
 MACHINEKIT_PATH="/usr/src/machinekit"
 TRAVIS_PATH="$MACHINEKIT_PATH/.travis"
-DOCKER_CONTAINER=${DOCKER_CONTAINER:-"kinsamanka/mkdocker"}
+DOCKER_CONTAINER=${DOCKER_CONTAINER:-"kinsamanka/machinekit_builder"}
 COMMITTER_NAME="$(git log -1 --pretty=format:%an)"
 COMMITTER_EMAIL="$(git log -1 --pretty=format:%ae)"
 COMMIT_TIMESTAMP="$(git log -1 --pretty=format:%at)"

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -ex
 cd "$(dirname $0)/.."
 
-CHROOT_PATH="/opt/rootfs"
 MACHINEKIT_PATH="/usr/src/machinekit"
 TRAVIS_PATH="$MACHINEKIT_PATH/.travis"
 DOCKER_CONTAINER=${DOCKER_CONTAINER:-"kinsamanka/mkdocker"}
@@ -33,13 +32,13 @@ fi
 
 # run build step
 docker run \
-    -v $(pwd):${CHROOT_PATH}${MACHINEKIT_PATH} \
+    -v $(pwd):/opt/rootfs/${MACHINEKIT_PATH} \
+    -v $(pwd)/.travis:/travis \
     -e FLAV="${FLAV}" \
     -e JOBS=${JOBS} \
     -e TAG=${TAG} \
     -e DISTRO=${DISTRO} \
     -e MARCH=${MARCH} \
-    -e CHROOT_PATH=${CHROOT_PATH} \
     -e MACHINEKIT_PATH=${MACHINEKIT_PATH} \
     -e TRAVIS_PATH=${TRAVIS_PATH} \
     -e COMMITTER_NAME="${COMMITTER_NAME}" \
@@ -59,7 +58,7 @@ docker run \
     -e TRAVIS_BRANCH \
     -e LC_ALL="POSIX" \
     ${DOCKER_CONTAINER}:${TAG} \
-    ${CHROOT_PATH}${TRAVIS_PATH}/${cmd}.sh
+    /travis/${cmd}.sh
 
 if test ${cmd} = build_rip; then
     # PR:  Run regression tests
@@ -77,4 +76,3 @@ if test ${cmd} = build_rip; then
 	-e LC_ALL="POSIX" \
 	 mk_runtest /run_tests.sh
 fi
-

--- a/.travis/get_ccache.sh
+++ b/.travis/get_ccache.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+branch="${TAG}/${CMD}"
+if [ ! -z ${FLAV+x} ]; then
+    branch+="/${FLAV}"
+fi
+
+res=$(git ls-remote git://github.com/${CCACHE_REPO})
+
+# fetch if ccache is available
+if [[ "${res}" = *"${branch}"* ]]; then
+    git clone -b ${branch} --depth=1 git://github.com/${CCACHE_REPO} ../ccache
+    # delete git directory, no need for history
+    rm -rf ../ccache/.git
+else # empty ccache
+    mkdir ../ccache
+fi

--- a/.travis/save_ccache.sh
+++ b/.travis/save_ccache.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -ex
+
+branch="${TAG}/${CMD}"
+if [ ! -z ${FLAV+x} ]; then
+    branch+="/${FLAV}"
+fi
+
+# only upload if ssh key is present
+if [ -f ~/.ssh/id_rsa ]; then
+    cd ${TRAVIS_BUILD_DIR}/../ccache
+    git init
+    git add -A
+    git config --global user.email "travis-ci@machinekit.io"
+    git config --global user.name "travis-ci"
+    git commit -m ccache 2>&1 >/dev/null
+    git remote add origin git@github.com:${CCACHE_REPO}.git
+    git checkout -b ${branch}
+    git push --set-upstream origin ${branch} --force || true
+fi


### PR DESCRIPTION
# Note: this PR will fail the current CI tests

Delete the travis env `DOCKER_CONTAINER` and then restart the tests. 

## Improvements
- gcc 4.7 for wheezy builds
- ccache support 

[travis-ci results](https://travis-ci.org/kinsamanka/machinekit/builds/97648560)

The Docker container was renamed due to issues encountered with the Docker registry autobuilder. Improvements made by @zultron on the original mkdocker container were incorporated into this new container. The dockerfiles can be found [here](http://github.com/kinsamanka/machinekit_builder) 