### PR TITLE
hm2_soc_ol.c: speed up hm2_soc_read/hm2_soc_write

### DIFF
--- a/configs/hm2-soc-stepper/irqtest.hal
+++ b/configs/hm2-soc-stepper/irqtest.hal
@@ -37,13 +37,11 @@ newsig enable bit
 
 
 addf hm2_de0n.0.read           servo
-addf hm2_de0n.0.read_gpio      servo
 
 addf test.update               servo
 addf rate 		       servo
 
 addf hm2_de0n.0.write          servo
-addf hm2_de0n.0.write_gpio     servo
 addf servo-period              servo
 addf sp-stats                  servo
 

--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
@@ -173,48 +173,14 @@ static int locate_uio_device(hm2_soc_t *brd, const char *name);
 //
 static int hm2_soc_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
     hm2_soc_t *brd = this->private;
-    int i;
-    u32* src = (u32*) (brd->base + addr);
-    u32* dst = (u32*) buffer;
-
-    /* Per Peter Wallace, all hostmot2 access should be 32 bits and 32-bit aligned */
-    /* Check for any address or size values that violate this alignment */
-    if ( ((addr & 0x3) != 0) || ((size & 0x03) != 0) ){
-        u16* dst16 = (u16*) dst;
-        u16* src16 = (u16*) src;
-        /* hm2_read_idrom performs a 16-bit read, which seems to be OK, so let's allow it */
-        if ( ((addr & 0x1) != 0) || (size != 2) ){
-            LL_ERR( "hm2_soc_read: Unaligned Access: %08x %04x\n", addr,size);
-            memcpy(dst, src, size);
-            return 1;  // success
-        }
-        dst16[0] = src16[0];
-        return 1;  // success
-    }
-    for (i=0; i<(size/4); i++) {
-        dst[i] = src[i];
-    }
+    memcpy(buffer, brd->base + addr, size);
     return 1;  // success
 }
 
 static int hm2_soc_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
     hm2_soc_t *brd = this->private;
-    int i;
-    u32* src = (u32*) buffer;
-    u32* dst = (u32*) (brd->base + addr);
-
-    /* Per Peter Wallace, all hostmot2 access should be 32 bits and 32-bit aligned */
-    /* Check for any address or size values that violate this alignment */
-    if ( ((addr & 0x3) != 0) || ((size & 0x03) != 0) ){
-        LL_ERR( "hm2_soc_write: Unaligned Access: %08x %04x\n", addr,size);
-        memcpy(dst, src, size);
-        return 1;  // success
-    }
-
-    for (i=0; i<(size/4); i++) {
-        dst[i] = src[i];
-    }
-    return 1;  // success
+    memcpy(brd->base + addr, buffer, size);
+    return 1;
 }
 
 // when no firmware= was specified, hm2_register() will read/write from the

--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
@@ -150,9 +150,6 @@ RTAPI_IP_STRING(descriptor, ".bin file with encoded fwid protobuf descriptor mes
 static int no_init_llio;
 RTAPI_IP_INT(no_init_llio, "debugging - if 1, do not set any llio fields (like num_leds");
 
-static int timer1;
-RTAPI_IP_INT(timer1, "rate for hm2 Timer1 IRQ, 0: IRQ disabled");
-
 static int num;
 RTAPI_IP_INT(num, "hm2 instance number, used for <boardname>.<num>.<pinname>");
 


### PR DESCRIPTION
shaves off 10-20% off time spent in hm2_read/hm2_write
beating optimized library functions is usually not a good idea