### PR TITLE
Motion: make thread creation optional

### DIFF
--- a/configs/common/newthread.hal
+++ b/configs/common/newthread.hal
@@ -1,0 +1,1 @@
+newthread servo-thread [HAL]SERVO_PERIOD fp

--- a/configs/sim/axis/axis_mm.ini
+++ b/configs/sim/axis/axis_mm.ini
@@ -82,10 +82,14 @@ COMM_TIMEOUT =          1.0
 # Interval between tries to emcmot, in seconds
 COMM_WAIT =             0.010
 
+# if both BASE_PERIOD and SERVO_PERIOD are unset or 0, motion will not create any threads.
+# in this case, threads need to be created explicitly by 'newthread'
+# see HALFILE=newthread and [HAL]SERVO_PERIOD below
+
 # BASE_PERIOD is unused in this configuration but specified in core_sim.hal
 BASE_PERIOD  =               0
 # Servo task period, in nano-seconds
-SERVO_PERIOD =               1000000
+SERVO_PERIOD =               0
 
 # Hardware Abstraction Layer section --------------------------------------------------
 [HAL]
@@ -94,8 +98,14 @@ SERVO_PERIOD =               1000000
 # files, and then to execute any individual HALCMD commands.
 #
 
+# used in configs/common/newthread.hal
+# Servo task period, in nano-seconds
+SERVO_PERIOD =               1000000
+
+
 # list of hal config files to run through halcmd
 # files are executed in the order in which they appear
+HALFILE = newthread.hal
 HALFILE = core_sim.hal
 HALFILE = sim_spindle_encoder.hal
 HALFILE = axis_manualtoolchange.hal

--- a/configs/sim/axis/newthread.hal
+++ b/configs/sim/axis/newthread.hal
@@ -1,0 +1,1 @@
+../../common/newthread.hal

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -225,8 +225,10 @@ static void update_status(void);
   the amp enable/disable are inhibited
   */
 
-void emcmotController(void *arg, long period)
+extern int emcmotController(void *arg,  const hal_funct_args_t *fa)
 {
+    long period = fa_period(fa);
+
     // - overrun detection -
     // maintain some records of how long it's been between calls.  The
     // first time we see a delay that's much longer than the records show
@@ -244,7 +246,7 @@ void emcmotController(void *arg, long period)
     static long int cycles[CYCLE_HISTORY];
     static int priming = 1;
 
-    long long int now = rtapi_get_clocks();
+    long long int now = fa_start_time(fa);
     long int this_run = (long int)(now - last);
     emcmot_hal_data->last_period = this_run;
 #ifdef HAVE_CPU_KHZ
@@ -344,6 +346,7 @@ check_stuff ( "after update_status()" );
     first_pass = 0;
 
 /* end of controller function */
+    return 0;
 }
 
 /***********************************************************************

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -33,6 +33,7 @@
 
 /* joint data */
 #include "hal.h"
+#include "hal_priv.h"
 #include "../motion/motion.h"
 
 typedef struct {
@@ -299,13 +300,14 @@ extern TP_STRUCT *emcmotPrimQueue;
 extern TP_STRUCT *emcmotAltQueue;
 extern TP_STRUCT *emcmotQueue;
 
+extern long traj_period_nsec; // motion.c commandline argument
 /***********************************************************************
 *                    PUBLIC FUNCTION PROTOTYPES                        *
 ************************************************************************/
 
 /* function definitions */
-extern void emcmotCommandHandler(void *arg, long period);
-extern void emcmotController(void *arg, long period);
+extern int emcmotCommandHandler(void *arg, const hal_funct_args_t *fa);
+extern int emcmotController(void *arg,  const hal_funct_args_t *fa);
 extern void emcmotSetCycleTime(unsigned long nsec);
 
 /* these are related to synchronized I/O */

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -250,14 +250,12 @@ int rtapi_app_main(void)
 	return -1;
     }
 
-    if (!nothreads) {
-	/* set up for realtime execution of code */
-	retval = init_threads();
-	if (retval != 0) {
-	    rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: init_threads() failed\n"));
-	    hal_exit(mot_comp_id);
-	    return -1;
-	}
+    /* set up for realtime execution of code */
+    retval = init_threads();
+    if (retval != 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: init_threads() failed\n"));
+	hal_exit(mot_comp_id);
+	return -1;
     }
 
     rtapi_print_msg(RTAPI_MSG_INFO, "MOTION: init_module() complete\n");

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -58,7 +58,7 @@ static long servo_period_nsec = 1000000;	/* servo thread period */
 RTAPI_MP_LONG(servo_period_nsec, "servo thread period (nsecs)");
 static int servo_cpu = -1;		/* explicitly bind to CPU */
 RTAPI_MP_INT(servo_cpu, "CPU of servo thread");
-static long traj_period_nsec = 0;	/* trajectory planner period */
+long traj_period_nsec = 0;	/* trajectory planner period */
 RTAPI_MP_LONG(traj_period_nsec, "trajectory planner period (nsecs)");
 int num_joints = EMCMOT_MAX_JOINTS;	/* default number of joints present */
 RTAPI_MP_INT(num_joints, "number of joints");
@@ -152,8 +152,8 @@ static int init_comm_buffers(void);
 static int init_threads(void);
 
 /* functions called by init_threads() */
-static int setTrajCycleTime(double secs);
-static int setServoCycleTime(double secs);
+int setTrajCycleTime(double secs);
+int setServoCycleTime(double secs);
 
 // init the shared state handling between tp and motion
 static int init_shared(tp_shared_t *tps,
@@ -250,12 +250,14 @@ int rtapi_app_main(void)
 	return -1;
     }
 
-    /* set up for realtime execution of code */
-    retval = init_threads();
-    if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: init_threads() failed\n"));
-	hal_exit(mot_comp_id);
-	return -1;
+    if (!nothreads) {
+	/* set up for realtime execution of code */
+	retval = init_threads();
+	if (retval != 0) {
+	    rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: init_threads() failed\n"));
+	    hal_exit(mot_comp_id);
+	    return -1;
+	}
     }
 
     rtapi_print_msg(RTAPI_MSG_INFO, "MOTION: init_module() complete\n");
@@ -1226,56 +1228,77 @@ static int init_threads(void)
     int retval;
 
     rtapi_print_msg(RTAPI_MSG_INFO, "MOTION: init_threads() starting...\n");
+    int nothreads = ((base_period_nsec == 0) && (servo_period_nsec == 0));
+    if (!nothreads) {
 
-    /* if base_period not specified, assume same as servo_period */
-    if (base_period_nsec == 0) {
-	base_period_nsec = servo_period_nsec;
-    }
-    if (traj_period_nsec == 0) {
-	traj_period_nsec = servo_period_nsec;
-    }
-    /* servo period must be greater or equal to base period */
-    if (servo_period_nsec < base_period_nsec) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MOTION: bad servo period %ld nsec\n", servo_period_nsec);
-	return -1;
-    }
-    /* convert desired periods to floating point */
-    base_period_sec = base_period_nsec * 0.000000001;
-    servo_period_sec = servo_period_nsec * 0.000000001;
-    /* calculate period ratios, round to nearest integer */
-    servo_base_ratio = (servo_period_sec / base_period_sec) + 0.5;
-    /* revise desired periods to be integer multiples of each other */
-    servo_period_nsec = base_period_nsec * servo_base_ratio;
-    /* create HAL threads for each period */
-    /* only create base thread if it is faster than servo thread */
-    if (servo_base_ratio > 1) {
-
-	retval = hal_create_thread("base-thread", base_period_nsec, base_thread_fp, base_cpu);
-	if (retval < 0) {
+	/* if base_period not specified, assume same as servo_period */
+	if (base_period_nsec == 0) {
+	    base_period_nsec = servo_period_nsec;
+	}
+	if (traj_period_nsec == 0) {
+	    traj_period_nsec = servo_period_nsec;
+	}
+	/* servo period must be greater or equal to base period */
+	if (servo_period_nsec < base_period_nsec) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,
-		"MOTION: failed to create %ld nsec base thread\n",
-		base_period_nsec);
+			    "MOTION: bad servo period %ld nsec\n", servo_period_nsec);
 	    return -1;
 	}
-    }
-    retval = hal_create_thread("servo-thread", servo_period_nsec, 1, servo_cpu);
-    if (retval < 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MOTION: failed to create %ld nsec servo thread\n",
-	    servo_period_nsec);
-	return -1;
+	/* convert desired periods to floating point */
+	base_period_sec = base_period_nsec * 0.000000001;
+	servo_period_sec = servo_period_nsec * 0.000000001;
+	/* calculate period ratios, round to nearest integer */
+	servo_base_ratio = (servo_period_sec / base_period_sec) + 0.5;
+	/* revise desired periods to be integer multiples of each other */
+	servo_period_nsec = base_period_nsec * servo_base_ratio;
+	/* create HAL threads for each period */
+	/* only create base thread if it is faster than servo thread */
+	if (servo_base_ratio > 1) {
+
+	    retval = hal_create_thread("base-thread", base_period_nsec, base_thread_fp, base_cpu);
+	    if (retval < 0) {
+		rtapi_print_msg(RTAPI_MSG_ERR,
+				"MOTION: failed to create %ld nsec base thread\n",
+				base_period_nsec);
+		return -1;
+	    }
+	}
+	retval = hal_create_thread("servo-thread", servo_period_nsec, 1, servo_cpu);
+	if (retval < 0) {
+	    rtapi_print_msg(RTAPI_MSG_ERR,
+			    "MOTION: failed to create %ld nsec servo thread\n",
+			    servo_period_nsec);
+	    return -1;
+	}
+    } else {
+	rtapi_print_msg(RTAPI_MSG_INFO,
+			"MOTION: not creating threads as both servo and base period are 0\n");
     }
     /* export realtime functions that do the real work */
-    retval = hal_export_funct("motion-controller", emcmotController, 0	/* arg 
-	 */ , 1 /* uses_fp */ , 0 /* reentrant */ , mot_comp_id);
+    hal_export_xfunct_args_t mot_args = {
+        .type = FS_XTHREADFUNC,
+        .funct.x = emcmotController,
+        .arg = 0,
+        .uses_fp = 1,
+        .reentrant = 0,
+        .owner_id = mot_comp_id
+    };
+
+    retval = hal_export_xfunctf(&mot_args, "motion-controller");
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "MOTION: failed to export controller function\n");
 	return -1;
     }
-    retval = hal_export_funct("motion-command-handler", emcmotCommandHandler, 0	/* arg 
-	 */ , 1 /* uses_fp */ , 0 /* reentrant */ , mot_comp_id);
+    hal_export_xfunct_args_t cmd_args = {
+        .type = FS_XTHREADFUNC,
+        .funct.x = emcmotCommandHandler,
+        .arg = 0,
+        .uses_fp = 1,
+        .reentrant = 0,
+        .owner_id = mot_comp_id
+    };
+    retval = hal_export_xfunctf(&cmd_args, "motion-command-handler");
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "MOTION: failed to export command handler function\n");
@@ -1294,12 +1317,13 @@ static int init_threads(void)
 	return -1;
     }
 #endif
-
-    // if we don't set cycle times based on these guesses, emc doesn't
-    // start up right
-    setServoCycleTime(servo_period_nsec * 1e-9);
-    setTrajCycleTime(traj_period_nsec * 1e-9);
-
+    if (!nothreads) {
+	// if we don't set cycle times based on these guesses, emc doesn't
+	// start up right
+	// if no threads, postponed until first invocation of emcmotCommandHandler
+	setServoCycleTime(servo_period_nsec * 1e-9);
+	setTrajCycleTime(traj_period_nsec * 1e-9);
+    }
     rtapi_print_msg(RTAPI_MSG_INFO, "MOTION: init_threads() complete\n");
     return 0;
 }
@@ -1312,7 +1336,7 @@ void emcmotSetCycleTime(unsigned long nsec ) {
     setServoCycleTime(nsec * servo_mult * 1e-9);
 }
 /* call this when setting the trajectory cycle time */
-static int setTrajCycleTime(double secs)
+int setTrajCycleTime(double secs)
 {
     static int t;
 
@@ -1350,7 +1374,7 @@ static int setTrajCycleTime(double secs)
 }
 
 /* call this when setting the servo cycle time */
-static int setServoCycleTime(double secs)
+int setServoCycleTime(double secs)
 {
     static int t;
 

--- a/src/emc/motion/motion.h
+++ b/src/emc/motion/motion.h
@@ -814,6 +814,9 @@ Suggestion: Split this in to an Error and a Status flag register..
     extern int emcmotErrorPutf(emcmot_error_t * errlog, const char *fmt, ...);
     extern int emcmotErrorGet(emcmot_error_t * errlog, char *error);
 
+    int setTrajCycleTime(double secs);
+    int setServoCycleTime(double secs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rtapi/rtapi_pci.h
+++ b/src/rtapi/rtapi_pci.h
@@ -104,7 +104,7 @@ int pci_disable_device(struct pci_dev *dev);
           pci_resource_start((dev), (bar)) + 1))
 
 void __iomem *pci_ioremap_bar(struct pci_dev *pdev, int bar);
-inline void iounmap(volatile void __iomem *addr);
+void iounmap(volatile void __iomem *addr);
 
 static inline const char *pci_name(const struct pci_dev *pdev)
 {


### PR DESCRIPTION
this has been a long-standing issue and became urgent because of #687 nearing conclusion - @dkhughes also needs this
 
Since this is touching on critical parts of motion execution, let's merge this only after some more extensive testing - the runtests alone do not cut it

please use axis_mm.ini for testing as a model. 

Thanks!