### PR TITLE
Alternative xhc-hb04 pendant fix

### DIFF
--- a/configs/sim/axis/xhc-hb04/xhc-hb04.tcl
+++ b/configs/sim/axis/xhc-hb04/xhc-hb04.tcl
@@ -89,16 +89,17 @@ proc is_uniq {list_name} {
   return 1 ;# unique
 } ;# is_uniq
 
+## formatting of `show pin <pin-name>` has changed
+## however if there is no match a blank line will be output
+## beneath the header - match that
+## trying to match a complex format that may change is madness.
+
 proc pin_exists {name} {
   set line [lindex [split [show pin $name] \n] 2]
-  if {"$line" == ""} {
+  if {"$line" == "\n"} {
     return 0 ;# fail
-  }
-  if [catch {scan $line "%d %s %s %s%s" owner type dir value pinname} msg] {
-     return 0 ;# fail
   } else {
-     #puts stderr "OK:$owner $type $dir $value $pinname"
-     return 1 ;# ok
+    return 1 ;# ok
   }
 } ;# pin_exists
 


### PR DESCRIPTION
This uses tcl and the fact that halcmd_commands.c will output a
new line '\n' at the end of its print of 'show pin <pin-name>'

If this char is all there is in the line after the header print
there were no pins of that name to display

Signed-off-by: Mick <arceye@mgware.co.uk>