### PR TITLE
Fixes compilation issue with gcc version 6.2.1

### DIFF
--- a/src/rtapi/rtapi_math/e_asin.c
+++ b/src/rtapi/rtapi_math/e_asin.c
@@ -95,12 +95,13 @@ qS4 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
 	} else if (ix<0x3fe00000) {	/* |x|<0.5 */
 	    if(ix<0x3e400000) {		/* if |x| < 2**-27 */
 		if(huge+x>one) return x;/* return x with inexact if x!=0*/
-	    } else 
+	    } else {
 		t = x*x;
 		p = t*(pS0+t*(pS1+t*(pS2+t*(pS3+t*(pS4+t*pS5)))));
 		q = one+t*(qS1+t*(qS2+t*(qS3+t*qS4)));
 		w = p/q;
 		return x+x*w;
+	    }
 	}
 	/* 1> |x|>= 0.5 */
 	w = one-rtapi_fabs(x);


### PR DESCRIPTION
rtapi/rtapi_math/e_asin.c: In function ‘__ieee754_asin’:
rtapi/rtapi_math/e_asin.c:98:8: error: this ‘else’ clause does not guard... [-Werror=misleading-indentation]
      } else
        ^~~~
rtapi/rtapi_math/e_asin.c:100:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘else’
   p = t_(pS0+t_(pS1+t_(pS2+t_(pS3+t_(pS4+t_pS5)))));
   ^
cc1: all warnings being treated as errors
