### PR TITLE
webtalk: support libwebsockets >= 1.6

### DIFF
--- a/src/machinetalk/webtalk/webtalk_defaultpolicy.cc
+++ b/src/machinetalk/webtalk/webtalk_defaultpolicy.cc
@@ -42,8 +42,11 @@ int default_policy(wtself_t *self,
 	    const char *identity = NULL;
 	    wss->txmode = LWS_WRITE_BINARY;
 	    UriQueryListA *q = wss->queryList;
+#ifdef LWS_NEW_API
+	    int fd = lws_get_socket_fd(wss->wsiref);
+#else
 	    int fd = libwebsocket_get_socket_fd(wss->wsiref);
-
+#endif
 	    while (q != NULL) {
 		lwsl_uri("%s %d: key='%s' value='%s'\n",
 			   __func__, fd, q->key,q->value);

--- a/src/machinetalk/webtalk/webtalk_initproto.cc
+++ b/src/machinetalk/webtalk/webtalk_initproto.cc
@@ -2,8 +2,11 @@
 
 #include "webtalk.hh"
 
-
+#ifdef LWS_NEW_API
+struct lws_protocols *protocols;
+#else
 struct libwebsocket_protocols *protocols;
+#endif
 
 #ifdef EXPERIMENTAL_ZWS_SUPPORT
 #define NPROTOS 6
@@ -13,10 +16,17 @@ struct libwebsocket_protocols *protocols;
 
 void init_protocols(void)
 {
+#ifdef LWS_NEW_API
+    // size must be number of protos + 1 - libwebsockets requires a zero delimiter struct
+    struct lws_protocols *p = protocols = 
+	(struct lws_protocols *) calloc(NPROTOS,
+					sizeof (struct lws_protocols));
+#else
     // size must be number of protos + 1 - libwebsockets requires a zero delimiter struct
     struct libwebsocket_protocols *p = protocols = 
 	(struct libwebsocket_protocols *) calloc(NPROTOS,
 						 sizeof (struct libwebsocket_protocols));
+#endif
     assert(p != 0);
 
     //  first protocol must always be HTTP handler


### PR DESCRIPTION
see section 'v1.6.0-chrome48-firefox42' in
https://github.com/warmcat/libwebsockets/blob/v2.0-stable/changelog

this should support both the stretch (1.7.3) version and master (2.x)

not actually tested.
lws_get_internal_extensions() is deprecated and still needs work.

Should address #937 .