### PR TITLE
Provide specific warning of Mac and DOS line endings comp/instcomp

### DIFF
--- a/src/hal/utils/comp.g
+++ b/src/hal/utils/comp.g
@@ -121,6 +121,8 @@ def _parse(rule, text, filename=None):
 def parse(filename):
     initialize()
     f = open(filename).read()
+    if '\r' in f:
+	raise SystemExit, "Error: Mac or DOS style line endings in file %s" % filename
     a, b = f.split("\n;;\n", 1)
     p = _parse('File', a + "\n\n", filename)
     if not p: raise SystemExit, 1

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -131,6 +131,8 @@ def _parse(rule, text, filename=None):
 def parse(filename):
     initialize()
     f = open(filename).read()
+    if '\r' in f:
+	raise SystemExit, "Error: Mac or DOS style line endings in file %s" % filename
     a, b = f.split("\n;;\n", 1)
     p = _parse('File', a + "\n\n", filename)
     if not p: raise SystemExit, 1


### PR DESCRIPTION
and exit.

When comp or icomp files are read in, the `\n` line endings are used
to split the file.

If `\r\n` DOS style or `\r` Mac style endings are present, it plays
havoc and a non specific failure results.

'Borrowed with pride' from jepler musings on same in
Emc-developers Digest, Vol 123, Issue 5

Signed-off-by: Mick <arceye@mgware.co.uk>