### PR TITLE
Fix up of package paths and return 3 desktops

### DIFF
--- a/debian/extras/usr/share/applications/linuxcnc-latency.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-latency.desktop
@@ -2,11 +2,11 @@
 Encoding=UTF-8
 Version=
 Type=Application
-Exec=/usr/bin/machinekit
+Exec=/usr/bin/latency-test
 Icon=machinekiticon
 X-GNOME-DocPath=
 Terminal=false
-Name=Machinekit
-Comment=The Machinekit CNC Machine Controller
+Name=Latency Test
+Comment=Determine your machine's latency
 StartupNotify=false
 Categories=X-CNC;

--- a/debian/extras/usr/share/applications/linuxcnc-pncconf.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-pncconf.desktop
@@ -2,11 +2,11 @@
 Encoding=UTF-8
 Version=
 Type=Application
-Exec=/usr/bin/machinekit
+Exec=/usr/bin/pncconf
 Icon=machinekiticon
 X-GNOME-DocPath=
 Terminal=false
-Name=Machinekit
-Comment=The Machinekit CNC Machine Controller
+Comment=Configuration Wizard For Mesa I/O Cards
 StartupNotify=false
 Categories=X-CNC;
+Name=Machinekit Pncconf Wizard

--- a/debian/extras/usr/share/applications/linuxcnc-stepconf.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-stepconf.desktop
@@ -2,11 +2,11 @@
 Encoding=UTF-8
 Version=
 Type=Application
-Exec=/usr/bin/machinekit
+Exec=/usr/bin/stepconf
 Icon=machinekiticon
 X-GNOME-DocPath=
 Terminal=false
-Name=Machinekit
-Comment=The Machinekit CNC Machine Controller
+Name=Machinekit Stepconf Wizard
+Comment=Stepconf Configuration Wizard
 StartupNotify=false
 Categories=X-CNC;

--- a/debian/machinekit.install
+++ b/debian/machinekit.install
@@ -33,12 +33,7 @@ usr/share/gtksourceview-2.0/
 usr/share/gscreen
 usr/share/gmoccapy
 usr/share/fdm
-usr/share/applications/linuxcnc.desktop
-#usr/share/applications/linuxcnc-gcoderef.desktop
-#usr/share/applications/linuxcnc-gcoderef-fr.desktop
-#usr/share/applications/linuxcnc-latency.desktop
-#usr/share/applications/linuxcnc-stepconf.desktop
-#usr/share/applications/linuxcnc-pncconf.desktop
+usr/share/applications/*
 usr/share/desktop-directories/cnc.directory
 etc/modprobe.d/linuxcnc.conf
 etc/xdg/menus/applications-merged/cnc.menu

--- a/debian/machinekit.postinst
+++ b/debian/machinekit.postinst
@@ -44,6 +44,15 @@ else
     fi
 fi
 
+# Until rebranded completely solve corner cases like this
 
+if [ -f "/usr/share/linuxcnc" ]; then
+    if [ ! -f "/usr/share/machinekit" ]; then
+	if [ ! -L "/usr/share/machinekit" ]; then
+	    ln -s /usr/share/linuxcnc /usr/share/machinekit
+	    echo "Creating machinekit symlink"
+	fi
+    fi
+fi
 
 

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -168,7 +168,7 @@ install: build
 	rm -f debian/tmp/usr/share/applications/linuxcnc-integratormanual*.desktop
 	rm -f debian/tmp/usr/share/applications/linuxcnc-gettingstarted*.desktop
 	rm -f debian/tmp/usr/share/applications/linuxcnc-developer*.desktop
-
+	
 	rm -rf debian/tmp/usr/share/doc/linuxcnc/html
 	rm -f debian/tmp/usr/share/linuxcnc/examples/sample-configs/*/*position*.txt
 	# update emcweb.hal


### PR DESCRIPTION
Until full rebranding is done, ensure /usr/share/machinekit exists by
postinst symlink to /usr/share/linuxcnc

Reverted removal of 3 desktop links and updated

Fixes  #938 and fixes #939

Signed-off-by: Mick <arceye@mgware.co.uk>