### PR TITLE
Fixes the c++11-narrowing errors.

### DIFF
--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -73,7 +73,7 @@
  * 'invalid offsetof from non-POD type'.
  */
 #undef offsetof
-#define offsetof(T,x) (size_t)(-1+(char*)&(((T*)1)->x))
+#define offsetof(T,x) (Py_ssize_t)(-1+(char*)&(((T*)1)->x))
 
 struct pyIniFile {
     PyObject_HEAD


### PR DESCRIPTION
emc/usr_intf/axis/extensions/emcmodule.cc:298:42: error: non-constant-expression cannot be narrowed from type 'size_t' (aka 'unsigned long') to 'Py_ssize_t' (aka 'long') in initializer list [-Wc++11-narrowing]
    {(char*)"echo_serial_number", T_INT, O(echo_serial_number), READONLY},
