### PR TITLE
Deprecate `option singleton` in instantiated components

### DIFF
--- a/src/hal/i_components/thc.icomp
+++ b/src/hal/i_components/thc.icomp
@@ -54,8 +54,6 @@ author "John Thornton";
 
 license "GPLv2 or greater";
 
-option singleton yes;
-
 // Input Pins
 pin in float encoder_vel "Connect to hm2_5i20.0.encoder.00.velocity";
 pin in float current_vel "Connect to motion.current-vel";
@@ -92,6 +90,7 @@ function _;
 
 FUNCTION(_)
 {
+
     // convert encoder velocity to volts
     volts = (encoder_vel - scale_offset) * vel_scale;
     if(volts < 0.0){volts = 0.0;} // make sure volts is not negative
@@ -136,6 +135,5 @@ FUNCTION(_)
         z_pos_out = z_pos_in;
         z_fb_out = z_pos_in; // keep axis motor position fb from being confused
     }
-
 return 0;
 }

--- a/src/hal/i_components/thcud.icomp
+++ b/src/hal/i_components/thcud.icomp
@@ -59,8 +59,6 @@ author "John Thornton";
 
 license "GPLv2 or greater";
 
-option singleton yes;
-
 // Input Pins
 pin in bit torch_up "Connect to an input pin";
 pin in bit torch_down "Connect to input pin";

--- a/src/hal/icomp-example/instcomp.asciidoc
+++ b/src/hal/icomp-example/instcomp.asciidoc
@@ -116,7 +116,7 @@ Thus existing configs will still work for the most part using loadrt (see Notes 
 
 This includes the sim configs included with machinekit
 
-The singleton component is supported by changes to halcmd, which will prevent more than one instance being loaded
+The singleton component is deprecated - just make sure you only load one if they clash
 
 Notes
 
@@ -254,9 +254,6 @@ The differing options are:
 * *'instanceparam [int / string] param_name = <value>'*
     Instanceparams that may be passed to the component at newinst
     If value not set, will be set to 0 or "\0" respectively
-
-*   *'singleton'*   will only allow one instance to be loaded anywhere within a single session
-    This is contrary to the basic premise of instantiated components, but implemented for compatibility
 
 *   *'option MAXCOUNT'*
 

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -366,7 +366,7 @@ static int comp_id;
 
     print >>f, "RTAPI_TAG(HAL,HC_INSTANTIABLE);"
     if options.get("singleton"):
-        print >>f, "RTAPI_TAG(HAL,HC_SINGLETON);"
+        print "option singleton is deprecated"
     print >>f
 
     has_array = False
@@ -1085,12 +1085,12 @@ def adocument(filename, outfilename, frontmatter):
         print >>f, ""
         for _, name, fp, doc in finddocs('funct'):
             if name != None and name != "_":
-                print >>f, "*%s.N.%s.funct*" % (comp_name, name) ,
+                print >>f, "*%s.N.%s.funct*" % (comp_name, to_hal(name)) ,
             else :
                 print >>f, "*%s.N.funct*" % comp_name ,
     	    print >>f, "\n( OR"
             if name != None and name != "_":
-                print >>f, "*<newinstname>.%s.funct*"  % name ,
+                print >>f, "*<newinstname>.%s.funct*"  % to_hal(name) ,
             else :
                 print >>f, "*<newinstname>.funct*" ,
             if fp:
@@ -1106,7 +1106,7 @@ def adocument(filename, outfilename, frontmatter):
     print >>f, ""    
     for _, name, type, array, dir, doc, value in finddocs('pin'):
         print >>f, ""
-        print >>f, "*%s.N.%s*" % (comp_name, name),
+        print >>f, "*%s.N.%s*" % (comp_name, to_hal(name)),
         print >>f, type, dir,
         if array:
             sz = name.count("#")
@@ -1116,7 +1116,7 @@ def adocument(filename, outfilename, frontmatter):
 
 	print >>f, "( OR"
 
-        print >>f, "*<newinstname>.%s*" % name,
+        print >>f, "*<newinstname>.%s*" % to_hal(name),
         print >>f, type, dir,
         if array:
             sz = name.count("#")


### PR DESCRIPTION
The option was originally supported for backward compatibility,
however it really contradicts the basic concept of instantiation.

If a component cannot ever have more than one instance, it should
be written as a standard .comp

Arose initially from Issue #1094 where checking for other instances
of a component marked as a singleton, without proper mutex lock
was causing problems
On reflection the whole concept within instcomps was removed.

Whilst editing instcomp, corrected an error that had crept in during
changes to document generation, whereby the pin names were displayed
in the docs in C style rather than the HAL names

Fixes #1094
Corrects documentation issue in #1093

Signed-off-by: Mick <arceye@mgware.co.uk>