### PR TITLE
rt-preempt, posix: be more assertive when exiting a HAL thread

### DIFF
--- a/src/rtapi/rt-preempt.c
+++ b/src/rtapi/rt-preempt.c
@@ -199,10 +199,20 @@ void _rtapi_task_delete_hook(task_data *task, int task_id) {
     /* Signal thread termination and wait for the thread to exit. */
     if (!extra_task_data[task_id].deleted) {
 	extra_task_data[task_id].deleted = 1;
+
+	// pthread_cancel() will get the thread out of any blocking system
+	// calls listed under 'Cancellation points' in man 7 pthreads
+	// read(), poll() being important ones
+	err = pthread_cancel(extra_task_data[task_id].thread);
+	if (err)
+	    rtapi_print_msg(RTAPI_MSG_ERR,
+			    "pthread_cancel() on RT thread '%s': %d %s\n",
+			    task->name, err, strerror(err));
 	err = pthread_join(extra_task_data[task_id].thread, &returncode);
 	if (err)
-	    rtapi_print_msg
-		(RTAPI_MSG_ERR, "pthread_join() on realtime thread failed\n");
+	    rtapi_print_msg(RTAPI_MSG_ERR,
+			    "pthread_join() on RT thread '%s': %d %s\n",
+			    task->name, err, strerror(err));
     }
     /* Free the thread stack. */
     free(extra_task_data[task_id].stackaddr);


### PR DESCRIPTION
previously, a HAL thread doing a blocking system call (read, poll etc)
would fail to terminate on hal_delete_thread() as pthread_join() alone
does not terminate any pending system calls. The pthread_cancel()
achieves this effect.

In theory this should remove any RT shutdown hangs when using posix/rt-preempt

see also the discussion at: https://github.com/machinekit/mksocfpga/issues/45#issuecomment-225340075

@dkhughes - please give it a spin!