### PR TITLE
axis: Workaround active axis selection issues on amd64

### DIFF
--- a/share/axis/tcl/axis.tcl
+++ b/share/axis/tcl/axis.tcl
@@ -859,7 +859,7 @@ radiobutton $_tabs_manual.axes.axisx \
 	-variable current_axis \
 	-width 2 \
         -text X \
-        -command axis_activated
+        -command axis_activated_x
 
 radiobutton $_tabs_manual.axes.axisy \
 	-anchor w \
@@ -868,7 +868,7 @@ radiobutton $_tabs_manual.axes.axisy \
 	-variable current_axis \
 	-width 2 \
         -text Y \
-        -command axis_activated
+        -command axis_activated_y
 
 radiobutton $_tabs_manual.axes.axisz \
 	-anchor w \
@@ -877,7 +877,7 @@ radiobutton $_tabs_manual.axes.axisz \
 	-variable current_axis \
 	-width 2 \
         -text Z \
-        -command axis_activated
+        -command axis_activated_z
 
 radiobutton $_tabs_manual.axes.axisa \
 	-anchor w \
@@ -886,7 +886,7 @@ radiobutton $_tabs_manual.axes.axisa \
 	-variable current_axis \
 	-width 2 \
         -text A \
-        -command axis_activated
+        -command axis_activated_a
 
 radiobutton $_tabs_manual.axes.axisb \
 	-anchor w \
@@ -895,7 +895,7 @@ radiobutton $_tabs_manual.axes.axisb \
 	-variable current_axis \
 	-width 2 \
         -text B \
-        -command axis_activated
+        -command axis_activated_b
 
 radiobutton $_tabs_manual.axes.axisc \
 	-anchor w \
@@ -904,7 +904,7 @@ radiobutton $_tabs_manual.axes.axisc \
 	-variable current_axis \
 	-width 2 \
         -text C \
-        -command axis_activated
+        -command axis_activated_c
 
 
 radiobutton $_tabs_manual.axes.axisu \
@@ -914,7 +914,7 @@ radiobutton $_tabs_manual.axes.axisu \
 	-variable current_axis \
 	-width 2 \
         -text U \
-        -command axis_activated
+        -command axis_activated_u
 
 radiobutton $_tabs_manual.axes.axisv \
 	-anchor w \
@@ -923,7 +923,7 @@ radiobutton $_tabs_manual.axes.axisv \
 	-variable current_axis \
 	-width 2 \
         -text V \
-        -command axis_activated
+        -command axis_activated_v
 
 radiobutton $_tabs_manual.axes.axisw \
 	-anchor w \
@@ -932,7 +932,7 @@ radiobutton $_tabs_manual.axes.axisw \
 	-variable current_axis \
 	-width 2 \
         -text W \
-        -command axis_activated
+        -command axis_activated_w
 
 # Grid widget $_tabs_manual.axes.axisa
 grid $_tabs_manual.axes.axisu \

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1712,6 +1712,19 @@ def reload_file(refilter=True):
     if line:
         o.set_highlight_line(line)
  
+def _axis_activated(axis):
+    if not hal_present: return # this only makes sense if HAL is present on this machine
+    vars.current_axis.set(axis)
+    comp['jog.x'] = vars.current_axis.get() == "x"
+    comp['jog.y'] = vars.current_axis.get() == "y"
+    comp['jog.z'] = vars.current_axis.get() == "z"
+    comp['jog.a'] = vars.current_axis.get() == "a"
+    comp['jog.b'] = vars.current_axis.get() == "b"
+    comp['jog.c'] = vars.current_axis.get() == "c"
+    comp['jog.u'] = vars.current_axis.get() == "u"
+    comp['jog.v'] = vars.current_axis.get() == "v"
+    comp['jog.w'] = vars.current_axis.get() == "w"
+
 class TclCommands(nf.TclCommands):
 #---------------------------------------------------------------------------------------------------
     if  user_commands :  # disable if user commands not activated in ini file
@@ -2589,17 +2602,32 @@ class TclCommands(nf.TclCommands):
         else:
             commands.set_view_z()
 
-    def axis_activated(*args):
-        if not hal_present: return # this only makes sense if HAL is present on this machine
-        comp['jog.x'] = vars.current_axis.get() == "x"
-        comp['jog.y'] = vars.current_axis.get() == "y"
-        comp['jog.z'] = vars.current_axis.get() == "z"
-        comp['jog.a'] = vars.current_axis.get() == "a"
-        comp['jog.b'] = vars.current_axis.get() == "b"
-        comp['jog.c'] = vars.current_axis.get() == "c"
-        comp['jog.u'] = vars.current_axis.get() == "u"
-        comp['jog.v'] = vars.current_axis.get() == "v"
-        comp['jog.w'] = vars.current_axis.get() == "w"
+    def axis_activated_x(*args):
+        _axis_activated("x")
+
+    def axis_activated_y(*args):
+        _axis_activated("y")
+
+    def axis_activated_z(*args):
+        _axis_activated("z")
+
+    def axis_activated_a(*args):
+        _axis_activated("a")
+
+    def axis_activated_b(*args):
+        _axis_activated("b")
+
+    def axis_activated_c(*args):
+        _axis_activated("c")
+
+    def axis_activated_u(*args):
+        _axis_activated("u")
+
+    def axis_activated_v(*args):
+        _axis_activated("v")
+
+    def axis_activated_w(*args):
+        _axis_activated("w")
 
     def set_joint_mode(*args):
         joint_mode = vars.joint_mode.get()


### PR DESCRIPTION
On amd64 the active axis selection 'current_axis' sometimes is set to an incorrect value, possibly by tk(inter).
Work around this by force-setting the variable in the radio button callback.

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1545, in __call__
    return self.func(*args)
  File "/home/mb/develop/git/machinekit/bin/axis", line 2465, in touch_off
    offset_axis = "xyzabcuvw".index(vars.current_axis.get())
ValueError: substring not found
```