### PR TITLE
classicladder/serial_linux: Fix code ident

### DIFF
--- a/src/hal/classicladder/serial_linux.c
+++ b/src/hal/classicladder/serial_linux.c
@@ -219,27 +219,26 @@ int SerialReceive( char * Buff, int MaxBuffLength, int TimeOutResp )
 	int NbrCarsReceived = 0;
 	if ( PortIsOpened )
 	{
-
-// the select is used it no char at all is received (else read() block...)
-int recep_descrip;
-fd_set myset;
-struct timeval tv;
-FD_ZERO( &myset);
-// add descrip to survey and set time-out wanted !
-FD_SET( fd, &myset );
-tv.tv_sec = TimeOutResp / 1000; //seconds
-tv.tv_usec = (TimeOutResp % 1000) * 1000; //micro-seconds
-if ( ModbusDebugLevel>=3 )
-	printf("select() for serial reading...\n");
-recep_descrip = select( 16, &myset, NULL, NULL, &tv );
-if ( recep_descrip>0 )
-{
-		if ( ModbusDebugLevel>=2 )
-			printf("Serial reading...\n");
+		// the select is used it no char at all is received (else read() block...)
+		int recep_descrip;
+		fd_set myset;
+		struct timeval tv;
+		FD_ZERO( &myset);
+		// add descrip to survey and set time-out wanted !
+		FD_SET( fd, &myset );
+		tv.tv_sec = TimeOutResp / 1000; //seconds
+		tv.tv_usec = (TimeOutResp % 1000) * 1000; //micro-seconds
+		if ( ModbusDebugLevel>=3 )
+			printf("select() for serial reading...\n");
+		recep_descrip = select( 16, &myset, NULL, NULL, &tv );
+		if ( recep_descrip>0 )
+		{
+			if ( ModbusDebugLevel>=2 )
+				printf("Serial reading...\n");
 			NbrCarsReceived = read(fd,Buff,MaxBuffLength);
-		if ( ModbusDebugLevel>=2 )
-			printf("%d chars found\n", NbrCarsReceived);
-}
+			if ( ModbusDebugLevel>=2 )
+				printf("%d chars found\n", NbrCarsReceived);
+		}
 	}
 	return NbrCarsReceived;
 }


### PR DESCRIPTION
This fixes the following compiler warning:

```
hal/classicladder/serial_linux.c: In function ‘SerialReceive’:
hal/classicladder/serial_linux.c:237:3: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   if ( ModbusDebugLevel>=2 )
   ^~
hal/classicladder/serial_linux.c:239:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
    NbrCarsReceived = read(fd,Buff,MaxBuffLength);
    ^~~~~~~~~~~~~~~
```