### PR TITLE
Minor edit to instcomp and comp

### DIFF
--- a/src/hal/utils/comp.g
+++ b/src/hal/utils/comp.g
@@ -971,7 +971,7 @@ def main():
             mode = DOCUMENT
         if k in ("-j", "--install-doc"):
             mode = INSTALLDOC
-        if k in ("-j", "--view-doc"):
+        if k in ("-v", "--view-doc"):
             mode = VIEWDOC
         if k in ("--print-modinc",):
             mode = MODINC

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -1298,7 +1298,7 @@ def main():
             mode = DOCUMENT
         if k in ("-j", "--install-doc"):
             mode = INSTALLDOC
-        if k in ("-j", "--view-doc"):
+        if k in ("-v", "--view-doc"):
             mode = VIEWDOC
         if k in ("--print-modinc",):
             mode = MODINC


### PR DESCRIPTION
Whilst reworking instcomp in another branch, realised that the single
letter commandline switch for --install-document and --view-document
was set to the same at 'j'

Blame goes way back!
https://github.com/LinuxCNC/linuxcnc/commit/86e2aa61f89517057ffe6ac991103c7eb4739c1e

Signed-off-by: Mick <arceye@mgware.co.uk>