### PR TITLE
Fix unintentional removal of userspace option in comp.

### DIFF
--- a/src/hal/utils/comp.g
+++ b/src/hal/utils/comp.g
@@ -1228,7 +1228,7 @@ def main():
 
     for k, v in opts:
         if k in ("-u", "--userspace"):
-            raise SystemExit, "Error: instcomp does not support userspace components"
+            userspace = True
         if k in ("-i", "--install"):
             mode = INSTALL
         if k in ("-c", "--compile"):


### PR DESCRIPTION
Cut and paste from almost identical changes in instcomp
resulted in removal of option that IS valid in comp

Signed-off-by: Mick <arceye@mgware.co.uk>