### PR TITLE
Update control.rt-preempt.in

### DIFF
--- a/debian/control.rt-preempt.in
+++ b/debian/control.rt-preempt.in
@@ -5,7 +5,7 @@ Depends: machinekit (= ${binary:Version}), ${shlibs:Depends},
 # These Debian-style RT_PREEMPT package names are restricted by
 # architecture; ARM arch SOCs are all incompatible, so this can't be
 # easily done for ARM.
- linux-image-rt-686-pae [i386], linux-image-rt-amd64 [amd64]
+ linux-image-4.1.19-rt22mah [i386], linux-image-4.1.19-rt22mah [amd64]
 Provides:  machinekit-rt-threads
 Suggests: hostmot2-firmware-all [!armhf]
 Enhances: machinekit


### PR DESCRIPTION
The debian meta-package listed as dependency, does not resolve to a current rt-preempt kernel any more.
This leaves the package machinekit-rt-preempt uninstallable.

List the latest rt-preempt kernel in our own repo as dependency, enabling installation

Fixes #917 (hopefully)