### PR TITLE
Expand mank script find path spec for RIP build display

### DIFF
--- a/bin/mank
+++ b/bin/mank
@@ -53,7 +53,7 @@ if [ -n "$path" ]; then
     filn=$(find "$path" -type f -name "$fil.asciidoc")
 else
     if [ "$RIP" == "yes" ]; then
-	filn=$(find . $EMC2_HOME/man -type f -name $fil.asciidoc)
+	filn=$(find . $EMC2_HOME/man /usr/share/doc/machinekit/man /usr/local/share/doc/machinekit/man -type f -name $fil.asciidoc)
     else
 	## this is the install path for machinekit-manual-pages plus optional /local prefix
 	filn=$(find . /usr/share/doc/machinekit/man /usr/local/share/doc/machinekit/man -type f -name $fil.asciidoc)


### PR DESCRIPTION
Cater for RIP build but using installed package for manual pages.

Signed-off-by: Mick <arceye@mgware.co.uk>