### PR TITLE
Fix package build to include lib/python/machinetalk/protobuf

### DIFF
--- a/debian/machinekit.install
+++ b/debian/machinekit.install
@@ -11,6 +11,7 @@ usr/lib/python*/*/*.so
 usr/lib/python*/*/*/*.py
 usr/lib/python*/*/gladevcp/*.glade
 usr/lib/python*/*/machinekit/*.so
+usr/lib/python*/*/machinetalk/protobuf/*.*
 usr/libexec/linuxcnc/linuxcnc_module_helper
 usr/libexec/linuxcnc/pci_read
 usr/libexec/linuxcnc/pci_write

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -158,6 +158,8 @@ install: build
 	dh_installdirs
 # start the install
 	mkdir -p debian/tmp
+	mkdir -p debian/tmp/usr/lib/python2.7/dist-packages/machinetalk/protobuf
+	cp lib/python/machinetalk/protobuf/*.* debian/tmp/usr/lib/python*/dist-packages/machinetalk/protobuf
 	(cd debian/extras && cp -a * ../tmp)
 	(cd src; export DESTDIR=`pwd`/../debian/tmp; $(MAKE) V=$(DH_VERBOSE) $@)
 	mkdir -p debian/tmp/usr/lib debian/tmp/usr/include/linuxcnc


### PR DESCRIPTION
The files and thus the path to the modules was changed but not duplicated
in the packaging

Had to specifically create the required directory in rules.in before
dh_install would work as intended, not sure why, but this debian config works

Fixes Issue #986

Signed-off-by: Mick <arceye@mgware.co.uk>