### PR TITLE
Amend (inst)comp manual page front-matter

### DIFF
--- a/src/hal/utils/comp.g
+++ b/src/hal/utils/comp.g
@@ -753,7 +753,7 @@ def adocument(filename, outfilename, frontmatter):
             print >>f, fm
         print >>f, "edit-path: src/%s" % (filename)
         print >>f, "generator: comp"
-	print >>f, "(This page is generated, do not edit directly. See the source file at src/%s)" % filename
+	print >>f, "description: This page was generated from src/%s. Do not edit directly, edit the source." % filename
         print >>f, "---"
         print >>f, ":skip-front-matter:\n"
 

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -990,7 +990,7 @@ def adocument(filename, outfilename, frontmatter):
             print >>f, fm
         print >>f, "edit-path: src/%s" % (filename)
         print >>f, "generator: instcomp"
-	print >>f, "(This page is generated, do not edit directly. See the source file at src/%s)" % filename
+	print >>f, "description: This page was generated from src/%s. Do not edit directly, edit the source." % filename
         print >>f, "---"
         print >>f, ":skip-front-matter:\n"
 


### PR DESCRIPTION
Use predefined yaml variable `description:` to prevent parsing error

Signed-off-by: Mick <arceye@mgware.co.uk>