### PR TITLE
Amend configure.ac HAVE_GTK test to use square bracketed args.

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2227,10 +2227,13 @@ AC_ARG_ENABLE(gtk,
     [BUILD_GTK=yes])
 
 if test "$BUILD_GTK" = "yes"; then
-    PKG_CHECK_MODULES(GTK, gtk+-2.0 >= 2.4.0,
-	[ AC_DEFINE(HAVE_GTK, 1, Use GTK) ],
-        [ AC_MSG_ERROR([no gtk+-2.0 found; use --disable-gtk])])
-    AC_PRUNE_DEFAULT_LDFLAGS(GTK_LIBS)
+    PKG_CHECK_MODULES([GTK], [gtk+-2.0 >= 2.4.0],
+	[
+    	    AC_DEFINE(HAVE_GTK, [1], [gtk > 2.4 available HAVE_GTK set])
+	    HAVE_GTK=yes
+	],
+	[ AC_MSG_ERROR([no gtk+-2.0 found; use --disable-gtk])]
+	[ AC_PRUNE_DEFAULT_LDFLAGS(GTK_LIBS) ] )
     PKG_CHECK_MODULES(GNOMEPRINT, libgnomeprintui-2.2,
         [
 	    GTK_CFLAGS="$GTK_CFLAGS $GNOMEPRINT_CFLAGS"


### PR DESCRIPTION
Changes in 0b36e4c did not work as anticipated and HAVE_GTK
was not defined, resulting in halmeter, halscope, classicladder
and all gtk dependent binaries not being built

Fixes #1083

Signed-off-by: Mick <arceye@mgware.co.uk>