### PR TITLE
Edit to instcomp man page generation and add new offsetn component

### DIFF
--- a/src/hal/i_components/offsetn.icomp
+++ b/src/hal/i_components/offsetn.icomp
@@ -1,0 +1,61 @@
+//   This is a component for Machinekit HAL
+//   Multipin version of offset component (c) 2006 Jeff Epler <jepler@unpythonic.net>
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation; either version 2 of the License, or
+//   (at your option) any later version.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with this program; if not, write to the Free Software
+//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+component offsetn "Adds an offset to an input, and subtracts it from the feedback value, 1 - 9 pins sets";
+
+pin in float #.offset[pincount] "The offset value";
+
+pin in float #.in[pincount] "The input value";
+pin out float #.out[pincount] "The output value";
+
+pin in float #.fb_in[pincount] "The feedback input value";
+pin out float #.fb_out[pincount] "The feedback output value";
+
+
+instanceparam int pincount = 1; 
+    //Default to single, same as legacy component
+
+option MAXCOUNT 9;  
+    //Max of 9 to match current number of supported axes in most *kins
+
+function update_output "Updated the output value by adding the offset to the input";
+function update_feedback "Update the feedback value by subtracting the offset from the feedback";
+
+author "ArcEye <arceye@mgwareDOTcoDOTuk>";
+
+license "GPL";
+;;
+
+FUNCTION(update_feedback)
+{
+hal_s32_t n;
+
+	for (n = 0; n < localpincount; n++)
+		_fb_out(n) = _fb_in(n) - _offset(n);
+
+return 0;
+}
+
+FUNCTION(update_output)
+{
+hal_s32_t n;
+
+	for (n = 0; n < localpincount; n++)
+		_out(n) = _in(n) + _offset(n);
+
+return 0;
+}

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -1020,9 +1020,11 @@ def document(filename, outfilename):
         print >>f, ".HP"
     else:
         print >>f, ".B loadrt %s " % comp_name
-	print >>f, ".LP"
+        print >>f, ".LP"
         print >>f, ".B newinst %s <newinstname> [ pincount=\\fIN\\fB | iprefix=\\fIprefix\\fB ]" % comp_name
         print >>f, ".B                             [instanceparamX=\\fIX\\fB | argX=\\fIX\\fB ]"
+        print >>f, ".HP"
+        print >>f, "( args in [ ] denote possible args and parameters, may not be used in all components )"
         print >>f, ".HP"
         for type, name, default, doc in modparams:
             print >>f, "[%s=\\fIN\\fB]" % name,


### PR DESCRIPTION
Man page edit, clarifies that not all possible parameters and args
may be in use by all components

offsetn - multi-pin version of offset allowing 1-9 sets of pins
All pin sets are individual, allowing unique offsets per n axes
to be applied within same component

Fixes #870

Signed-off-by: Mick <arceye@mgware.co.uk>