### PR TITLE
Reinstate thc and thcud as standard components

### DIFF
--- a/src/hal/components/thc.comp
+++ b/src/hal/components/thc.comp
@@ -1,9 +1,9 @@
 component thc "Torch Height Control";
 
-description
+description 
 """
 Torch Height Control
-Mesa THC > Encoder > Machinekit THC component
+Mesa THC > encoder > Machinekit THC component
 
 The Mesa THC sends a frequency based on the voltage detected to the encoder.
 The velocity from the encoder is converted to volts with the velocity scale
@@ -24,7 +24,7 @@ pass the Z position and feed back untouched.
 
 If not enabled pass the Z position and feed back untouched.
 
-*Physical Connections*
+Physical Connections
 
 Plasma Torch Arc Voltage Signal => 6 x 487k 1% resistors => THC Arc Voltage In
 
@@ -34,7 +34,7 @@ Plasma Torch Arc OK Signal => input pin
 
 output pin => Plasma Torch Start Arc Contacts
 
-*HAL Plasma Connections*
+HAL Plasma Connections
 
 encoder.nn.velocity => thc.encoder-vel (tip voltage)
 
@@ -42,17 +42,19 @@ motion.spindle-on => output pin (start the arc)
 
 thc.arc-ok <= motion.digital-in-00 <= input pin (arc ok signal)
 
-*HAL Motion Connections*
+HAL Motion Connections
 
 thc.requested-vel <= motion.requested-vel
 
 thc.current-vel <= motion.current-vel
 
 """;
-
+ 
 author "John Thornton";
 
 license "GPLv2 or greater";
+
+option singleton yes;
 
 // Input Pins
 pin in float encoder_vel "Connect to hm2_5i20.0.encoder.00.velocity";
@@ -70,17 +72,18 @@ pin out float z_pos_out "Z Motor Position Command Out";
 pin out float z_fb_out "Z Position Feedback to Axis";
 pin out float volts "The Calculated Volts";
 pin out bit vel_status "When the THC thinks we are at requested speed";
+pin out float offset_value "The Current Offset";
 
 // Parameters
-pin io float vel_scale "The scale to convert the Velocity signal to Volts";
-pin io float scale_offset "The offset of the velocity input at 0 volts";
-pin io float velocity_tol "The deviation percent from planned velocity";
-pin io float voltage_tol "The deviation of Tip Voltage before correction takes place";
-pin io float correction_vel "The amount of change in user units per period to move Z to correct";
+param rw float vel_scale "The scale to convert the Velocity signal to Volts";
+param rw float scale_offset "The offset of the velocity input at 0 volts";
+param rw float velocity_tol "The deviation percent from planned velocity";
+param rw float voltage_tol "The deviation of Tip Voltage before correction takes place";
+param rw float correction_vel "The amount of change in user units per period to move Z to correct";
 
 // Global Variables
-variable hal_float_t offset;
-variable hal_float_t last_z_in;
+variable float offset = 0.0;
+variable float last_z_in = 0.0;
 
 function _;
 
@@ -88,42 +91,41 @@ function _;
 
 #include "rtapi_math.h"
 
-FUNCTION(_)
-{
-
+FUNCTION(_) {
     // convert encoder velocity to volts
     volts = (encoder_vel - scale_offset) * vel_scale;
-    if(volts < 0.0){volts = 0.0;} // make sure volts is not negative
+    if(volts < 0){volts = 0;} // make sure volts is not negative
+    offset_value = offset;
 
     if(enable){
-        hal_float_t min_velocity = requested_vel -(requested_vel*(velocity_tol*0.01));
-        if(current_vel > 0.0 && current_vel >= min_velocity){vel_status = 1;}
-        else {vel_status = false;}
-
+        float min_velocity = requested_vel -(requested_vel*(velocity_tol*0.01));
+        if(current_vel > 0 && current_vel >= min_velocity){vel_status = 1;}
+        else {vel_status =0;}
+        
         if(torch_on && arc_ok && vel_status){ // allow correction
             if((volts + voltage_tol) > volts_requested){
                 offset -= correction_vel;
             }
             if((volts - voltage_tol) < volts_requested){
                 offset += correction_vel;
-            }
-            last_z_in = 0.0;
+            }    
+            last_z_in = 0;
         }
         if(!torch_on){ // remove any offset
-            hal_float_t z_diff;
+            float z_diff;
             z_diff = z_pos_in - last_z_in;
-            if(z_diff > 0.0 && offset != 0.0){ // torch is moving up
-                if(offset > 0.0){ // positive offset
+            if(z_diff > 0 && offset != 0){ // torch is moving up
+                if(offset > 0){ // positive offset
                     if(offset > z_diff){ // remove some
                         offset -= z_diff;
                     }
-                    else {offset = 0.0;}
+                    else {offset = 0;}
                 }
-                if(offset < 0.0){ // negative offset
+                if(offset < 0){ // negative offset
                     if(offset < z_diff){ // remove some
                         offset += z_diff;
                     }
-                    else {offset = 0.0;}
+                    else {offset = 0;}
                 }
             }
             last_z_in = z_pos_in;
@@ -135,5 +137,5 @@ FUNCTION(_)
         z_pos_out = z_pos_in;
         z_fb_out = z_pos_in; // keep axis motor position fb from being confused
     }
-return 0;
 }
+

--- a/src/hal/components/thcud.comp
+++ b/src/hal/components/thcud.comp
@@ -1,6 +1,6 @@
 component thcud "Torch Height Control Up/Down Input";
 
-description
+description 
 """
 Torch Height Control
 This THC takes either an up or a down input from a THC
@@ -11,53 +11,59 @@ allow the THC to offset the Z axis as needed to maintain voltage.
 If enabled and torch is off and the Z axis is moving up remove any correction
 at a rate not to exceed the rate of movement of the Z axis.
 
-If enabled and torch is off and there is no correction
+If enabled and torch is off and there is no correction 
 pass the Z position and feed back untouched.
 
 If not enabled pass the Z position and feed back untouched.
 
-*Physical Connections typical*
-paraport.0.pin-12-in <= THC controller Plasma Up
-paraport.0.pin-13-in <= THC controller Plasma Down
-parport.0.pin-15-in  <= Plasma Torch Arc Ok Signal
-parport.0.pin-16-out => Plasma Torch Start Arc Contacts
+Typical Physical Connections using a Parallel Port
 
-*HAL Plasma Connections*
-thc.torch-up <= paraport.0.pin-12-in
-thc.torch-down <= paraport.0.pin-13-in
-motion.spindle-on => parport.0.pin-16-out (start the arc)
-thc.arc-ok <= motion.digital-in-00 <= parport.0.pin-15-in (arc ok signal)
+Parallel Pin 12 <= THC controller Plasma Up
 
-*HAL Motion Connections*
-thc.requested-vel <= motion.requested-vel
-thc.current-vel <= motion.current-vel
+Parallel Pin 13 <= THC controller Plasma Down
 
-*Pyvcp Connections*
+Parallel Pin 15  <= Plasma Torch Arc Ok Signal
+
+Parallel Pin 16 => Plasma Torch Start Arc Contacts
+
+HAL Plasma Connections
+
+net torch-up thcud.torch-up <= paraport.0.pin-12-in
+
+net torch-down thcud.torch-down <= paraport.0.pin-13-in
+
+net torch-on motion.spindle-on => parport.0.pin-16-out (start the arc)
+
+net are-ok thc.arc-ok <= motion.digital-in-00 <= parport.0.pin-15-in (arc ok signal)
+
+HAL Motion Connections
+
+net requested-vel thc.requested-vel <= motion.requested-vel
+
+net current-vel thc.current-vel <= motion.current-vel
+
+Pyvcp Connections
 In the xml file you need something like:
 
-    <checkbutton>
-      <text>"THC Enable"</text>
-      <halpin>"thc-enable"</halpin>
-    </checkbutton>
-    <spinbox>
-      <width>"5"</width>
-      <halpin>"vel-tol"</halpin>
-      <min_>.01</min_>
-      <max_>1</max_>
-      <resolution>0.01</resolution>
-      <initval>0.2</initval>
-      <format>"1.2f"</format>
-      <font>("Arial",10)</font>
-    </spinbox>
+  <pyvcp>
+  <checkbutton>
+    <text>"THC Enable"</text>
+    <halpin>"thc-enable"</halpin>
+  </checkbutton>
+  </pyvcp>
 
 Connect the Pyvcp pins in the postgui.hal file like this:
 
 net thc-enable thcud.enable <= pyvcp.thc-enable
-""";
 
+
+""";
+ 
 author "John Thornton";
 
 license "GPLv2 or greater";
+
+option singleton yes;
 
 // Input Pins
 pin in bit torch_up "Connect to an input pin";
@@ -77,12 +83,12 @@ pin out bit vel_status "When the THC thinks we are at requested speed";
 pin out bit removing_offset "Pin for testing";
 
 // Parameters
-pin io float velocity_tol "The deviation percent from planned velocity";
-pin io float correction_vel "The Velocity to move Z to correct";
+param rw float velocity_tol "The deviation percent from planned velocity";
+param rw float correction_vel "The Velocity to move Z to correct";
 
 // Global Variables
-variable hal_float_t offset;
-variable hal_float_t last_z_in;
+variable float offset = 0.0;
+variable float last_z_in = 0.0;
 
 function _;
 
@@ -90,41 +96,40 @@ function _;
 
 #include "rtapi_math.h"
 
-FUNCTION(_)
-{
+FUNCTION(_) {
     if(enable){
-        hal_float_t min_velocity = requested_vel -(requested_vel*(1.0 /velocity_tol));
-        if(current_vel > 0.0 && current_vel >= min_velocity){vel_status = true;}
-        else {vel_status = false;}
-
+        float min_velocity = requested_vel -(requested_vel*(velocity_tol*0.01));
+        if(current_vel > 0 && current_vel >= min_velocity){vel_status = 1;}
+        else {vel_status =0;}
+        
         if(torch_on && arc_ok && vel_status){ // allow correction
             if(torch_down){
                 offset -= correction_vel;
             }
             if(torch_up){
                 offset += correction_vel;
-            }
-            last_z_in = 0.0;
+            }    
+            last_z_in = 0;
         }
         if(!torch_on){ // remove any offset
-            hal_float_t z_diff;
+            float z_diff;
             z_diff = z_pos_in - last_z_in;
-            if(z_diff > 0.0 && offset != 0.0){ // torch is moving up
-                removing_offset = true;
+            if(z_diff > 0 && offset != 0){ // torch is moving up
+                removing_offset = 1;
                 if(offset > 0){ // positive offset
                     if(offset > z_diff){ // remove some
                         offset -= z_diff;
                     }
-                    else {offset = 0.0;}
+                    else {offset = 0;}
                 }
-                if(offset < 0.0){ // negative offset
+                if(offset < 0){ // negative offset
                     if(offset < z_diff){ // remove some
                         offset += z_diff;
                     }
-                    else {offset = 0.0;}
+                    else {offset = 0;}
                 }
             }
-            else {removing_offset = false;}
+            else {removing_offset = 0;}
             last_z_in = z_pos_in;
         }
         z_pos_out = z_pos_in + offset;
@@ -134,6 +139,5 @@ FUNCTION(_)
         z_pos_out = z_pos_in;
         z_fb_out = z_pos_in; // keep axis motor position fb from being confused
     }
-
-return 0;
 }
+

--- a/src/hal/utils/comp.g
+++ b/src/hal/utils/comp.g
@@ -857,7 +857,7 @@ def adocument(filename, outfilename, frontmatter):
         print >>f, ""
         for _, name, fp, doc in finddocs('funct'):
     	    if name != None and name != "_":
-                print >>f, "*%s.N.%s*" % (comp_name, name) 
+                print >>f, "*%s.N.%s*" % (comp_name, to_hal(name)) 
             else :
                 print >>f, "*%s.N*" % comp_name 
             if fp:
@@ -871,7 +871,7 @@ def adocument(filename, outfilename, frontmatter):
     print >>f, "=== PINS"
     print >>f, ""    
     for _, name, type, array, dir, doc, value, personality in finddocs('pin'):
-        print >>f, "*%s*" % name,
+        print >>f, "*%s*" % to_hal(name),
         print >>f, type, dir,
         if array:
             sz = name.count("#")
@@ -894,7 +894,7 @@ def adocument(filename, outfilename, frontmatter):
         print >>f, "=== PARAMETERS"
         print >>f, ""
         for _, name, type, array, dir, doc, value, personality in finddocs('param'):
-            print >>f, "*%s*" % name,
+            print >>f, "*%s*" % to_hal(name),
             print >>f, type, dir,
             if array:
                 sz = name.count("#")


### PR DESCRIPTION
Further to #1095, as author is adamant component
should be a singleton and circumstances in which 2 plasma torches
might be used are unlikely, revert the .icomp versions back to .comp
where singleton is supported

Changes to comp.g to match those in instcomp.g in #1095, to
ensure that asciidoc man pages have component pin names with
HAL `-` separators not C `_` separators

Signed-off-by: Mick <arceye@mgware.co.uk>