### PR TITLE
Fixes compilation issue with make -j8 - missing destination directory

### DIFF
--- a/src/machinetalk/Submakefile
+++ b/src/machinetalk/Submakefile
@@ -274,6 +274,7 @@ PROTO_JS_SRCS +=$(JSGEN)/nanopb.js
 
 # --- misc supporting files ----
 ../lib/python/$(NAMESPACEDIR)/nanopb_generator.py: $(NANOPB)/generator/nanopb_generator.py
+	@mkdir -p ../lib/python/$(NAMESPACEDIR)/
 	cp $^ $@
 
 ../lib/python/$(NAMESPACEDIR)/__init__.py:


### PR DESCRIPTION
cp: cannot create regular file '../lib/python/machinetalk/protobuf/nanopb_generator.py': No such file or directory
machinetalk/Submakefile:277: recipe for target '../lib/python/machinetalk/protobuf/nanopb_generator.py' failed
make: *** [../lib/python/machinetalk/protobuf/nanopb_generator.py] Error 1