### PR TITLE
hm2_soc: make robust against FPGA-not-loaded condition

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_soc.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc.h
@@ -48,9 +48,11 @@
 
 
 typedef struct {
-//    struct dts_dev *dev;
+    int fpga_state;
+    const char *fpga_dev;       // "fpga0"
     int  uio_fd;
-    char *uio_dev;
+    int firmware_given;
+    const char *uio_dev;
     void __iomem *base;
     int len;
     unsigned long ctrl_base_addr;


### PR DESCRIPTION
if u-boot does not load the fpga, and userland did not either, the FPGA
status is:

  cat /sys/class/fpga/fpga0/status
  power up phase

In this state, calling mmap(/dev/uio0) will currently crash the kernel
(at least 3.10.37-ltsi).

if the FPGA is loaded, either by u-boot or userland, status changes to
'user mode', and it is safe to mmap(/dev/uio0).

NB: 'user mode' persists a reboot - one needs to power off to return to
    'power up phase' - something I overlooked

This patch guards against accidential mmap() if in 'power up phase', by
more prudently investigating the status, and recording if firmware= was
specified at the loadrt hm2_soc command line or not.

altera_fpga_status() takes some code from the Altera FPGA kernel module.

we can now drop boot-time loading of the FPGA firmware for good, which
means we can adopt Robert Nelson's clever u-boot environment
configuration because it is now fpga agnostic.

Signed-off-by: Michael Haberler <git@mah.priv.at>