### PR TITLE
configs/5i25.ini: hm2_soc takes config="firmware=<path-under-/lib/fir…

### DIFF
--- a/configs/hm2-soc-stepper/5i25-soc.ini
+++ b/configs/hm2-soc-stepper/5i25-soc.ini
@@ -8,7 +8,7 @@
 [HOSTMOT2]
 DRIVER=hm2_soc
 BOARD=5i25
-CONFIG="num_encoders=0 num_pwmgens=0 num_stepgens=3"
+CONFIG="firmware=socfpga/soc_system.rbf num_encoders=0 num_pwmgens=0 num_stepgens=3"
 
 
 

--- a/configs/hm2-soc-stepper/hm2-soc-stepper-5i25.hal
+++ b/configs/hm2-soc-stepper/hm2-soc-stepper-5i25.hal
@@ -36,8 +36,7 @@ loadrt tp
 loadrt hostmot2
 
 # load low-level driver
-loadrt [HOSTMOT2](DRIVER)
-#config=[HOSTMOT2](CONFIG)
+loadrt [HOSTMOT2](DRIVER) config=[HOSTMOT2](CONFIG)
 
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES  #tp=tp kins=trivkins
 


### PR DESCRIPTION
…mware>" param now

The FPGA blob is expected to be installed as /lib/firmware/socfpga/soc_system.rbf

I've manually uploaded an interim firmware package which installs this file
so the process gets going:

apt-cache showpkg socfpga-rbf
Package: socfpga-rbf
Versions:
0.12 (/var/lib/apt/lists/deb.machinekit.io_debian_dists_jessie_main_binary-armhf_Packages.gz) (/var/lib/dpkg/status)
 Description Language:
                 File: /var/lib/apt/lists/deb.machinekit.io_debian_dists_jessie_main_binary-armhf_Packages.gz
                  MD5: 11bf37dc043d46c59d00f4ec646b88ca


Reverse Depends:
Dependencies:
0.12 -
Provides:
0.12 -
Reverse Provides: