### PR TITLE
Fix pin assignment on Raspberry Pi 2/3

### DIFF
--- a/src/hal/drivers/hal_gpio.c
+++ b/src/hal/drivers/hal_gpio.c
@@ -55,9 +55,9 @@ static unsigned char rev1_pins[] = {3, 5, 7, 26, 24, 21, 19, 23,  8, 10, 11, 12,
 static unsigned char rev2_gpios[] = {2, 3, 4,  7,  8,  9, 10, 11, 14, 15, 17, 18, 22, 23, 24, 25, 27};
 static unsigned char rev2_pins[] = {3, 5, 7, 26, 24, 21, 19, 23, 8,  10, 11, 12, 15, 16, 18, 22, 13};
 
-// Raspberry2:
-static unsigned char rpi2_gpios[] = {2, 3, 4, 5,   6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 21, 23, 24, 25, 26, 27 };
-static unsigned char rpi2_pins[] =  {3, 5, 7, 20, 31, 26, 24, 21, 19, 23, 32, 33,  8, 10, 36, 11, 12, 35, 38, 15, 40, 16, 18, 22, 37, 13 };
+// Raspberry2/3:
+static unsigned char rpi2_gpios[] = {2, 3, 4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 21, 23, 24, 25, 26, 27 };
+static unsigned char rpi2_pins[] =  {3, 5, 7, 29, 31, 26, 24, 21, 19, 23, 32, 33,  8, 10, 36, 11, 12, 35, 38, 15, 40, 16, 18, 22, 37, 13 };
 
 static int npins;
 static int  mem_fd;


### PR DESCRIPTION
Corrects GPIO 5 which is on Pin#29 (not #20).