### PR TITLE
Misc fixes:  fix #1064; cosmetic tweaks

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -148,6 +148,7 @@ else
     AC_SUBST(CC_FOR_BUILD,$CC)
 fi
 
+AC_PROG_CXX
 AC_PROG_CPP()
 AC_CHECK_TOOL(OBJCOPY, objcopy)
 AC_CHECK_TOOL(LD, ld)
@@ -2318,7 +2319,6 @@ AC_SUBST(GLIB_CFLAGS)
 ##############################################################################
 
 SPATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin
-AC_PROG_CXX
 
 # make this optional - it will likely only result in warnings
 AX_CXX_COMPILE_STDCXX_11(noext,optional)

--- a/src/po/Submakefile
+++ b/src/po/Submakefile
@@ -57,8 +57,8 @@ TCLSRCS := \
 
 po/linuxcnc.pot:
 	$(ECHO) Localizing linuxcnc.pot
-	(cd ..; $(XGETTEXT) -k_ -o src/$@ `src/po/fixpaths.py -j src $^`)
-	touch $@
+	@(cd ..; $(XGETTEXT) -k_ -o src/$@ `src/po/fixpaths.py -j src $^`)
+	@touch $@
 TARGETS += po/linuxcnc.pot
 
 pofiles: po/linuxcnc.pot

--- a/src/rebrand
+++ b/src/rebrand
@@ -6,8 +6,6 @@
 # $USERPREFIX is exported from autoconfig
 #####################################################################
 
-echo "USERPREFIX = $USERPREFIX"
-
 if [ ! -f "$USERPREFIX/scripts/machinekit" ]; then
     if [ ! -L "$USERPREFIX/scripts/machinekit" ]; then
         ln -s $USERPREFIX/scripts/linuxcnc $USERPREFIX/scripts/machinekit


### PR DESCRIPTION
Here are a few fixes from my tree.

The `configure.ac` commit actually fixes an issue, #1064.

The other two commits hide some build output.