### PR TITLE
Remove 'inline' from negate function.

### DIFF
--- a/src/emc/tp/blendmath.c
+++ b/src/emc/tp/blendmath.c
@@ -82,7 +82,7 @@ double fsign(double f)
 }
 
 /** negate a value (or not) based on a bool parameter */
-inline double negate(double f, int neg)
+double negate(double f, int neg)
 {
     return (neg) ? -f : f;
 }


### PR DESCRIPTION
This fixes the following error ([tested on Ubuntu 16.04](https://www.youtube.com/watch?v=DMAiPX3bi8A)):
```
$ linuxcnc
MACHINEKIT - 0.1
Machine configuration directory is '/opt/machinekit.koppi/configs/sim/axis'
Machine configuration file is 'axis_mm.ini'
Starting Machinekit...
io started
halcmd loadusr io started
core_sim.hal:7: insmod failed, returned -1:
do_load_cmd: dlopen: /opt/machinekit.koppi/rtlib/posix/tp.so: undefined symbol: negate
rpath=/opt/machinekit.koppi/rtlib/posix:/opt/machinekit.koppi/lib
See /var/log/linuxcnc.log for more information.
Shutting down and cleaning up Machinekit...
Cleanup done
Machinekit terminated with an error.  You can find more information in the log:
    /home/koppi/linuxcnc_debug.txt
and
    /home/koppi/linuxcnc_print.txt
as well as in the output of the shell command 'dmesg' and in the terminal
```

Note: this is a different error class than was already discussed in a similar but unrelated issue: #677 