### PR TITLE
Amend hal_priv.h to remove compiler warnings

### DIFF
--- a/src/hal/lib/hal_priv.h
+++ b/src/hal/lib/hal_priv.h
@@ -511,7 +511,7 @@ static inline const char* fa_funct_name(const hal_funct_args_t *fa)
     return fa->funct->name;
 }
 
-static inline const int fa_argc(const hal_funct_args_t *fa)
+static inline int fa_argc(const hal_funct_args_t *fa)
 {
     return fa->argc;
 }


### PR DESCRIPTION
The extra warnings now generated by gcc4.9 and higher, mean that hal_priv.h produces multiple warnings of 
`hal_priv.h :514    warning: type qualifiers ignored on function return type ...`

This is because hal_priv.h:514 has a declared `const int` return type and actually returns `int` , which is what `hal_funct_args_t->argc` actually is.