### PR TITLE
mank: Update pager

### DIFF
--- a/bin/mank
+++ b/bin/mank
@@ -61,7 +61,7 @@ else
 fi
 
 if [ ! -z "$filn" ]; then
-    asciidoctor $filn -o - | elinks -dump | more
+    asciidoctor $filn -o - | elinks -dump | pager -s
 
     ## allow dispensing with key read and screen clear when scripting use of mank, as in instcomp / comp
     ## --view-doc


### PR DESCRIPTION
Switch mank to use the same default pager as man.

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>