### PR TITLE
rtapi_math/k_rem_pio2: Fix -Werror=misleading-indentation compile fai…

### DIFF
--- a/src/rtapi/rtapi_math/k_rem_pio2.c
+++ b/src/rtapi/rtapi_math/k_rem_pio2.c
@@ -189,7 +189,9 @@ twon24  =  5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
 
     /* compute q[0],q[1],...q[jk] */
 	for (i=0;i<=jk;i++) {
-	    for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j]; q[i] = fw;
+	    for(j=0,fw=0.0;j<=jx;j++)
+		fw += x[j]*f[jx+i-j];
+	    q[i] = fw;
 	}
 
 	jz = jk;


### PR DESCRIPTION
…lure

Compiling rtapi/rtapi_math/k_rem_pio2.c
rtapi/rtapi_math/k_rem_pio2.c: In function ‘__kernel_rem_pio2’:
rtapi/rtapi_math/k_rem_pio2.c:192:6: error: this ‘for’ clause does not guard... [-Werror=misleading-indentation]
      for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j]; q[i] = fw;
      ^~~
rtapi/rtapi_math/k_rem_pio2.c:192:54: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘for’
      for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j]; q[i] = fw;
                                                      ^
cc1: all warnings being treated as errors
Makefile:391: recipe for target 'objects/rtapi/rtapi_math/k_rem_pio2.o' failed