### PR TITLE
Final cross-build tweaks

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -3,6 +3,7 @@
 /rules
 /files
 /configure.cmdline
+/machinekit.install
 /machinekit-*-kernel-*.install
 /machinekit-dev.install
 

--- a/debian/configure
+++ b/debian/configure
@@ -138,6 +138,7 @@ do_xenomai_kernel() {
     rules_enable_threads xenomai-kernel
     XENOMAI_KERNEL_HEADERS+=" ${KVER}"
     HAVE_FLAVOR=true
+    HAVE_KTHREADS_FLAVOR=true
 }
 
 do_rtai_kernel() {
@@ -162,6 +163,7 @@ do_rtai_kernel() {
     rules_enable_threads rtai-kernel
     RTAI_KERNEL_HEADERS+=" ${KVER}"
     HAVE_FLAVOR=true
+    HAVE_KTHREADS_FLAVOR=true
 }
 
 do_tcl_tk_version() {
@@ -210,7 +212,9 @@ test "$1" != --help || usage
 
 # set defaults
 BUILD_DEPS=  # List of Build-Depends
+DEPS= # List of Depends
 HAVE_FLAVOR=false
+HAVE_KTHREADS_FLAVOR=false
 
 # delete old files
 rm -f machinekit-{rtai,xenomai}-kernel-*.install
@@ -220,6 +224,8 @@ cp control.in control
 echo "debian/control:  copied base template" >&2
 cp rules.in rules; chmod +x rules
 echo "debian/rules:  copied base template" >&2
+cp machinekit.install.in machinekit.install
+echo "debian/machinekit.install.in:  copied base template" >&2
 
 # read command line options
 while getopts dprxR:X:t:?h ARG; do
@@ -242,9 +248,18 @@ do_tcl_tk_version "$TCL_TK_VER"
 rules_set_kthreads_headers xenomai-kernel $XENOMAI_KERNEL_HEADERS
 rules_set_kthreads_headers rtai-kernel $RTAI_KERNEL_HEADERS
 
+# Kthreads need `kmod` for both build and runtime deps
+if $HAVE_KTHREADS_FLAVOR; then
+    BUILD_DEPS+='kmod, '
+    DEPS+='kmod, '
+    echo "usr/libexec/linuxcnc/linuxcnc_module_helper" >> \
+	machinekit.install
+fi
+
 # Set control Build-Depends:
 sed -i control \
     -e "s/@BUILD_DEPS@/${BUILD_DEPS}/" \
+    -e "s/@DEPS@/${DEPS}/" \
     -e "s/@TCL_TK_BUILD_DEPS@/${TCL_TK_BUILD_DEPS}/" \
     -e "s/@TCL_TK_DEPS@/${TCL_TK_DEPS}/"
 echo "debian/control:  add final Build-Depends: list" >&2

--- a/debian/control.in
+++ b/debian/control.in
@@ -11,7 +11,7 @@ Build-Depends: debhelper (>= 6),
     pkg-config, psmisc, python-tk, libxaw7-dev, libboost-serialization-dev,
     libzmq3-dev (>= 4.0.4), libczmq-dev (>= 2.2.0), libjansson-dev (>= 2.5),
     libwebsockets-dev (>= 1.2.2),
-    python-zmq (>= 14.0.1), procps, kmod,
+    python-zmq (>= 14.0.1), procps,
     liburiparser-dev, libssl-dev, python-setuptools,
     uuid-dev, uuid-runtime, libavahi-client-dev,
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
@@ -40,7 +40,7 @@ Breaks: linuxcnc
 Replaces: linuxcnc
 Architecture: any
 Depends: ${shlibs:Depends}, machinekit-rt-threads, @TCL_TK_DEPS@,
-    bwidget (>= 1.7), libtk-img (>=1.13),
+    @DEPS@ bwidget (>= 1.7), libtk-img (>=1.13),
     ${python:Depends}, ${misc:Depends},
     python-tk, python-imaging, python-imaging-tk,
     python-gnome2, python-glade2,
@@ -49,7 +49,7 @@ Depends: ${shlibs:Depends}, machinekit-rt-threads, @TCL_TK_DEPS@,
     python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
     python-avahi, python-simplejson, python-pyftpdlib,
     python-pydot, xdot,
-    tclreadline, bc, procps, psmisc, module-init-tools | kmod,
+    tclreadline, bc, procps, psmisc,
     gstreamer0.10-plugins-base
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/debian/machinekit.install.in
+++ b/debian/machinekit.install.in
@@ -13,7 +13,6 @@ usr/lib/python*/*/gladevcp/*.glade
 usr/lib/python*/*/machinekit/*.so
 usr/lib/python*/*/machinetalk/protobuf/*.py
 usr/lib/python*/*/machinetalk/*.py
-usr/libexec/linuxcnc/linuxcnc_module_helper
 usr/libexec/linuxcnc/pci_read
 usr/libexec/linuxcnc/pci_write
 usr/libexec/linuxcnc/inivar

--- a/src/Makefile
+++ b/src/Makefile
@@ -263,10 +263,11 @@ SUBDIRS := \
 	emc \
 	emc/pythonplugin \
 	\
-	module_helper \
-	\
 	po \
 
+ifeq ($(HAVE_KERNEL_THREADS),yes)
+SUBDIRS += module_helper
+endif
 
 # moved to src/rtapi/Submakefile
 # ULAPISRCS := rtapi/$(RTPREFIX)_ulapi.c
@@ -748,7 +749,9 @@ ifeq ($(HAVE_KERNEL_THREADS),yes)
 CHECK_KFLAV_SWITCH=-k
 endif
 setuid:
+ifeq ($(HAVE_KERNEL_THREADS),yes)
 	$(call fix_perms,../libexec/linuxcnc_module_helper)
+endif
 	$(call fix_perms,../libexec/pci_read)
 	$(call fix_perms,../libexec/pci_write)
 	$(foreach f,$(BUILD_THREAD_FLAVORS),\
@@ -1007,7 +1010,9 @@ endif
 
 install-kernel-dep: install-dirs
 	$(SETUID) ../libexec/rtapi_app_* $(DESTDIR)$(EMC2_LIBEXEC_DIR)
+ifeq ($(HAVE_KERNEL_THREADS),yes)
 	$(SETUID) ../libexec/linuxcnc_module_helper $(DESTDIR)$(EMC2_LIBEXEC_DIR)
+endif
 ifeq ($(BUILD_DRIVERS),yes)
 	$(SETUID) ../libexec/pci_write $(DESTDIR)$(EMC2_LIBEXEC_DIR)
 	$(SETUID) ../libexec/pci_read $(DESTDIR)$(EMC2_LIBEXEC_DIR)

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2295,22 +2295,25 @@ then
     AC_MSG_ERROR([awk not found])
 fi
 
-AC_PATH_PROG(INSMOD, insmod, "none", $SPATH)
-if test $INSMOD = "none"
-then
-    AC_MSG_ERROR([insmod not found])
-fi
+if test -n "${rtai_kernels}${xenomai_kernels}${shmdrv_kernels}"; then
+    # Kernel module tools only needed for kthreads
+    AC_PATH_PROG(INSMOD, insmod, "none", $SPATH)
+    if test $INSMOD = "none"
+    then
+	AC_MSG_ERROR([insmod not found])
+    fi
 
-AC_PATH_PROG(RMMOD, rmmod, "none", $SPATH)
-if test $RMMOD = "none"
-then
-    AC_MSG_ERROR([rmmod not found])
-fi
+    AC_PATH_PROG(RMMOD, rmmod, "none", $SPATH)
+    if test $RMMOD = "none"
+    then
+	AC_MSG_ERROR([rmmod not found])
+    fi
 
-AC_PATH_PROG(LSMOD, lsmod, "none", $SPATH)
-if test $LSMOD = "none"
-then
-    AC_MSG_ERROR([lsmod not found])
+    AC_PATH_PROG(LSMOD, lsmod, "none", $SPATH)
+    if test $LSMOD = "none"
+    then
+	AC_MSG_ERROR([lsmod not found])
+    fi
 fi
 
 AC_PATH_PROG(PIDOF, pidof, "none", $SPATH)

--- a/tests/module-loading/shared-test.sh
+++ b/tests/module-loading/shared-test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 outpipe=pipe-stdout
+trap "rm -f $outpipe" 0 1 2 3 9 15 EXIT
 mkfifo $outpipe
 
 tee hal-output < $outpipe | egrep $(cat PIN_NAME_REGEX) | wc -l \


### PR DESCRIPTION
These are a last few tweaks needed for cross-building (or maybe "arising out of the cross-building effort").

- Remove package build-deps needed for building kernel threads
  - This could be avoided, but it's easier than installing them into build container images, and aren't kthreads obsolete?
- Remove a FIFO left behind by one group of regression tests that isn't removed by `git clean` but that chokes `dpkg-source`
  - Also not strictly needed for cross-building, but makes testing cross-building packages and RIP+tests from the same tree much easier
