### PR TITLE
Update hal_gpio driver for Raspberry Pi 3

### DIFF
--- a/src/hal/drivers/cpuinfo.c
+++ b/src/hal/drivers/cpuinfo.c
@@ -72,7 +72,7 @@ int get_rpi_revision(void)
    else if ((strcmp(revision, "a01041") == 0) ||
             (strcmp(revision, "a21041") == 0 ))
       return 3;
-   else if ((strcmp(revision, "a22082") == 0))
+   else if (strcmp(revision, "a22082") == 0)
       return 4;
    else // assume rev 5
       return 5;

--- a/src/hal/drivers/cpuinfo.c
+++ b/src/hal/drivers/cpuinfo.c
@@ -72,6 +72,8 @@ int get_rpi_revision(void)
    else if ((strcmp(revision, "a01041") == 0) ||
             (strcmp(revision, "a21041") == 0 ))
       return 3;
-   else // assume rev 4
+   else if ((strcmp(revision, "a22082") == 0))
       return 4;
+   else // assume rev 4
+      return 5;
 }

--- a/src/hal/drivers/cpuinfo.c
+++ b/src/hal/drivers/cpuinfo.c
@@ -74,6 +74,6 @@ int get_rpi_revision(void)
       return 3;
    else if ((strcmp(revision, "a22082") == 0))
       return 4;
-   else // assume rev 4
+   else // assume rev 5
       return 5;
 }

--- a/src/hal/drivers/hal_gpio.c
+++ b/src/hal/drivers/hal_gpio.c
@@ -219,6 +219,13 @@ int rtapi_app_main(void)
     rtapi_print_msg(RTAPI_MSG_INFO, "%d cores rev %d", ncores, rev);
 
     switch (rev) {
+    case 4
+      rtapi_print_msg(RTAPI_MSG_INFO, "Raspberry3\n");
+      pins = rpi2_pins;
+      gpios = rpi2_gpios;
+      npins = sizeof(rpi2_pins);
+      break;
+
     case 3:
       rtapi_print_msg(RTAPI_MSG_INFO, "Raspberry2\n");
       pins = rpi2_pins;

--- a/src/hal/drivers/hal_gpio.c
+++ b/src/hal/drivers/hal_gpio.c
@@ -219,7 +219,7 @@ int rtapi_app_main(void)
     rtapi_print_msg(RTAPI_MSG_INFO, "%d cores rev %d", ncores, rev);
 
     switch (rev) {
-    case 4
+    case 4:
       rtapi_print_msg(RTAPI_MSG_INFO, "Raspberry3\n");
       pins = rpi2_pins;
       gpios = rpi2_gpios;


### PR DESCRIPTION
/proc/cpuinfo returns

Hardware        : BCM2709
Revision        : a22082

I am unable to compile and test this patch at the moment due to configuration challenges.