### PR TITLE
machinekit/launcher: adding ensure_launcher function

### DIFF
--- a/lib/python/machinekit/launcher.py
+++ b/lib/python/machinekit/launcher.py
@@ -262,3 +262,13 @@ def set_debug_level(level):
 # set the Machinekit ini
 def set_machinekit_ini(ini):
     os.environ['MACHINEKIT_INI'] = ini
+
+
+# ensure mklauncher is running
+def ensure_mklaucher():
+    try:
+        subprocess.check_output(['pgrep', 'mklauncher'])
+        return
+    except subprocess.CalledProcessError:
+        pass
+    launcher.start_process('mklauncher .')


### PR DESCRIPTION
This function makes life a lot easier for Machinekit beginners.

add to a `run.py` script:

``` python
launcher.ensure_mklauncher()
```
and don't need to worry about mklauncher beeing laucnhed.
