### PR TITLE
Fixes R_ARM_MOVW_ABS_NC relocation issue on armv7hl

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -380,7 +380,7 @@ DEBUG := -g -Wall -funwind-tables
 PROFILE_CFLAGS :=
 PROFILE_LDFLAGS :=
 
-CFLAGS := $(INCLUDE) $(OPT) $(DEBUG) $(PROFILE_CFLAGS) -DULAPI $(call cc-option,-std=gnu99 -fgnu89-inline)
+CFLAGS := $(INCLUDE) $(OPT) $(DEBUG) $(PROFILE_CFLAGS) -DULAPI $(call cc-option,-std=gnu99 -fgnu89-inline -fPIC)
 
 # enable runtime comparison of GIT_CONFIG_SHA (config.h) and GIT_BUILD_SHA
 CFLAGS += -DGIT_BUILD_SHA=\"'$(GIT_BUILD_SHA)'\"
@@ -395,7 +395,7 @@ LDFLAGS += -L$(LIB_DIR) -Wl,-rpath,$(LIB_DIR)
 else
 LDFLAGS += -Wl,-rpath-link,../lib
 endif
-LDFLAGS += -Wl,--no-as-needed
+LDFLAGS += -Wl,--no-as-needed $(CFLAGS)
 
 # Rules to make .o (object) files
 $(sort $(CUSEROBJS)) : objects/%.o: %.c


### PR DESCRIPTION
Compiling usercomp adxl345.comp
armv7hl-redhat-linux-gnueabi-gcc -DULAPI -I. -Imachinetalk/build -Imachinetalk/nanopb -Imachinetalk/include -Imachinetalk/webtalk -Ilibnml/linklist -Ilibnml/cms -Ilibnml/rcs -Ilibnml/inifile -Ilibnm
l/os_intf -Ilibnml/nml -Ilibnml/buffer -Ilibnml/posemath -Irtapi -Irtapi_export -Ihal/lib -Ihal/vtable-example -Ihal/userfunct-example -Ihal/drivers -Ihal/cython -Iemc/nml_intf -Iemc/kinematics -Iem
c/motion -Iemc/tp -Iemc/ini -Iemc/rs274ngc -Iemc/pythonplugin -I/usr/include/python2.7 -o ../bin/adxl345 -Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -Wl,-rpath-link,../lib -Wl,--no-as
-needed \
         objects/hal/user_comps/adxl345.c \
        ../lib/liblinuxcnchal.so.0 \
        ../lib/librtapi_math.so.0
/usr/bin/ld: /tmp/ccG0bkPM.o: relocation R_ARM_MOVW_ABS_NC against `a local symbol' can not be used when making a shared object; recompile with -fPIC
/tmp/ccG0bkPM.o: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
hal/user_comps/Submakefile:23: recipe for target '../bin/adxl345' failed