### PR TITLE
Hm2 soc cramps + firmware path length expansion

### DIFF
--- a/configs/hm2-soc-stepper/5i25-soc-cramps.ini
+++ b/configs/hm2-soc-stepper/5i25-soc-cramps.ini
@@ -1,0 +1,293 @@
+
+#The hm2 sample stepper config should be pretty close. Copy an existing say
+#5I20.ini file to 5i25-probx.ini or some such, replace the BOARD with 5i25,
+#delete the firmware string on the loadrt hm2 line and you should be pretty
+#close. The hm2-soc-stepper file may need some changes as well for any GPIO may not
+#make sense with the 5i25 config
+
+[HOSTMOT2]
+DRIVER=hm2_soc_ol
+BOARD=5i25
+CONFIG="firmware=socfpga/dtbo/hm2reg_uio.dtbo num_encoders=2 num_pwmgens=2 num_stepgens=10"
+
+
+
+
+[EMC]
+
+#- Version of this INI file
+VERSION =               $Revision$
+
+# Name of machine, for use with display, etc.
+MACHINE =               HM2-Soc-OL-Stepper
+
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+#DEBUG =                0x00000003
+#DEBUG =                0x00000007
+DEBUG = 0
+
+
+
+
+[DISPLAY]
+
+# Name of display program, e.g., tkemc
+#DISPLAY =               tkemc
+DISPLAY =              axis
+
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.200
+
+# Path to help file
+#HELP_FILE =             tklinucnc.txt
+
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.5
+
+# Prefix to be used
+PROGRAM_PREFIX = ../../nc_files/
+
+# Introductory graphic
+INTRO_GRAPHIC =         machinekit.gif
+INTRO_TIME =            2
+
+# Increments for the JOG section
+INCREMENTS = 10 1 0.1 0.01
+
+
+#PYVCP = 3D.Temps.panel.xml
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+
+
+[TASK]
+
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.010
+
+
+
+
+[RS274NGC]
+
+# File containing interpreter variables
+PARAMETER_FILE =        hm2-soc-stepper.var
+
+
+
+
+[EMCMOT]
+
+EMCMOT =                motmod
+
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+
+# Interval between tries to emcmot, in seconds
+COMM_WAIT =             0.010
+
+#+ Base task period, in nanosecs - this is the fastest thread in the machine
+BASE_PERIOD =   200000
+
+#- Servo task period, in nanosecs - will be rounded to an int multiple of BASE_PERIOD
+SERVO_PERIOD =  2100000
+
+
+[HAL]
+
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+
+HALFILE =		hm2-soc-stepper-5i25-cramps.hal
+
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =               save neta
+
+
+[TRAJ]
+
+AXES =                  3
+COORDINATES =           X Y Z
+#HOME =                  0 0 0
+LINEAR_UNITS =          mm
+ANGULAR_UNITS =         degree
+CYCLE_TIME =            0.010
+
+DEFAULT_VELOCITY =      15
+MAX_VELOCITY =          3000
+DEFAULT_ACCELERATION =  6000
+MAX_ACCELERATION =      8000
+MAX_LINEAR_VELOCITY = 2000.00
+
+
+[AXIS_0]
+
+#
+# Step timing is 40 us steplen + 40 us stepspace
+# That gives 80 us step period = 12.5 KHz step freq
+#
+# Bah, even software stepping can handle that, hm2 doesnt buy you much with
+# such slow steppers.
+#
+# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
+#
+# This gives a maxvel of 12.5/1 = 12.5 ips
+#
+
+
+TYPE =              LINEAR
+MAX_VELOCITY =       200
+MAX_ACCELERATION =   1000
+STEPGEN_MAX_VEL =    250
+STEPGEN_MAX_ACC =    1250
+# Set Stepgen max 20% higher than the axis
+
+#STEPGEN_MAX_VEL =    12
+#STEPGEN_MAX_ACC =    24
+
+#BACKLASH =           0.000
+
+# scale is 200 steps/rev * 5 revs/inch
+#SCALE =           1000
+SCALE =           320
+
+MIN_LIMIT =             -100.0
+MAX_LIMIT =             100.0
+
+#FERROR =     0.050
+#MIN_FERROR = 0.005
+FERROR =			2.0
+MIN_FERROR = 	0.20
+
+HOME =                  0.000
+HOME_OFFSET =           0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+HOME_USE_INDEX =                NO
+HOME_IGNORE_LIMITS =            NO
+
+# these are in nanoseconds
+DIRSETUP =			650
+DIRHOLD =			650
+STEPLEN =			1900
+STEPSPACE =			1900
+
+
+
+
+[AXIS_1]
+
+TYPE =              LINEAR
+MAX_VELOCITY =       20000
+MAX_ACCELERATION =   100000
+STEPGEN_MAX_VEL =    25000
+STEPGEN_MAX_ACC =    125000
+# Set Stepgen max 20% higher than the axis
+#STEPGEN_MAX_VEL =    12
+#STEPGEN_MAX_ACC =    24
+
+#BACKLASH =           0.000
+
+#SCALE = 1000
+#SCALE = 1250
+SCALE = 640
+
+MIN_LIMIT =             -1000.0
+MAX_LIMIT =             1000.0
+
+#FERROR =     0.050
+#MIN_FERROR = 0.005
+
+FERROR =			2.0
+MIN_FERROR =   0.20
+
+
+HOME =                  0.000
+HOME_OFFSET =           -0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+HOME_USE_INDEX =                NO
+HOME_IGNORE_LIMITS =            NO
+
+# these are in nanoseconds
+#DIRSETUP   =              200
+#DIRHOLD    =              200
+#STEPLEN    =              40000
+#STEPSPACE  =              40000
+
+DIRSETUP =			30
+DIRHOLD =			30
+STEPLEN =			30
+STEPSPACE =			30
+
+
+
+[AXIS_2]
+
+TYPE =              LINEAR
+MAX_VELOCITY =      10
+#MAX_ACCELERATION =  20
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    12
+STEPGEN_MAX_ACC =    24
+
+BACKLASH =           0.000
+
+SCALE = -1000
+
+MIN_LIMIT =             -100.0
+MAX_LIMIT =             100.0
+
+FERROR =     12.6
+MIN_FERROR = 1.26
+
+HOME =                  0.0
+HOME_OFFSET =           0.0
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+HOME_USE_INDEX =                 NO
+HOME_IGNORE_LIMITS =             NO
+
+# these are in nanoseconds
+#DIRSETUP   =              200
+#DIRHOLD    =              200
+#STEPLEN    =              40000
+#STEPSPACE  =              40000
+
+DIRSETUP =			650
+DIRHOLD =			650
+STEPLEN =			1900
+STEPSPACE =			1900
+
+
+
+[EMCIO]
+
+# Name of IO controller program, e.g., io
+EMCIO =                 io
+
+# cycle time, in seconds
+CYCLE_TIME =            0.100
+
+# tool table file
+TOOL_TABLE =            tool.tbl
+

--- a/configs/hm2-soc-stepper/hm2-soc-stepper-5i25-cramps.hal
+++ b/configs/hm2-soc-stepper/hm2-soc-stepper-5i25-cramps.hal
@@ -1,0 +1,218 @@
+# #######################################
+#
+# HAL file for HostMot2 Socfpga with 10 steppers cramps cape variant
+#
+# Derived from Ted Hyde's original hm2-servo config
+#
+# Based up work and discussion with Seb & Peter & Jeff
+# GNU license references - insert here. www.machinekit.io
+#
+# Adapted for the Mksocfpga platform for testing use with a cramps cape,
+# By Michael Brown Holotronic 2016
+#
+# ########################################
+# Firmware files are in /lib/firmware/hm2/7i43/
+# Must symlink the hostmot2 firmware directory of sanbox to
+# /lib/firmware before running EMC2...
+# sudo ln -s $HOME/emc2-sandbox/src/hal/drivers/mesa-hostmot2/firmware /lib/firmware/hm2
+#
+# See also:
+# <http://www.linuxcnc.org/docs/devel/html/man/man9/hostmot2.9.html#config%20modparam>
+# and http://wiki.linuxcnc.org/cgi-bin/emcinfo.pl?HostMot2
+#
+# #####################################################################
+
+
+# ###################################
+# Core EMC/HAL Loads
+# ###################################
+
+# kinematics
+loadrt trivkins
+
+# motion controller, get name and thread periods from ini file
+# trajectory planner
+loadrt tp
+
+# hostmot2 driver
+loadrt hostmot2
+
+# load low-level driver
+loadrt [HOSTMOT2](DRIVER) config=[HOSTMOT2](CONFIG)
+
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES  #tp=tp kins=trivkins
+
+# only the 7i43 needs this, but it doesnt hurt the others
+#loadrt probe_parport
+
+
+
+# ################################################
+# THREADS
+# ################################################
+
+addf motion-command-handler               servo-thread
+addf motion-controller                    servo-thread
+
+addf hm2_[HOSTMOT2](BOARD).0.write        servo-thread
+addf hm2_[HOSTMOT2](BOARD).0.read         servo-thread
+
+# revel in the free time here from not having to run PID
+#addf hm2_[HOSTMOT2](BOARD).0.pet_watchdog servo-thread
+
+
+# ######################################################
+# Axis-of-motion Specific Configs (not the GUI)
+# ######################################################
+
+
+# ################
+# X [0] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.00.enable bit
+sets emcmot.00.enable FALSE
+
+net emcmot.00.enable <= axis.0.amp-enable-out
+net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.00.enable
+
+# added some signals to control a led (pin 39 or 40 on gpio0 port)
+# and control power on a cramps-cape (pin 1 or 2 on gpio0 port)
+setp hm2_[HOSTMOT2](BOARD).0.gpio.000.is_output TRUE
+setp hm2_[HOSTMOT2](BOARD).0.gpio.000.invert_output TRUE
+
+net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.gpio.000.out
+
+net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.led.CR01
+
+# position command and feedback
+net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
+net emcmot.00.pos-cmd => hm2_[HOSTMOT2](BOARD).0.stepgen.00.position-cmd
+
+net motor.00.pos-fb <= hm2_[HOSTMOT2](BOARD).0.stepgen.00.position-fb
+net motor.00.pos-fb => axis.0.motor-pos-fb
+
+
+# timing parameters
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.dirsetup        [AXIS_0]DIRSETUP
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.dirhold         [AXIS_0]DIRHOLD
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.steplen         [AXIS_0]STEPLEN
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.stepspace       [AXIS_0]STEPSPACE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.position-scale  [AXIS_0]SCALE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.step_type       0
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.control-type    0
+
+
+# ################
+# Y [1] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.01.enable bit
+sets emcmot.01.enable FALSE
+
+net emcmot.01.enable <= axis.1.amp-enable-out
+net emcmot.01.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.01.enable
+
+
+# position command and feedback
+net emcmot.01.pos-cmd <= axis.1.motor-pos-cmd
+net emcmot.01.pos-cmd => hm2_[HOSTMOT2](BOARD).0.stepgen.01.position-cmd
+
+net motor.01.pos-fb <= hm2_[HOSTMOT2](BOARD).0.stepgen.01.position-fb
+net motor.01.pos-fb => axis.1.motor-pos-fb
+
+
+# timing parameters
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.dirsetup        [AXIS_1]DIRSETUP
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.dirhold         [AXIS_1]DIRHOLD
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.steplen         [AXIS_1]STEPLEN
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.stepspace       [AXIS_1]STEPSPACE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.position-scale  [AXIS_1]SCALE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.step_type       0
+
+
+# ################
+# Z [2] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.02.enable bit
+sets emcmot.02.enable FALSE
+
+net emcmot.02.enable <= axis.2.amp-enable-out
+net emcmot.02.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.02.enable
+
+
+# position command and feedback
+net emcmot.02.pos-cmd <= axis.2.motor-pos-cmd
+net emcmot.02.pos-cmd => hm2_[HOSTMOT2](BOARD).0.stepgen.02.position-cmd
+
+net motor.02.pos-fb <= hm2_[HOSTMOT2](BOARD).0.stepgen.02.position-fb
+net motor.02.pos-fb => axis.2.motor-pos-fb
+
+
+# timing parameters
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.dirsetup        [AXIS_2]DIRSETUP
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.dirhold         [AXIS_2]DIRHOLD
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.steplen         [AXIS_2]STEPLEN
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.stepspace       [AXIS_2]STEPSPACE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.position-scale  [AXIS_2]SCALE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.step_type       0
+
+
+
+
+#
+# The Mesa AnyIO output pins can be in open-drain mode (drive low, float
+# high) or push/pull mode (drive low, drive high).
+#
+# When a logical output is 1 in open-drain mode, the FPGA lets the pin
+# float and it gets pulled high to +5V via a 10K resistor.
+#
+# When a logical output is 1 in push/pull mode, the FPGA pushes the pin
+# high but only to +3.3V.  This is problematic on some kinds of inputs.
+#
+
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.048.is_opendrain 1
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.049.is_opendrain 1
+
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.054.is_opendrain 1
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.055.is_opendrain 1
+
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.060.is_opendrain 1
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.061.is_opendrain 1
+
+
+
+
+# ##################################################
+# Standard I/O Block - EStop, Etc
+# ##################################################
+
+# create a signal for the estop loopback
+net estop-loop iocontrol.0.user-enable-out => iocontrol.0.emc-enable-in
+
+# create signals for tool loading loopback
+net tool-prep-loop iocontrol.0.tool-prepare => iocontrol.0.tool-prepared
+net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
+

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -43,7 +43,7 @@ char **argv_split(gfp_t gfp, const char *str, int *argcp);
 #endif
 
 #ifndef FIRMWARE_NAME_MAX
-    #define FIRMWARE_NAME_MAX  30
+    #define FIRMWARE_NAME_MAX  62
 #endif
 
 #define HM2_VERSION "0.15"
@@ -72,9 +72,9 @@ char **argv_split(gfp_t gfp, const char *str, int *argcp);
 
 
 
-// 
+//
 // idrom addresses & constants
-// 
+//
 
 #define HM2_ADDR_IOCOOKIE  (0x0100)
 #define HM2_IOCOOKIE       (0x55AACAFE)
@@ -88,9 +88,9 @@ char **argv_split(gfp_t gfp, const char *str, int *argcp);
 #define HM2_MAX_MODULE_DESCRIPTORS  (48)
 #define HM2_MAX_PIN_DESCRIPTORS     (1000)
 
-// 
+//
 // Pin Descriptor constants
-// 
+//
 
 #define HM2_PIN_SOURCE_IS_PRIMARY   (0x00000000)
 #define HM2_PIN_SOURCE_IS_SECONDARY (0x00000001)
@@ -101,9 +101,9 @@ char **argv_split(gfp_t gfp, const char *str, int *argcp);
 #define HM2_IDROMOFFSET_BOARDNAME_LOW    (0x0C)
 #define HM2_IDROMOFFSET_BOARDNAME_HIGH   (0x10)
 
-// 
+//
 // Module Descriptor constants from IDROMConst.vhd
-// 
+//
 
 #define HM2_GTAG_WATCHDOG          (2)
 #define HM2_GTAG_IOPORT            (3)
@@ -114,7 +114,7 @@ char **argv_split(gfp_t gfp, const char *str, int *argcp);
 #define HM2_GTAG_SSI               (8)
 #define HM2_GTAG_UART_TX           (9)
 #define HM2_GTAG_UART_RX           (10)
-#define HM2_GTAG_PKTUART_TX        (27)  // PktUART uses same addresses as normal UART with 
+#define HM2_GTAG_PKTUART_TX        (27)  // PktUART uses same addresses as normal UART with
 #define HM2_GTAG_PKTUART_RX        (28) // the assumption you would not use both in one config
 #define HM2_GTAG_TRANSLATIONRAM    (11)
 #define HM2_GTAG_MUXED_ENCODER     (12)
@@ -129,9 +129,9 @@ char **argv_split(gfp_t gfp, const char *str, int *argcp);
 #define HM2_GTAG_DAQFIFO           (21) // Not supported
 #define HM2_GTAG_BINOSC            (22) // Not supported
 #define HM2_GTAG_DDMA              (23) // Not supported
-#define HM2_GTAG_BISS              (24) 
-#define HM2_GTAG_FABS              (25) 
-#define HM2_GTAG_HM2DPLL           (26) 
+#define HM2_GTAG_BISS              (24)
+#define HM2_GTAG_FABS              (25)
+#define HM2_GTAG_HM2DPLL           (26)
 #define HM2_GTAG_LIOPORT           (64) // Not supported
 #define HM2_GTAG_LED               (128)
 
@@ -182,7 +182,7 @@ typedef struct {
 
 
 
-// 
+//
 // these structures keep track of the FPGA's I/O pins; and for I/O pins
 // used as GPIOs, keep track of the HAL state of the pins
 //
@@ -431,7 +431,7 @@ typedef struct {
         } param;
 
     } hal;
-    
+
     __s64 accum;
     __s64 offset;
     __u32 old_reg;
@@ -459,31 +459,31 @@ typedef struct {
     // hw registers
     u32 status_addr;
     u32 *status_reg;
-    
+
     u32 command_addr;
-    
+
     u32 data_addr;
-    
+
     u32 position_addr;
     u32 *position_reg;
 
     u32 velocity_addr;
     s32 *velocity_reg;
-    
+
     hal_float_t written_khz;
     hal_float_t kHz;
-    
+
 } hm2_resolver_t;
 
 
 //
 // pwmgen
-// 
+//
 
 #define HM2_PWMGEN_OUTPUT_TYPE_PWM          1  // this is the same value that the software pwmgen component uses
 #define HM2_PWMGEN_OUTPUT_TYPE_UP_DOWN      2  // this is the same value that the software pwmgen component uses
 #define HM2_PWMGEN_OUTPUT_TYPE_PDM          3  // software pwmgen does not support pdm as an output type
-#define HM2_PWMGEN_OUTPUT_TYPE_PWM_SWAPPED  4  // software pwmgen does not support pwm/swapped output type because it doesnt need to 
+#define HM2_PWMGEN_OUTPUT_TYPE_PWM_SWAPPED  4  // software pwmgen does not support pwm/swapped output type because it doesnt need to
 
 typedef struct {
 
@@ -627,9 +627,9 @@ typedef struct {
 } hm2_tp_pwmgen_t;
 
 
-// 
+//
 // ioport
-// 
+//
 
 typedef struct {
     int num_instances;
@@ -664,9 +664,9 @@ typedef struct {
 
 
 
-// 
+//
 // stepgen
-// 
+//
 
 typedef struct {
     struct {
@@ -721,7 +721,7 @@ typedef struct {
     u32 written_dirhold;
     u32 written_step_type;
     u32 table_width;
-    
+
 } hm2_stepgen_instance_t;
 
 
@@ -777,7 +777,7 @@ typedef struct {
 
 //
 // Buffered SPI transciever
-// 
+//
 
 typedef struct {
     u32 cd[16];
@@ -807,7 +807,7 @@ typedef struct {
 
 //
 // UART
-// 
+//
 
 typedef struct {
     u32 clock_freq;
@@ -840,7 +840,7 @@ typedef struct {
 
 //
 // PktUART
-// 
+//
 
 typedef struct {
     u32 clock_freq;
@@ -906,9 +906,9 @@ typedef struct {
 } hm2_dpll_t ;
 
 
-// 
+//
 // watchdog
-// 
+//
 
 typedef struct {
     struct {
@@ -977,7 +977,7 @@ typedef struct {
 } hm2_led_t ;
 
 
-// 
+//
 // raw peek/poke access
 //
 
@@ -999,7 +999,7 @@ typedef struct {
 
 
 
-// 
+//
 // this struct hold an entry in our Translation RAM region list
 //
 
@@ -1013,7 +1013,7 @@ typedef struct {
 
 
 
-// 
+//
 // this struct holds a HostMot2 instance
 //
 
@@ -1050,7 +1050,7 @@ typedef struct {
 
     int dpll_module_present;
     int use_serial_numbers;
-    
+
     hm2_pin_t *pin;
     int num_pins;
 
@@ -1282,7 +1282,7 @@ int hm2_allocate_bspi_tram(char* name);
 int hm2_bspi_write_chan(char* name, int chan, u32 val);
 int hm2_allocate_bspi_tram(char* name);
 int hm2_tram_add_bspi_frame(char *name, int chan, u32 **wbuff, u32 **rbuff);
-int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz, 
+int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
                         int delay, int cpol, int cpha, int clear, int echo);
 int hm2_bspi_set_read_function(char *name, int (*func)(void *subdata), void *subdata);
 int hm2_bspi_set_write_function(char *name, int (*func)(void *subdata), void *subdata);
@@ -1295,7 +1295,7 @@ int  hm2_uart_parse_md(hostmot2_t *hm2, int md_index);
 void hm2_uart_print_module(hostmot2_t *hm2);
 void hm2_uart_cleanup(hostmot2_t *hm2);
 void hm2_uart_write(hostmot2_t *hm2);
-void hm2_uart_force_write(hostmot2_t *hm2); 
+void hm2_uart_force_write(hostmot2_t *hm2);
 void hm2_uart_prepare_tram_write(hostmot2_t *hm2, long period);
 void hm2_uart_process_tram_read(hostmot2_t *hm2, long period);
 int hm2_uart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode);
@@ -1310,7 +1310,7 @@ int  hm2_pktuart_parse_md(hostmot2_t *hm2, int md_index);
 void hm2_pktuart_print_module(hostmot2_t *hm2);
 void hm2_pktuart_cleanup(hostmot2_t *hm2);
 void hm2_pktuart_write(hostmot2_t *hm2);
-void hm2_pktuart_force_write(hostmot2_t *hm2); // ?? 
+void hm2_pktuart_force_write(hostmot2_t *hm2); // ??
 void hm2_pktuart_prepare_tram_write(hostmot2_t *hm2, long period); //??
 void hm2_pktuart_process_tram_read(hostmot2_t *hm2, long period);  //  ??
 int hm2_pktuart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode, int txclear, int rxclear);
@@ -1327,9 +1327,9 @@ int hm2_dpll_parse_md(hostmot2_t *hm2, int md_index);
 void hm2_dpll_process_tram_read(hostmot2_t *hm2, long period);
 void hm2_dpll_write(hostmot2_t *hm2, long period);
 
-// 
+//
 // watchdog functions
-// 
+//
 
 int hm2_watchdog_parse_md(hostmot2_t *hm2, int md_index);
 void hm2_watchdog_print_module(hostmot2_t *hm2);
@@ -1342,7 +1342,7 @@ void hm2_watchdog_process_tram_read(hostmot2_t *hm2);
 
 
 
-// 
+//
 // LED functions
 //
 


### PR DESCRIPTION
Moved the hm2-soc-stepper-cramps config here from the mksocfpga repo.

Modest increase of hostmot2 firmware path length from 30 to 62 as per @dkhughes sugestion here:

https://github.com/machinekit/mksocfpga/issues/9#issuecomment-217850033
