### PR TITLE
#903 Adding overlay based hostmot2 fpga driver required by Zynq SoCs

### DIFF
--- a/configs/hm2-soc-stepper/5i25-soc-ol.ini
+++ b/configs/hm2-soc-stepper/5i25-soc-ol.ini
@@ -1,0 +1,293 @@
+
+#The hm2 sample stepper config should be pretty close. Copy an existing say 
+#5I20.ini file to 5i25-probx.ini or some such, replace the BOARD with 5i25, 
+#delete the firmware string on the loadrt hm2 line and you should be pretty 
+#close. The hm2-soc-stepper file may need some changes as well for any GPIO may not 
+#make sense with the 5i25 config
+
+[HOSTMOT2]
+DRIVER=hm2_soc_ol
+BOARD=5i25
+CONFIG="firmware=zynq_5i25_overlay.dtbo num_encoders=0 num_pwmgens=0 num_stepgens=3"
+
+
+
+
+[EMC]
+
+#- Version of this INI file
+VERSION =               $Revision$
+
+# Name of machine, for use with display, etc.
+MACHINE =               HM2-Soc-OL-Stepper
+
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+#DEBUG =                0x00000003
+#DEBUG =                0x00000007
+DEBUG = 0
+
+
+
+
+[DISPLAY]
+
+# Name of display program, e.g., tkemc
+#DISPLAY =               tkemc
+DISPLAY =              axis
+
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.200
+
+# Path to help file
+#HELP_FILE =             tklinucnc.txt
+
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.5
+
+# Prefix to be used
+PROGRAM_PREFIX = ../../nc_files/
+
+# Introductory graphic
+INTRO_GRAPHIC =         machinekit.gif
+INTRO_TIME =            5
+
+# Increments for the JOG section
+INCREMENTS = 10 1 0.1 0.01
+
+
+#PYVCP = 3D.Temps.panel.xml
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+
+
+[TASK]
+
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.010
+
+
+
+
+[RS274NGC]
+
+# File containing interpreter variables
+PARAMETER_FILE =        hm2-soc-stepper.var
+
+
+
+
+[EMCMOT]
+
+EMCMOT =                motmod
+
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+
+# Interval between tries to emcmot, in seconds
+COMM_WAIT =             0.010
+
+#+ Base task period, in nanosecs - this is the fastest thread in the machine
+BASE_PERIOD =   200000
+
+#- Servo task period, in nanosecs - will be rounded to an int multiple of BASE_PERIOD
+SERVO_PERIOD =  2100000
+
+
+[HAL]
+
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+
+HALFILE =		hm2-soc-ol-stepper-5i25.hal
+
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =               save neta
+
+
+[TRAJ]
+NO_FORCE_HOMING = 1
+AXES =                  3
+COORDINATES =           X Y Z
+#HOME =                  0 0 0
+LINEAR_UNITS =          mm
+ANGULAR_UNITS =         degree
+CYCLE_TIME =            0.010
+
+DEFAULT_VELOCITY =      15
+MAX_VELOCITY =          300
+DEFAULT_ACCELERATION =  600
+MAX_ACCELERATION =      800
+MAX_LINEAR_VELOCITY = 200.00
+
+
+[AXIS_0]
+
+# 
+# Step timing is 40 us steplen + 40 us stepspace
+# That gives 80 us step period = 12.5 KHz step freq
+#
+# Bah, even software stepping can handle that, hm2 doesnt buy you much with
+# such slow steppers.
+#
+# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
+#
+# This gives a maxvel of 12.5/1 = 12.5 ips
+#
+
+
+TYPE =              LINEAR
+MAX_VELOCITY =       200
+MAX_ACCELERATION =   1000
+STEPGEN_MAX_VEL =    250
+STEPGEN_MAX_ACC =    1250
+# Set Stepgen max 20% higher than the axis
+
+#STEPGEN_MAX_VEL =    12
+#STEPGEN_MAX_ACC =    24
+
+#BACKLASH =           0.000
+
+# scale is 200 steps/rev * 5 revs/inch
+#SCALE =           1000
+SCALE =           320
+
+MIN_LIMIT =             -100.0
+MAX_LIMIT =             200.0
+
+#FERROR =     0.050
+#MIN_FERROR = 0.005
+FERROR =			2.0
+MIN_FERROR = 	0.20
+
+HOME =                  0.000
+HOME_OFFSET =           0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+HOME_USE_INDEX =                NO
+HOME_IGNORE_LIMITS =            NO
+
+# these are in nanoseconds
+DIRSETUP =			650
+DIRHOLD =			650
+STEPLEN =			1900
+STEPSPACE =			1900
+
+
+
+
+[AXIS_1]
+
+TYPE =              LINEAR
+MAX_VELOCITY =       200
+MAX_ACCELERATION =   1000
+STEPGEN_MAX_VEL =    250
+STEPGEN_MAX_ACC =    1250
+# Set Stepgen max 20% higher than the axis
+#STEPGEN_MAX_VEL =    12
+#STEPGEN_MAX_ACC =    24
+
+#BACKLASH =           0.000
+
+#SCALE = 1000
+#SCALE = 1250
+SCALE = 320
+
+MIN_LIMIT =             -100.0
+MAX_LIMIT =             100.0
+
+#FERROR =     0.050
+#MIN_FERROR = 0.005
+
+FERROR =			2.0
+MIN_FERROR =   0.20
+
+
+HOME =                  0.000
+HOME_OFFSET =           -0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+HOME_USE_INDEX =                NO
+HOME_IGNORE_LIMITS =            NO
+
+# these are in nanoseconds
+#DIRSETUP   =              200
+#DIRHOLD    =              200
+#STEPLEN    =              40000
+#STEPSPACE  =              40000
+
+DIRSETUP =			650
+DIRHOLD =			650
+STEPLEN =			1900
+STEPSPACE =			1900
+
+
+
+[AXIS_2]
+
+TYPE =              LINEAR
+MAX_VELOCITY =      10
+#MAX_ACCELERATION =  20
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    12
+STEPGEN_MAX_ACC =    24
+
+BACKLASH =           0.000
+
+SCALE = -1000
+
+MIN_LIMIT =             -100.0
+MAX_LIMIT =             100.0
+
+FERROR =     2.6
+MIN_FERROR = 0.26
+
+HOME =                  0.0
+HOME_OFFSET =           0.0
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+HOME_USE_INDEX =                 NO
+HOME_IGNORE_LIMITS =             NO
+
+# these are in nanoseconds
+#DIRSETUP   =              200
+#DIRHOLD    =              200
+#STEPLEN    =              40000
+#STEPSPACE  =              40000
+
+DIRSETUP =			650
+DIRHOLD =			650
+STEPLEN =			1900
+STEPSPACE =			1900
+
+
+
+[EMCIO]
+
+# Name of IO controller program, e.g., io
+EMCIO =                 io
+
+# cycle time, in seconds
+CYCLE_TIME =            0.100
+
+# tool table file
+TOOL_TABLE =            tool.tbl
+

--- a/configs/hm2-soc-stepper/hm2-soc-ol-stepper-5i25.hal
+++ b/configs/hm2-soc-stepper/hm2-soc-ol-stepper-5i25.hal
@@ -1,0 +1,208 @@
+# #######################################
+#
+# HAL file for HostMot2 with 3 steppers
+#
+# Derived from Ted Hyde's original hm2-servo config
+#
+# Based up work and discussion with Seb & Peter & Jeff
+# GNU license references - insert here. www.machinekit.io
+#
+#
+# ########################################
+# Firmware files are in /lib/firmware/hm2/7i43/
+# Must symlink the hostmot2 firmware directory of sanbox to
+# /lib/firmware before running EMC2...
+# sudo ln -s $HOME/emc2-sandbox/src/hal/drivers/mesa-hostmot2/firmware /lib/firmware
+#
+# See also:
+# <http://www.linuxcnc.org/docs/devel/html/man/man9/hostmot2.9.html#config%20modparam>
+# and http://wiki.linuxcnc.org/cgi-bin/emcinfo.pl?HostMot2
+#
+# #####################################################################
+
+
+# ###################################
+# Core EMC/HAL Loads
+# ###################################
+
+# kinematics
+loadrt trivkins
+
+# motion controller, get name and thread periods from ini file
+# trajectory planner
+loadrt tp
+
+# hostmot2 driver
+loadrt hostmot2
+
+# load low-level driver
+loadrt [HOSTMOT2](DRIVER) config=[HOSTMOT2](CONFIG)
+
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES  #tp=tp kins=trivkins
+
+# only the 7i43 needs this, but it doesnt hurt the others
+#loadrt probe_parport
+
+
+
+# ################################################
+# THREADS
+# ################################################
+
+addf motion-command-handler               servo-thread
+addf motion-controller                    servo-thread
+
+addf hm2_[HOSTMOT2](BOARD).0.write        servo-thread
+addf hm2_[HOSTMOT2](BOARD).0.read         servo-thread
+
+# revel in the free time here from not having to run PID
+#addf hm2_[HOSTMOT2](BOARD).0.pet_watchdog servo-thread
+
+
+# ######################################################
+# Axis-of-motion Specific Configs (not the GUI)
+# ######################################################
+
+
+# ################
+# X [0] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.00.enable bit
+sets emcmot.00.enable FALSE
+
+net emcmot.00.enable <= axis.0.amp-enable-out
+net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.00.enable
+
+
+# position command and feedback
+net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
+net emcmot.00.pos-cmd => hm2_[HOSTMOT2](BOARD).0.stepgen.00.position-cmd
+
+net motor.00.pos-fb <= hm2_[HOSTMOT2](BOARD).0.stepgen.00.position-fb
+net motor.00.pos-fb => axis.0.motor-pos-fb
+
+
+# timing parameters
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.dirhold         [AXIS_0]DIRHOLD
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.stepspace       [AXIS_0]STEPSPACE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.position-scale  [AXIS_0]SCALE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.step_type       0
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.control-type    0
+
+
+# ################
+# Y [1] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.01.enable bit
+sets emcmot.01.enable FALSE
+
+net emcmot.01.enable <= axis.1.amp-enable-out
+net emcmot.01.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.01.enable
+
+
+# position command and feedback
+net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
+net emcmot.01.pos-cmd => hm2_[HOSTMOT2](BOARD).0.stepgen.01.position-cmd
+
+net motor.01.pos-fb <= hm2_[HOSTMOT2](BOARD).0.stepgen.01.position-fb
+net motor.01.pos-fb => axis.1.motor-pos-fb
+
+
+# timing parameters
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.dirhold         [AXIS_1]DIRHOLD
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.stepspace       [AXIS_1]STEPSPACE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.position-scale  [AXIS_1]SCALE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.step_type       0
+
+
+# ################
+# Z [2] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.02.enable bit
+sets emcmot.02.enable FALSE
+
+net emcmot.02.enable <= axis.2.amp-enable-out
+net emcmot.02.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.02.enable
+
+
+# position command and feedback
+net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
+net emcmot.02.pos-cmd => hm2_[HOSTMOT2](BOARD).0.stepgen.02.position-cmd
+
+net motor.02.pos-fb <= hm2_[HOSTMOT2](BOARD).0.stepgen.02.position-fb
+net motor.02.pos-fb => axis.2.motor-pos-fb
+
+
+# timing parameters
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.dirhold         [AXIS_2]DIRHOLD
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.stepspace       [AXIS_2]STEPSPACE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.position-scale  [AXIS_2]SCALE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.step_type       0
+
+
+
+
+#
+# The Mesa AnyIO output pins can be in open-drain mode (drive low, float
+# high) or push/pull mode (drive low, drive high).
+#
+# When a logical output is 1 in open-drain mode, the FPGA lets the pin
+# float and it gets pulled high to +5V via a 10K resistor.
+#
+# When a logical output is 1 in push/pull mode, the FPGA pushes the pin
+# high but only to +3.3V.  This is problematic on some kinds of inputs.
+#
+
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.048.is_opendrain 1
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.049.is_opendrain 1
+
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.054.is_opendrain 1
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.055.is_opendrain 1
+
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.060.is_opendrain 1
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.061.is_opendrain 1
+
+
+
+
+# ##################################################
+# Standard I/O Block - EStop, Etc
+# ##################################################
+
+# create a signal for the estop loopback
+net estop-loop iocontrol.0.user-enable-out => iocontrol.0.emc-enable-in
+
+# create signals for tool loading loopback
+net tool-prep-loop iocontrol.0.tool-prepare => iocontrol.0.tool-prepared
+net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -1265,8 +1265,9 @@ endif
 
 ifdef TARGET_PLATFORM_SOCFPGA
 ifeq ($(BUILD_SYS),user-dso)
-obj-$(CONFIG_HM2_SOC) += hm2_soc.o
+obj-$(CONFIG_HM2_SOC) += hm2_soc.o hm2_soc_ol.o
 hm2_soc-objs := hal/drivers/mesa-hostmot2/hm2_soc.o
+hm2_soc_ol-objs := hal/drivers/mesa-hostmot2/hm2_soc_ol.o
 endif
 endif
 
@@ -1678,6 +1679,7 @@ ifdef TARGET_PLATFORM_SOCFPGA
 ifeq ($(BUILD_SYS),user-dso)
 $(RTLIBDIR)/hostmot2$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hostmot2-objs))
 $(RTLIBDIR)/hm2_soc$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hm2_soc-objs))
+$(RTLIBDIR)/hm2_soc_ol$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hm2_soc_ol-objs))
 endif
 endif
 

--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
@@ -1,0 +1,507 @@
+//
+//    Copyright (C) 2007-2008 Sebastian Kuzminsky
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+//    Transformed for Machinekit socfpga in 2016 by Michael Brown
+//    Copyright (C) Holotronic 2016-2017
+//
+//    some polishings Michael Haberler 2016
+//
+//    Rewritten for overlay based FPGA manager interface
+//    Copyright (C) 2016 Devin Hughes, JD Squared
+
+// in device tree (sos_system.dts)
+// Address comes from FPGA project map
+//
+//  hm2reg_io_0: hm2-socfpga@0x100040000 {
+//      compatible = "machkt,hm2reg-io-1.0";
+//      reg = <0x00000001 0x00040000 0x00010000>;
+//      clocks = <&clk_0>;
+//  }; //end hm2-socfpga@0x100040000 (hm2reg_io_0)
+//---------------------------------------------------------------------------//
+
+#include "config.h"
+
+// this should be an general socfpga #define
+#if !defined(TARGET_PLATFORM_SOCFPGA)
+#error "This driver is for the socfpga platform only"
+#endif
+
+#if !defined(BUILD_SYS_USER_DSO)
+#error "This driver is for usermode threads only"
+#endif
+
+#include "rtapi.h"
+#include "rtapi_app.h"
+#include "rtapi_string.h"
+#include "rtapi_hexdump.h"
+#include "rtapi_compat.h"
+#include "rtapi_io.h"
+#include "hal.h"
+#include "hal/lib/config_module.h"
+#include "hostmot2-lowlevel.h"
+#include "hostmot2.h"
+#include "hm2_soc_ol.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <string.h>
+#include <ctype.h>
+
+/* Wrap up dt state */
+#define DTOV_STAT_UNAPPLIED	0x0
+#define DTOV_STAT_APPLIED 	0x1
+
+#define HM2REG_IO_0_SPAN 65536
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Michael Brown & Michael Haberler & Devin Hughes");
+MODULE_DESCRIPTION("Low level driver for HostMot2 on SoC Based Devices");
+MODULE_SUPPORTED_DEVICE("Mesa-AnythingIO-5i25");
+
+static char *config[HM2_SOC_MAX_BOARDS];
+RTAPI_MP_ARRAY_STRING(config, HM2_SOC_MAX_BOARDS,
+		      "config string for the AnyIO boards (see hostmot2(9) manpage)")
+static int debug;
+RTAPI_MP_INT(debug, "turn on extra debug output");
+
+static char *uio_dev = "/dev/uio0";
+RTAPI_MP_STRING(uio_dev, "UIO device to use; default /dev/uio0");
+
+static int comp_id;
+static hm2_soc_t board[HM2_SOC_MAX_BOARDS];
+static int num_boards;
+static int failed_errno = 0; // errno of last failed registration
+/* Pick a configfs folder that is unlikely to conflict with other overlays */
+static char *configfs_dir = "/sys/kernel/config/device-tree/overlays/hm2_soc_ol";
+static char *configfs_path = "/sys/kernel/config/device-tree/overlays/hm2_soc_ol/path";
+static char *configfs_status = "/sys/kernel/config/device-tree/overlays/hm2_soc_ol/status";
+
+
+static int hm2_soc_mmap(hm2_soc_t *board);
+
+static int fpga_status();
+static char *strlwr(char *str);
+
+//
+// these are the "low-level I/O" functions exported up
+//
+static int hm2_soc_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+    hm2_soc_t *board = this->private;
+    int i;
+    u32* src = (u32*) (board->base + addr);
+    u32* dst = (u32*) buffer;
+
+    /* Per Peter Wallace, all hostmot2 access should be 32 bits and 32-bit aligned */
+    /* Check for any address or size values that violate this alignment */
+    if ( ((addr & 0x3) != 0) || ((size & 0x03) != 0) ){
+        u16* dst16 = (u16*) dst;
+        u16* src16 = (u16*) src;
+        /* hm2_read_idrom performs a 16-bit read, which seems to be OK, so let's allow it */
+        if ( ((addr & 0x1) != 0) || (size != 2) ){
+            LL_ERR( "hm2_soc_read: Unaligned Access: %08x %04x\n", addr,size);
+            memcpy(dst, src, size);
+            return 1;  // success
+        }
+        dst16[0] = src16[0];
+        return 1;  // success
+    }
+    for (i=0; i<(size/4); i++) {
+        dst[i] = src[i];
+    }
+    return 1;  // success
+}
+
+static int hm2_soc_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+    hm2_soc_t *board = this->private;
+    int i;
+    u32* src = (u32*) buffer;
+    u32* dst = (u32*) (board->base + addr);
+
+    /* Per Peter Wallace, all hostmot2 access should be 32 bits and 32-bit aligned */
+    /* Check for any address or size values that violate this alignment */
+    if ( ((addr & 0x3) != 0) || ((size & 0x03) != 0) ){
+        LL_ERR( "hm2_soc_write: Unaligned Access: %08x %04x\n", addr,size);
+        memcpy(dst, src, size);
+        return 1;  // success
+    }
+
+    for (i=0; i<(size/4); i++) {
+        dst[i] = src[i];
+    }
+    return 1;  // success
+}
+
+// when no firmware= was specified, hm2_register() will read/write from the
+// (as of yet unmapped) fpga region. Trap this case by lazy mapping - this will
+// happen only once at startup as hm2_soc_mmap() sets llio->read&write
+// to hm2_soc_read & hm2_soc_write.
+static int hm2_soc_unmapped_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+    hm2_soc_t *board = this->private;
+    int rc = hm2_soc_mmap(board);
+    if (rc)
+	return rc;
+    return hm2_soc_read(this, addr, buffer, size);
+}
+
+static int hm2_soc_unmapped_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+    hm2_soc_t *board = this->private;
+    int rc = hm2_soc_mmap(board);
+    if (rc)
+	return rc;
+    return hm2_soc_write(this, addr, buffer, size);
+}
+
+static int hm2_soc_verify_firmware(hm2_lowlevel_io_t *this,  const struct firmware *fw) {
+    // Overlay based drivers need the *name* of the overlay, not the contents.
+    if(this->firmware == NULL) {
+	LL_ERR("NULL firmware name, unable to program fpga");
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static int hm2_soc_reset(hm2_lowlevel_io_t *this) {
+    // currently not needed
+    LL_DBG( "soc_reset");
+    return 0;
+}
+
+/* Updated to program fpga by applying overlay */
+static int hm2_soc_program_fpga(hm2_lowlevel_io_t *this,
+				const bitfile_t *bitfile,
+				const struct firmware *fw) {
+
+    int rc;
+    hm2_soc_t *board =  this->private;
+
+    LL_DBG("soc_program_fpga");
+
+    // To program with an overlay, simply create a folder in the
+    // configfs device-tree/overlays/ folder. The kernel autogenerates
+    // three files in the directory. Write the name of a valid overlay
+    // on the firmware path to the "path" node and it will do all of the
+    // magic.
+
+    DIR* dir = opendir(configfs_dir);
+    if(dir) {
+        // old config left behind? - Directory always appears empty
+        // so okay to call rmdir()
+        if(rmdir(configfs_dir) < 0) {
+            LL_ERR("rmdir(%s) failed: %s", configfs_dir, strerror(errno));
+            return -EIO;
+        }
+    }
+
+    // umask will clip permissions to match parent
+    if(mkdir(configfs_dir, 0777) < 0) {
+        LL_ERR("mkdir(%s) failed: %s", configfs_dir, strerror(errno));
+        return -EIO;
+    }
+
+    //
+    int fd;
+        
+    // Spin to give configfs time to make the files
+    int retries = 10;
+    while(retries > 0) {
+        fd = open(configfs_path, O_WRONLY);
+        if (fd != -1)
+            break;
+        retries--;
+        usleep(200000);
+    }    
+    
+    if (fd < 0) {
+        LL_ERR("open(%s) failed: %s", configfs_path, strerror(errno));
+        return -EIO;
+    }
+
+    int size = strlen(this->firmware);
+    
+    // load FPGA by writing the name of the overlay to the path node
+    if (write(fd, this->firmware, size) != size)  {
+        LL_ERR("write(%s, %zu) failed: %s",
+            this->firmware, size, strerror(errno));
+        close(fd);
+        return -EIO;
+    }
+    close(fd);
+    
+    // Spin to give fpga time to program
+    retries = 12;
+    while(retries > 0) {
+        board->fpga_state = fpga_status();
+        if (board->fpga_state == DTOV_STAT_APPLIED)
+            break;
+        retries--;
+        usleep(250000);
+    }
+   
+    if (board->fpga_state != DTOV_STAT_APPLIED) {
+        LL_ERR("DTOverlay status is not applied post programming: state=%d",
+            board->fpga_state);
+        return -ENOENT;
+    }
+
+    rc = hm2_soc_mmap(this->private);
+    if (rc) {
+        LL_ERR("soc_mmap_fail");
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static int hm2_soc_mmap(hm2_soc_t *board) {
+
+    volatile void *virtual_base;
+    hm2_lowlevel_io_t *this = &board->llio;
+
+    // we can mmap this device safely only if programmed so cop out
+    if (board->fpga_state != DTOV_STAT_APPLIED) {
+        LL_ERR("invalid fpga state %d, unsafe to mmap %s",
+            board->fpga_state, board->uio_dev);
+        return -EIO;
+    }
+
+    // Fix race from overlay framework
+    // spin to give uio device time to appear with proper permissions
+    int retries = 10;
+    while(retries > 0) {
+        board->uio_fd = open(board->uio_dev , ( O_RDWR | O_SYNC ));
+        if (board->uio_fd != -1)
+            break;
+        retries--;
+        usleep(200000);
+    }
+    
+    if (board->uio_fd < 0) {
+        LL_ERR("Could not open %s: %s",  board->uio_dev, strerror(errno));
+        return -errno;
+    }
+    virtual_base = mmap( NULL, HM2REG_IO_0_SPAN, ( PROT_READ | PROT_WRITE ),
+                         MAP_SHARED, board->uio_fd, 0);
+
+    if (virtual_base == MAP_FAILED) {
+        LL_ERR( "mmap failed: %s", strerror(errno));
+            close(board->uio_fd);
+        board->uio_fd = -1;
+        return -EINVAL;
+    }
+
+    if (debug)
+    rtapi_print_hex_dump(RTAPI_MSG_INFO, RTAPI_DUMP_PREFIX_OFFSET,
+		         16, 1, (const void *)virtual_base, 4096, 1,
+		         "hm2 regs at %p:", virtual_base);
+
+    // this duplicates stuff already happening in hm2_register - no harm
+    u32 reg = *((u32 *)(virtual_base + HM2_ADDR_IOCOOKIE));
+    if (reg != HM2_IOCOOKIE) {
+        LL_ERR("invalid cookie, got 0x%08X, expected 0x%08X\n", reg, HM2_IOCOOKIE);
+        LL_ERR( "FPGA failed to initialize, or unexpected firmware?\n");
+        close(board->uio_fd);
+        board->uio_fd = -1;
+        return -EINVAL;
+    }
+
+    reg = *((u32 *)(virtual_base + HM2_ADDR_IDROM_OFFSET));
+    hm2_idrom_t *idrom = (void *)(virtual_base + reg);
+
+    LL_DBG("hm2 cookie check OK, board name='%8.8s'", idrom->board_name);
+
+    void *configname = (void *)virtual_base + HM2_ADDR_CONFIGNAME;
+    if (strncmp(configname, HM2_CONFIGNAME, HM2_CONFIGNAME_LENGTH) != 0) {
+        LL_ERR("%s signature not found at %p", HM2_CONFIGNAME, configname);
+        close(board->uio_fd);
+        board->uio_fd = -1;
+        return -EINVAL;
+    }
+
+    // use BoardNameHigh as board name - see http://freeby.mesanet.com/regmap
+    rtapi_snprintf(this->name, sizeof(this->name), "hm2_%4.4s.%d",
+                   idrom->board_name + 4, num_boards);
+    strlwr(this->name);
+    board->base = (void *)virtual_base;
+    // now it's safe to read/write
+    this->read = hm2_soc_read;
+    this->write = hm2_soc_write;
+    return 0;
+}
+
+static int hm2_soc_register(hm2_soc_t *brd, const char *uiodev) {
+    memset(brd, 0,  sizeof(hm2_soc_t));
+
+    // no directory to check state yet, so it's unknown
+    brd->fpga_state = -1;
+    brd->uio_dev = uio_dev;
+
+    brd->llio.comp_id = comp_id;
+    brd->llio.num_ioport_connectors = 2;
+    brd->llio.pins_per_connector = 17;
+    brd->llio.ioport_connector_name[0] = "P3";
+    brd->llio.ioport_connector_name[1] = "P2";
+    brd->llio.fpga_part_number = 0; // "6slx9tqg144";
+    brd->llio.num_leds = 2;
+
+    // keeps hm2_register happy - will be overwritten
+    // once the FPGA regs are accessible
+    strcpy( brd->llio.name, "foo");
+
+    brd->llio.threadsafe = 1;
+
+    // not safe to read yet as fpga memory not yet mapped
+    // so trap this on first downcall
+    brd->llio.read = hm2_soc_unmapped_read;
+    brd->llio.write = hm2_soc_unmapped_write;
+    brd->llio.reset = hm2_soc_reset;
+
+    // hm2_register will downcall on those if firmware= given
+    brd->llio.program_fpga = hm2_soc_program_fpga;
+    brd->llio.verify_firmware = hm2_soc_verify_firmware;
+
+    brd->llio.private = brd;
+    hm2_lowlevel_io_t *this =  &brd->llio;
+
+    int r = hm2_register( this, config[0]);
+    if (r != 0) {
+        THIS_ERR("hm2_soc_ol_board fails HM2 registration\n");
+        close(brd->uio_fd);
+        board->uio_fd = -1;
+        return -EIO;
+    }
+
+    LL_PRINT("initialized AnyIO hm2_soc_ol_board \n");
+    num_boards++;
+    return 0;
+}
+
+
+static int hm2_soc_munmap(hm2_soc_t *board) {
+    if (board->base != NULL)
+        munmap((void *) board->base, HM2REG_IO_0_SPAN);
+    if (board->uio_fd > -1) {
+        close(board->uio_fd);
+        board->uio_fd = -1;
+    }
+    return(1);
+}
+
+int rtapi_app_main(void) {
+    int r = 0;
+
+    LL_PRINT("loading Mesa AnyIO HostMot2 socfpga overlay driver version " HM2_SOCFPGA_VERSION "\n");
+
+    // Don't check for the hm2 module here, it hasn't been probed yet...
+
+    comp_id = hal_init(HM2_LLIO_NAME);
+    if (comp_id < 0) return comp_id;
+
+    r = hm2_soc_register(&board[0], uio_dev);
+    if (r != 0) {
+        LL_ERR("error registering UIO driver\n");
+        hal_exit(comp_id);
+        return r;
+    }
+
+    if (failed_errno) {
+        // at least one card registration failed
+        hal_exit(comp_id);
+        r = hm2_soc_munmap(&board[0]);
+        return r;
+    }
+
+    if (num_boards == 0) {
+        // no cards were detected
+        LL_PRINT("error - no supported cards detected\n");
+        hal_exit(comp_id);
+        r = hm2_soc_munmap(&board[0]);
+        return r;
+    }
+
+    hal_ready(comp_id);
+    return 0;
+}
+
+
+void rtapi_app_exit(void) {
+    hm2_unregister(&board->llio);
+    hm2_soc_munmap(&board[0]);
+    // Clean up the overlay
+    rmdir(configfs_dir);
+    LL_PRINT("UIO driver unloaded\n");
+    hal_exit(comp_id);
+}
+
+
+static char *strlwr(char *str) {
+  unsigned char *p = (unsigned char *)str;
+  while (*p) {
+     *p = tolower(*p);
+      p++;
+  }
+  return str;
+}
+
+struct dt_ol_state {
+    int state;
+    char *name;
+};
+
+static struct dt_ol_state dt_ol_states[] = {
+    { DTOV_STAT_UNAPPLIED, "unapplied" },
+    { DTOV_STAT_APPLIED, "applied" },
+    { -1, NULL }
+};
+
+static int fpga_status() {
+    // The device tree status node only has two choices. If the state is applied
+    // then the fpga was configured correctly, and any modules are probed.
+    int fd = open(configfs_status, O_RDONLY);
+    if (fd < 0) {
+        LL_ERR( "Failed to open sysfs entry '%s': %s\n",
+                configfs_status, strerror(errno));
+        return -errno;
+    }
+
+    char status[50];
+    memset(status, 0, sizeof(status));
+    int len = read(fd, status, sizeof(status));
+    if (len < 0)  {
+        LL_ERR( "Failed to read sysfs entry '%s': %s\n",
+                configfs_status, strerror(errno));
+        close(fd);
+        return -errno;
+    }
+    close(fd);
+    struct dt_ol_state *fs = dt_ol_states;
+    while (fs->state > -1) {
+        if (strncmp(status, fs->name, strlen(fs->name)) == 0) {
+            LL_DBG( "FPGA overlay status: %s", status);
+            return fs->state;
+        }
+        fs++;
+    }
+    
+    // state wasn't recognized from array
+    LL_ERR( "FPGA overlay unknown status: %s", status);
+    return -EINVAL;
+}
+

--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.h
@@ -1,0 +1,53 @@
+
+//
+//    Copyright (C) 2007-2008 Sebastian Kuzminsky
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+
+#define HM2_SOCFPGA_VERSION "0.9"
+
+#define HM2_LLIO_NAME "hm2_soc_ol"
+
+#define HM2_SOC_MAX_BOARDS  2
+
+typedef struct {
+    int fpga_state;
+    int  uio_fd;
+    int firmware_given;
+    const char *uio_dev;
+    void __iomem *base;
+    int len;
+    unsigned long ctrl_base_addr;
+    unsigned long data_base_addr;
+    char *firmware;
+    hm2_lowlevel_io_t llio;
+} hm2_soc_t;
+
+struct compatible {
+    char vendor[32];
+    char name[32];
+};
+
+struct dts_device_id {
+    unsigned short address_width;           //address width /
+    unsigned short clocks;                  // clocks /
+    struct compatible compatible;
+    unsigned short data_width;       /* (class,subclass,prog-if) triplet */
+    char name[32];
+    unsigned long reg[3];
+};
+

--- a/src/hal/drivers/mesa-hostmot2/hostmot2-lowlevel.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2-lowlevel.h
@@ -120,6 +120,8 @@ struct hm2_lowlevel_io_struct {
     // if FALSE, the hostmot2 driver will export only global read() and write() functions (and pet_watchdog())
     // if TRUE, the hostmot2 driver will export those three functions and also read_gpio() and write_gpio()
     int threadsafe;
+    
+    char *firmware; // Name of the firmware file
 
     void *private;  // for the low-level driver to hang their struct on
 };

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.c
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.c
@@ -1191,7 +1191,7 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
         goto fail0;
     }
 
-
+    llio->firmware = hm2->config.firmware;
 
     // NOTE: program_fpga will be NULL for 6i25 and 5i25 (and future cards 
     // with EPROM firmware, probably. 


### PR DESCRIPTION
Issue #903: This is the overlay based fpga driver used to get the Zynq port functioning correctly. 
I separated the driver into it's own module to keep backwards compatibility with the kernel 3 version altera soc code. This overlay based driver is generic - it should work on any fpga device provided it supports the configfs overlay based fpga framework.

The driver must be passed the name of the overlay file through the hostmot2 config string. Due to the way the bit file is passed to the low level drivers (i.e., too late), a new value had to be added to the low level io struct. Should not break any compatibility with other llio drivers. This avoids duplicating config string parsing in the low level driver.