### PR TITLE
Remove typo which had perpetuated from initial commit of hm2_soc_ol instcomp

### DIFF
--- a/configs/hm2-soc-stepper/5i25-socfpga.ini
+++ b/configs/hm2-soc-stepper/5i25-socfpga.ini
@@ -11,9 +11,9 @@ BOARD=de0n
 
 # device name as exported in the device tree overlay
 # see /lib/firmware/socfpga/dtbo/template.dts:
-#                        hm2reg_io_0: hm2-socfpg0@0x40000 {
+#                        hm2reg_io_0: hm2-socfpga0@0x40000 {
 #                                     ^^^^^^^^^^^
-DEVNAME=hm2-socfpg0
+DEVNAME=hm2-socfpga0
 
 #CONFIG="firmware=zynq_5i25_overlay.dtbo num_encoders=0 num_pwmgens=0 num_stepgens=3"
 #CONFIG="firmware=socfpga/dtbo/hm2reg_uio-irq.dtbo num_encoders=0 num_pwmgens=0 num_stepgens=3"


### PR DESCRIPTION
This results in newinst trying to load an instance called `hm2-socfpg0`
in the sample config.

This fails because the name must match that in the .dts files,
which is `hm2-socfpga0`

Signed-off-by: Mick <arceye@mgware.co.uk>