### PR TITLE
videoserver: add custom arguments

### DIFF
--- a/src/machinetalk/videoserver/video.ini
+++ b/src/machinetalk/videoserver/video.ini
@@ -14,3 +14,4 @@ quality: 80
 format: "YUYV"
 device: "/dev/video1"
 bufferSize: 2
+arguments: -o "output_http.so -w /usr/local/www -p 8080"

--- a/src/machinetalk/videoserver/videoserver.py
+++ b/src/machinetalk/videoserver/videoserver.py
@@ -41,7 +41,7 @@ class VideoServer(threading.Thread):
         self.debug = debug
 
         self.videoDevices = {}
-        self.cfg = ConfigParser.ConfigParser()
+        self.cfg = ConfigParser.ConfigParser(defaults={'arguments': ''})
         self.cfg.read(self.inifile)
         if self.debug:
             print (("video devices:", self.cfg.sections()))
@@ -53,6 +53,7 @@ class VideoServer(threading.Thread):
             videoDevice.quality = self.cfg.get(n, 'quality')
             videoDevice.device = self.cfg.get(n, 'device')
             videoDevice.bufferSize = self.cfg.getint(n, 'bufferSize')
+            videoDevice.arguments = self.cfg.get(n, 'arguments')
             self.videoDevices[n] = videoDevice
             if self.debug:
                 print (("framerate:", videoDevice.framerate))
@@ -60,6 +61,7 @@ class VideoServer(threading.Thread):
                 print (("quality:", videoDevice.quality))
                 print (("device:", videoDevice.device))
                 print (("bufferSize:", videoDevice.bufferSize))
+                print (("arguments:", videoDevice.arguments))
 
     def startVideo(self, deviceId):
         videoDevice = self.videoDevices[deviceId]
@@ -91,14 +93,19 @@ class VideoServer(threading.Thread):
         libpath = '/usr/local/lib/'
         os.environ['LD_LIBRARY_PATH'] = libpath
 
-        command = ['mjpg_streamer -i \"' + libpath + 'input_uvc.so -n' +
+        arguments = ""
+        if videoDevice.arguments is not '':
+            arguments = ' ' + videoDevice.arguments
+
+        command = ['mjpg_streamer -i \"%s' + libpath + 'input_uvc.so -n' +
                    ' -f ' + str(videoDevice.framerate) +
                    ' -r ' + videoDevice.resolution +
                    ' -q ' + videoDevice.quality +
                    ' -d ' + videoDevice.device +
                    '" -o \"' + libpath + 'output_zmqserver.so --address ' +
                    videoDevice.zmqUri +
-                   ' --buffer_size ' + str(videoDevice.bufferSize) + '\"']
+                   ' --buffer_size ' + str(videoDevice.bufferSize) + '\"' +
+                   arguments]
 
         if self.debug:
             print (("command:", command))


### PR DESCRIPTION
Allows custom arguments for mjpeg streamer (e.g. to enable http streaming).