### PR TITLE
Changes to debian packaging to add comp to main package

### DIFF
--- a/debian/machinekit-dev.install.in
+++ b/debian/machinekit-dev.install.in
@@ -1,8 +1,0 @@
-usr/include/linuxcnc/*.hh
-usr/include/linuxcnc/*.h
-usr/include/linuxcnc/userpci/*.h
-usr/lib/*.a
-usr/lib/*.so
-usr/bin/comp
-usr/share/linuxcnc/Makefile.modinc
-usr/share/linuxcnc/Makefile.inc

--- a/debian/machinekit-posix.install
+++ b/debian/machinekit-posix.install
@@ -1,3 +1,11 @@
 usr/lib/linuxcnc/posix/*.so
 usr/lib/linuxcnc/ulapi-posix.so
 usr/libexec/linuxcnc/rtapi_app_posix
+usr/include/linuxcnc/*.hh
+usr/include/linuxcnc/*.h
+usr/include/linuxcnc/userpci/*.h
+usr/lib/*.a
+usr/lib/*.so
+usr/bin/comp
+usr/share/linuxcnc/Makefile.modinc
+usr/share/linuxcnc/Makefile.inc

--- a/debian/machinekit-posix.install.in
+++ b/debian/machinekit-posix.install.in
@@ -1,9 +1,8 @@
-usr/lib/linuxcnc/rt-preempt/*.so
-usr/lib/linuxcnc/ulapi-rt-preempt.so
-usr/libexec/linuxcnc/rtapi_app_rt-preempt
+usr/lib/linuxcnc/posix/*.so
+usr/lib/linuxcnc/ulapi-posix.so
+usr/libexec/linuxcnc/rtapi_app_posix
 usr/include/linuxcnc/*.hh
 usr/include/linuxcnc/*.h
-usr/include/linuxcnc/userpci/*.h
 usr/lib/*.a
 usr/lib/*.so
 usr/bin/comp

--- a/debian/machinekit-rt-preempt.install
+++ b/debian/machinekit-rt-preempt.install
@@ -1,3 +1,11 @@
 usr/lib/linuxcnc/rt-preempt/*.so
 usr/lib/linuxcnc/ulapi-rt-preempt.so
 usr/libexec/linuxcnc/rtapi_app_rt-preempt
+usr/include/linuxcnc/*.hh
+usr/include/linuxcnc/*.h
+usr/include/linuxcnc/userpci/*.h
+usr/lib/*.a
+usr/lib/*.so
+usr/bin/comp
+usr/share/linuxcnc/Makefile.modinc
+usr/share/linuxcnc/Makefile.inc

--- a/debian/machinekit-rt-preempt.install.in
+++ b/debian/machinekit-rt-preempt.install.in
@@ -1,9 +1,8 @@
-usr/lib/linuxcnc/posix/*.so
-usr/lib/linuxcnc/ulapi-posix.so
-usr/libexec/linuxcnc/rtapi_app_posix
+usr/lib/linuxcnc/rt-preempt/*.so
+usr/lib/linuxcnc/ulapi-rt-preempt.so
+usr/libexec/linuxcnc/rtapi_app_rt-preempt
 usr/include/linuxcnc/*.hh
 usr/include/linuxcnc/*.h
-usr/include/linuxcnc/userpci/*.h
 usr/lib/*.a
 usr/lib/*.so
 usr/bin/comp

--- a/debian/machinekit-xenomai.install
+++ b/debian/machinekit-xenomai.install
@@ -1,3 +1,11 @@
 usr/lib/linuxcnc/xenomai/*
 usr/lib/linuxcnc/ulapi-xenomai.so
 usr/libexec/linuxcnc/rtapi_app_xenomai
+usr/include/linuxcnc/*.hh
+usr/include/linuxcnc/*.h
+usr/include/linuxcnc/userpci/*.h
+usr/lib/*.a
+usr/lib/*.so
+usr/bin/comp
+usr/share/linuxcnc/Makefile.modinc
+usr/share/linuxcnc/Makefile.inc

--- a/debian/machinekit-xenomai.install.in
+++ b/debian/machinekit-xenomai.install.in
@@ -3,7 +3,6 @@ usr/lib/linuxcnc/ulapi-xenomai.so
 usr/libexec/linuxcnc/rtapi_app_xenomai
 usr/include/linuxcnc/*.hh
 usr/include/linuxcnc/*.h
-usr/include/linuxcnc/userpci/*.h
 usr/lib/*.a
 usr/lib/*.so
 usr/bin/comp

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -182,12 +182,12 @@ endif
 	cp src/rtapi/shmdrv/limits.d-machinekit.conf \
 	    debian/tmp/etc/security/limits.d/machinekit.conf
 
-	if (grep ^USERMODE_PCI=yes src/Makefile.inc -q); then \
-	    cp debian/machinekit-dev.install.in debian/machinekit-dev.install; \
-	else \
-	    grep -v userpci debian/machinekit-dev.install.in \
-		> debian/machinekit-dev.install; \
-	fi
+#	if (grep ^USERMODE_PCI=yes src/Makefile.inc -q); then \
+#	    cp debian/machinekit-dev.install.in debian/machinekit-dev.install; \
+#	else \
+#	    grep -v userpci debian/machinekit-dev.install.in \
+#		> debian/machinekit-dev.install; \
+#	fi
 
 	dh_install --sourcedir=debian/tmp --fail-missing -Xusr/bin/pasm
 
@@ -213,9 +213,9 @@ binary-arch: build install
 	dh_installdeb
 
 #	# delete files that should be in machinekit-dev package
-	rm -f debian/machinekit/usr/bin/comp
-	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.modinc
-	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.inc
+#	rm -f debian/machinekit/usr/bin/comp
+#	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.modinc
+#	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.inc
 
 	cat debian/machinekit/DEBIAN/shlibs debian/shlibs.pre > \
 	    debian/shlibs.local

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -182,13 +182,16 @@ endif
 	cp src/rtapi/shmdrv/limits.d-machinekit.conf \
 	    debian/tmp/etc/security/limits.d/machinekit.conf
 
-#	if (grep ^USERMODE_PCI=yes src/Makefile.inc -q); then \
-#	    cp debian/machinekit-dev.install.in debian/machinekit-dev.install; \
-#	else \
-#	    grep -v userpci debian/machinekit-dev.install.in \
-#		> debian/machinekit-dev.install; \
-#	fi
+	cp debian/machinekit-posix.install.in debian/machinekit-posix.install
+	cp debian/machinekit-rt-preempt.install.in debian/machinekit-rt-preempt.install
+	cp debian/machinekit-xenomai.install.in debian/machinekit-xenomai.install
 
+	if (grep ^USERMODE_PCI=yes src/Makefile.inc -q); then \
+	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-posix.install; \
+	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-rt-preempt.install; \
+	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-xenomai.install; \
+	fi
+	
 	dh_install --sourcedir=debian/tmp --fail-missing -Xusr/bin/pasm
 
 # Build architecture-independent files here.


### PR DESCRIPTION
Relates to Issue #1060

This PR will test whether Makefile.inc generated within
a build for xenomai flavour, will fix problem with comp
installing to the wrong flavour directory

Signed-off-by: Mick <arceye@mgware.co.uk>