### PR TITLE
Merging machinetalk-protobuf generic

### DIFF
--- a/src/emc/rs274ngc/previewmodule.cc
+++ b/src/emc/rs274ngc/previewmodule.cc
@@ -41,7 +41,7 @@ static const char *istat_topic = "status";
 static int batch_limit = 100;
 static const char *p_client = "preview"; //NULL; // single client for now
 
-static pb::Container istat, output;
+static machinetalk::Container istat, output;
 
 static size_t n_containers, n_messages, n_bytes;
 
@@ -52,13 +52,13 @@ static size_t n_containers, n_messages, n_bytes;
 int _task = 0; // control preview behaviour when remapping
 
 // publish an interpreter status change.
-static void publish_istat(pb::InterpreterStateType state)
+static void publish_istat(machinetalk::InterpreterStateType state)
 {
-    static pb::InterpreterStateType last_state = pb::INTERP_STATE_UNSET;
+    static machinetalk::InterpreterStateType last_state = machinetalk::INTERP_STATE_UNSET;
     int retval;
 
     if (state ^ last_state) {
-	istat.set_type(pb::MT_INTERP_STAT);
+	istat.set_type(machinetalk::MT_INTERP_STAT);
 	istat.set_interp_state(state);
     istat.set_interp_name("preview");
 
@@ -80,7 +80,7 @@ static void send_preview(const char *client, bool flush = false)
     if ((output.preview_size() > batch_limit) || flush) {
 	n_containers++;
 	n_bytes += output.ByteSize();
-	output.set_type(pb::MT_PREVIEW);
+	output.set_type(machinetalk::MT_PREVIEW);
 	retval = send_pbcontainer(client, output, z_preview);
 	assert(retval == 0);
     }
@@ -89,16 +89,16 @@ static void send_preview(const char *client, bool flush = false)
 // send preview start message
 static void preview_start()
 {
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_PREVIEW_START);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_PREVIEW_START);
     send_preview(p_client);
 }
 
 // send preview end message
 static void preview_end()
 {
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_PREVIEW_END);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_PREVIEW_END);
     send_preview(p_client);
 }
 
@@ -135,7 +135,7 @@ static int z_init(void)
 #endif
 
     note_printf(istat, "interpreter startup pid=%d", getpid());
-    publish_istat(pb::INTERP_IDLE);
+    publish_istat(machinetalk::INTERP_IDLE);
 
     return 0;
 }
@@ -330,8 +330,8 @@ void ARC_FEED(int line_number,
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_ARC_FEED);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_ARC_FEED);
     p->set_line_number(line_number);
     p->set_first_end(first_end);
     p->set_second_end(second_end);
@@ -340,7 +340,7 @@ void ARC_FEED(int line_number,
     p->set_rotation(rotation);
     p->set_axis_end_point(axis_end_point);
 
-    pb::Position *pos = p->mutable_pos();
+    machinetalk::Position *pos = p->mutable_pos();
     pos->set_a(a_position);
     pos->set_b(b_position);
     pos->set_c(c_position);
@@ -366,11 +366,11 @@ void STRAIGHT_FEED(int line_number,
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_STRAIGHT_FEED);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_STRAIGHT_FEED);
     p->set_line_number(line_number);
 
-    pb::Position *pos = p->mutable_pos();
+    machinetalk::Position *pos = p->mutable_pos();
     pos->set_x(x);
     pos->set_y(y);
     pos->set_z(z);
@@ -399,11 +399,11 @@ void STRAIGHT_TRAVERSE(int line_number,
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_STRAIGHT_TRAVERSE);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_STRAIGHT_TRAVERSE);
     p->set_line_number(line_number);
 
-    pb::Position *pos = p->mutable_pos();
+    machinetalk::Position *pos = p->mutable_pos();
     pos->set_x(x);
     pos->set_y(y);
     pos->set_z(z);
@@ -429,12 +429,12 @@ void SET_G5X_OFFSET(int g5x_index,
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_SET_G5X_OFFSET);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_SET_G5X_OFFSET);
     //    p->set_line_number(line_number);
     p->set_g5_index(g5x_index);
 
-    pb::Position *pos = p->mutable_pos();
+    machinetalk::Position *pos = p->mutable_pos();
     pos->set_x(x);
     pos->set_y(y);
     pos->set_z(z);
@@ -460,11 +460,11 @@ void SET_G92_OFFSET(double x, double y, double z,
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_SET_G92_OFFSET);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_SET_G92_OFFSET);
     //    p->set_line_number(line_number);
 
-    pb::Position *pos = p->mutable_pos();
+    machinetalk::Position *pos = p->mutable_pos();
     pos->set_x(x);
     pos->set_y(y);
     pos->set_z(z);
@@ -485,8 +485,8 @@ void SET_XY_ROTATION(double t) {
     //     callmethod(callback, "set_xy_rotation", "f", t);
     // if(result == NULL) interp_error ++;
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_SET_G92_OFFSET);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_SET_G92_OFFSET);
     //    p->set_line_number(line_number);
     p->set_xy_rotation(t);
     send_preview(p_client);
@@ -499,8 +499,8 @@ void SELECT_PLANE(CANON_PLANE pl) {
     maybe_new_line();
     // if(interp_error) return;
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_SELECT_PLANE);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_SELECT_PLANE);
     p->set_plane(pl);
     send_preview(p_client);
 
@@ -518,8 +518,8 @@ void SET_TRAVERSE_RATE(double rate) {
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_SET_TRAVERSE_RATE);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_SET_TRAVERSE_RATE);
     //    p->set_line_number(line_number);
     p->set_rate(rate);
     send_preview(p_client);
@@ -545,8 +545,8 @@ void CHANGE_TOOL(int pocket) {
     if(result == NULL) interp_error ++;
     Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_CHANGE_TOOL);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_CHANGE_TOOL);
     //    p->set_line_number(line_number);
     p->set_pocket(pocket);
     send_preview(p_client);
@@ -570,8 +570,8 @@ void SET_FEED_RATE(double rate) {
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_SET_FEED_RATE);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_SET_FEED_RATE);
     //    p->set_line_number(line_number);
     p->set_rate(rate);
     send_preview(p_client);
@@ -586,8 +586,8 @@ void DWELL(double time) {
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_DWELL);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_DWELL);
     //    p->set_line_number(line_number);
     p->set_time(time);
     send_preview(p_client);
@@ -602,8 +602,8 @@ void MESSAGE(char *comment) {
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_MESSAGE);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_MESSAGE);
     //    p->set_line_number(line_number);
     p->set_text(comment);
     send_preview(p_client);
@@ -623,8 +623,8 @@ void COMMENT(const char *comment) {
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_COMMENT);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_COMMENT);
     //    p->set_line_number(line_number);
     p->set_text(comment);
     send_preview(p_client);
@@ -645,11 +645,11 @@ void USE_TOOL_LENGTH_OFFSET(EmcPose offset) {
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_USE_TOOL_OFFSET);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_USE_TOOL_OFFSET);
     //    p->set_line_number(line_number);
 
-    pb::Position *pos = p->mutable_pos();
+    machinetalk::Position *pos = p->mutable_pos();
     pos->set_x(offset.tran.x);
     pos->set_y(offset.tran.y);
     pos->set_z(offset.tran.z);
@@ -751,11 +751,11 @@ void STRAIGHT_PROBE(int line_number,
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_STRAIGHT_PROBE);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_STRAIGHT_PROBE);
     p->set_line_number(line_number);
 
-    pb::Position *pos = p->mutable_pos();
+    machinetalk::Position *pos = p->mutable_pos();
     pos->set_x(x);
     pos->set_y(y);
     pos->set_z(z);
@@ -778,11 +778,11 @@ void RIGID_TAP(int line_number,
     // if(result == NULL) interp_error ++;
     // Py_XDECREF(result);
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_RIGID_TAP);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_RIGID_TAP);
     p->set_line_number(line_number);
 
-    pb::Position *pos = p->mutable_pos();
+    machinetalk::Position *pos = p->mutable_pos();
     pos->set_x(x);
     pos->set_y(y);
     pos->set_z(z);
@@ -1012,15 +1012,15 @@ static PyObject *parse_file(PyObject *self, PyObject *args) {
     _pos_u = _pos_v = _pos_w = 0;
 
     note_printf(istat, "open '%s'", f);
-    publish_istat(pb::INTERP_RUNNING);
+    publish_istat(machinetalk::INTERP_RUNNING);
     preview_start();
     interp_new.init();
     interp_new.open(f);
     maybe_new_line();
 
-    pb::Preview *p = output.add_preview();
-    p->set_type(pb::PV_SOURCE_CONTEXT);
-    p->set_stype(pb::ST_NGC_FILE);
+    machinetalk::Preview *p = output.add_preview();
+    p->set_type(machinetalk::PV_SOURCE_CONTEXT);
+    p->set_stype(machinetalk::ST_NGC_FILE);
     p->set_filename(f);
     p->set_line_number(interp_new.sequence_number());
 
@@ -1051,7 +1051,7 @@ static PyObject *parse_file(PyObject *self, PyObject *args) {
 out_error:
     preview_end();
     send_preview(p_client, true);
-    publish_istat(pb::INTERP_IDLE);
+    publish_istat(machinetalk::INTERP_IDLE);
 
     if(pinterp) pinterp->close();
     if(interp_error) {

--- a/src/hal/drivers/mesa-hostmot2/fwid.c
+++ b/src/hal/drivers/mesa-hostmot2/fwid.c
@@ -93,16 +93,16 @@ int hm2_fwid_parse_md(hostmot2_t *hm2, int md_index) {
 	buf =  hm2->llio->fwid_msg;
     }
 
-    hm2->fwid.dmsg = (pb_Firmware *)kmalloc(sizeof(pb_Firmware), GFP_KERNEL);
+    hm2->fwid.dmsg = (machinetalk_Firmware *)kmalloc(sizeof(machinetalk_Firmware), GFP_KERNEL);
     if (hm2->fwid.dmsg == NULL) {
-	HM2_ERR("out of memory allocating pb_Firmware\n");
+	HM2_ERR("out of memory allocating machinetalk_Firmware\n");
 	r = -ENOMEM;
 	goto fail0;
     }
 
     // this is the actual decoding step:
     pb_istream_t stream = pb_istream_from_buffer(buf,  rawsize);
-    if (!pb_decode(&stream, pb_Firmware_fields, hm2->fwid.dmsg)) {
+    if (!pb_decode(&stream, machinetalk_Firmware_fields, hm2->fwid.dmsg)) {
 	HM2_ERR("pb_decode(Firmware) failed: '%s'\n", PB_GET_ERROR(&stream));
 	r = -EINVAL;
 	goto fail2;
@@ -110,7 +110,7 @@ int hm2_fwid_parse_md(hostmot2_t *hm2, int md_index) {
     if (hm2->llio->fwid_len == 0)
 	kfree(buf);
 
-    pb_Firmware *fw = hm2->fwid.dmsg;
+    machinetalk_Firmware *fw = hm2->fwid.dmsg;
     if (fw->has_board_name)
 	HM2_DBG("board_name = '%s'", fw->board_name);
     if (fw->has_build_sha)
@@ -126,7 +126,7 @@ int hm2_fwid_parse_md(hostmot2_t *hm2, int md_index) {
 
     size_t n;
     for (n = 0; n < fw->connector_count; n++) {
-	pb_Connector *conn = &fw->connector[n];
+	machinetalk_Connector *conn = &fw->connector[n];
 	if (conn->has_name) {
 	    HM2_DBG("connector %zu name = '%s'", n, conn->name);
 	    hm2->llio->ioport_connector_name[n] = conn->name;

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -1040,10 +1040,10 @@ typedef struct {
 
 } hm2_led_t ;
 
-struct _pb_Firmware;
+struct _machinetalk_Firmware;
 
 typedef struct {
-    struct _pb_Firmware *dmsg; // decoded protobuf message, nanopb format
+    struct _machinetalk_Firmware *dmsg; // decoded protobuf message, nanopb format
 } hm2_fwid_t ;
 
 

--- a/src/hal/utils/halcmd_rtapiapp.cc
+++ b/src/hal/utils/halcmd_rtapiapp.cc
@@ -15,7 +15,7 @@
 
 using namespace google::protobuf;
 
-static pb::Container command, reply;
+static machinetalk::Container command, reply;
 
 static zctx_t *z_context;
 static void *z_command;
@@ -23,7 +23,7 @@ static int timeout = 5000;
 static std::string errormsg;
 int proto_debug;
 
-int rtapi_rpc(void *socket, pb::Container &tx, pb::Container &rx)
+int rtapi_rpc(void *socket, machinetalk::Container &tx, machinetalk::Container &rx)
 {
     zframe_t *request = zframe_new (NULL, tx.ByteSize());
     assert(request);
@@ -67,9 +67,9 @@ int rtapi_callfunc(int instance,
 		   const char *func,
 		   const char **args)
 {
-    pb::RTAPICommand *cmd;
+    machinetalk::RTAPICommand *cmd;
     command.Clear();
-    command.set_type(pb::MT_RTAPI_APP_CALLFUNC);
+    command.set_type(machinetalk::MT_RTAPI_APP_CALLFUNC);
     cmd = command.mutable_rtapicmd();
     cmd->set_func(func);
     cmd->set_instance(instance);
@@ -91,9 +91,9 @@ int rtapi_newinst(int instance,
 		  const char *instname,
 		  const char **args)
 {
-    pb::RTAPICommand *cmd;
+    machinetalk::RTAPICommand *cmd;
     command.Clear();
-    command.set_type(pb::MT_RTAPI_APP_NEWINST);
+    command.set_type(machinetalk::MT_RTAPI_APP_NEWINST);
     cmd = command.mutable_rtapicmd();
     cmd->set_instance(instance);
 
@@ -115,9 +115,9 @@ int rtapi_newinst(int instance,
 int rtapi_delinst(int instance,
 		  const char *instname)
 {
-    pb::RTAPICommand *cmd;
+    machinetalk::RTAPICommand *cmd;
     command.Clear();
-    command.set_type(pb::MT_RTAPI_APP_DELINST);
+    command.set_type(machinetalk::MT_RTAPI_APP_DELINST);
     cmd = command.mutable_rtapicmd();
     cmd->set_instance(instance);
     cmd->set_instname(instname);
@@ -128,9 +128,9 @@ int rtapi_delinst(int instance,
 
 }
 
-static int rtapi_loadop(pb::ContainerType type, int instance, const char *modname, const char **args)
+static int rtapi_loadop(machinetalk::ContainerType type, int instance, const char *modname, const char **args)
 {
-    pb::RTAPICommand *cmd;
+    machinetalk::RTAPICommand *cmd;
     command.Clear();
     command.set_type(type);
     cmd = command.mutable_rtapicmd();
@@ -151,20 +151,20 @@ static int rtapi_loadop(pb::ContainerType type, int instance, const char *modnam
 
 int rtapi_loadrt(int instance, const char *modname, const char **args)
 {
-    return rtapi_loadop(pb::MT_RTAPI_APP_LOADRT, instance, modname, args);
+    return rtapi_loadop(machinetalk::MT_RTAPI_APP_LOADRT, instance, modname, args);
 }
 
 int rtapi_unloadrt(int instance, const char *modname)
 {
-    return rtapi_loadop(pb::MT_RTAPI_APP_UNLOADRT, instance, modname, NULL);
+    return rtapi_loadop(machinetalk::MT_RTAPI_APP_UNLOADRT, instance, modname, NULL);
 }
 
 int rtapi_shutdown(int instance)
 {
-    pb::RTAPICommand *cmd;
+    machinetalk::RTAPICommand *cmd;
 
     command.Clear();
-    command.set_type(pb::MT_RTAPI_APP_EXIT);
+    command.set_type(machinetalk::MT_RTAPI_APP_EXIT);
     cmd = command.mutable_rtapicmd();
     cmd->set_instance(instance);
 
@@ -177,9 +177,9 @@ int rtapi_shutdown(int instance)
 
 int rtapi_ping(int instance)
 {
-    pb::RTAPICommand *cmd;
+    machinetalk::RTAPICommand *cmd;
     command.Clear();
-    command.set_type(pb::MT_RTAPI_APP_PING);
+    command.set_type(machinetalk::MT_RTAPI_APP_PING);
     cmd = command.mutable_rtapicmd();
     cmd->set_instance(instance);
 
@@ -191,9 +191,9 @@ int rtapi_ping(int instance)
 
 int rtapi_newthread(int instance, const char *name, int period, int cpu, int use_fp, int flags)
 {
-    pb::RTAPICommand *cmd;
+    machinetalk::RTAPICommand *cmd;
     command.Clear();
-    command.set_type(pb::MT_RTAPI_APP_NEWTHREAD);
+    command.set_type(machinetalk::MT_RTAPI_APP_NEWTHREAD);
     cmd = command.mutable_rtapicmd();
     cmd->set_instance(instance);
     cmd->set_threadname(name);
@@ -210,9 +210,9 @@ int rtapi_newthread(int instance, const char *name, int period, int cpu, int use
 
 int rtapi_delthread(int instance, const char *name)
 {
-    pb::RTAPICommand *cmd;
+    machinetalk::RTAPICommand *cmd;
     command.Clear();
-    command.set_type(pb::MT_RTAPI_APP_DELTHREAD);
+    command.set_type(machinetalk::MT_RTAPI_APP_DELTHREAD);
     cmd = command.mutable_rtapicmd();
     cmd->set_instance(instance);
     cmd->set_threadname(name);

--- a/src/machinetalk/haltalk/haltalk.hh
+++ b/src/machinetalk/haltalk/haltalk.hh
@@ -141,8 +141,8 @@ typedef struct htself {
     bool      interrupted;
     pid_t     pid;
 
-    pb::Container rx; // any ParseFrom.. function does a Clear() first
-    pb::Container tx; // tx must be Clear()'d after or before use
+    machinetalk::Container rx; // any ParseFrom.. function does a Clear() first
+    machinetalk::Container tx; // tx must be Clear()'d after or before use
 
 
     groupmap_t groups;

--- a/src/machinetalk/haltalk/haltalk_bridge.cc
+++ b/src/machinetalk/haltalk/haltalk_bridge.cc
@@ -114,9 +114,9 @@ prepare_discovery(htself_t *self)
     int retval;
 
     // bridge->sdiscover = sd_new(0, self->cfg->bridge_target_instance);
-    // retval = sd_add(bridge->sdiscover,  pb::ST_HAL_RCOMMAND, 0, pb::SA_ZMQ_PROTOBUF);
+    // retval = sd_add(bridge->sdiscover,  machinetalk::ST_HAL_RCOMMAND, 0, machinetalk::SA_ZMQ_PROTOBUF);
     // assert(retval == 0);
-    // retval = sd_add(bridge->sdiscover,  pb::ST_STP_HALRCOMP, 0, pb::SA_ZMQ_PROTOBUF);
+    // retval = sd_add(bridge->sdiscover,  machinetalk::ST_STP_HALRCOMP, 0, machinetalk::SA_ZMQ_PROTOBUF);
     // assert(retval == 0);
     // sd_log(bridge->sdiscover, self->cfg->debug > 1);
 

--- a/src/machinetalk/haltalk/haltalk_group.cc
+++ b/src/machinetalk/haltalk/haltalk_group.cc
@@ -60,7 +60,7 @@ handle_group_input(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
 		 gi != self->groups.end(); gi++) {
 
 		group_t *g = gi->second;
-		self->tx.set_type(pb::MT_HALGROUP_FULL_UPDATE);
+		self->tx.set_type(machinetalk::MT_HALGROUP_FULL_UPDATE);
 		self->tx.set_uuid(self->netopts.proc_uuid, sizeof(self->netopts.proc_uuid));
 		self->tx.set_serial(g->serial++);
 		describe_parameters(self);
@@ -86,7 +86,7 @@ handle_group_input(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
 	    groupmap_iterator gi = self->groups.find(topic);
 	    if (gi != self->groups.end()) {
 		group_t *g = gi->second;
-		self->tx.set_type(pb::MT_HALGROUP_FULL_UPDATE);
+		self->tx.set_type(machinetalk::MT_HALGROUP_FULL_UPDATE);
 		self->tx.set_uuid(self->netopts.proc_uuid, sizeof(self->netopts.proc_uuid));
 		self->tx.set_serial(g->serial++);
 		describe_parameters(self);
@@ -108,7 +108,7 @@ handle_group_input(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
 		}
 	    } else {
 		// non-existant topic, complain.
-		self->tx.set_type(pb::MT_STP_NOGROUP);
+		self->tx.set_type(machinetalk::MT_STP_NOGROUP);
 		note_printf(self->tx, "no such group: '%s', currently %d valid groups",
 			    topic, self->groups.size());
 		if (self->groups.size())
@@ -259,13 +259,13 @@ group_report_cb(int phase, hal_compiled_group_t *cgroup,
 {
     group_t *grp = (group_t *) cb_data;
     htself_t *self = grp->self;
-    pb::Signal *signal;
+    machinetalk::Signal *signal;
     int retval;
 
     switch (phase) {
 
     case REPORT_BEGIN:	// report initialisation
-	self->tx.set_type(pb::MT_HALGROUP_INCREMENTAL_UPDATE);
+	self->tx.set_type(machinetalk::MT_HALGROUP_INCREMENTAL_UPDATE);
 	// the serial enables detection of lost updates
 	// for a client to recover from a lost update:
 	// unsubscribe + re-subscribe which will cause
@@ -310,7 +310,7 @@ group_report_cb(int phase, hal_compiled_group_t *cgroup,
 int ping_groups(htself_t *self)
 {
     for (groupmap_iterator g = self->groups.begin(); g != self->groups.end(); g++) {
-	self->tx.set_type(pb::MT_PING);
+	self->tx.set_type(machinetalk::MT_PING);
 	int retval = send_pbcontainer(g->first.c_str(), self->tx,
 				      self->mksock[SVC_HALGROUP].socket);
 	assert(retval == 0);

--- a/src/machinetalk/haltalk/haltalk_introspect.cc
+++ b/src/machinetalk/haltalk/haltalk_introspect.cc
@@ -56,7 +56,7 @@ describe_group(htself_t *self, const char *group, const std::string &from,  void
 
     hal_group_t *g = halpr_find_group_by_name(group);
     if (g == NULL) {
-	self->tx.set_type(pb::MT_HALRCOMP_ERROR);
+	self->tx.set_type(machinetalk::MT_HALRCOMP_ERROR);
 	note_printf(self->tx, "no such group: '%s'", group);
 	return send_pbcontainer(from, self->tx, socket);
     }
@@ -73,7 +73,7 @@ describe_comp(htself_t *self, const char *comp, const std::string &from,  void *
 
     hal_comp_t *c = halpr_find_comp_by_name(comp);
     if (c == NULL) {
-	self->tx.set_type(pb::MT_HALRCOMP_ERROR);
+	self->tx.set_type(machinetalk::MT_HALRCOMP_ERROR);
 	note_printf(self->tx, "no such component: '%s'", comp);
 	return send_pbcontainer(from, self->tx, socket);
     }
@@ -84,7 +84,7 @@ describe_comp(htself_t *self, const char *comp, const std::string &from,  void *
 // add protocol parameters the subscriber might want to know about
 int describe_parameters(htself_t *self)
 {
-    pb::ProtocolParameters *pp = self->tx.mutable_pparams();
+    machinetalk::ProtocolParameters *pp = self->tx.mutable_pparams();
     pp->set_keepalive_timer(self->cfg->keepalive_timer);
     pp->set_group_timer(self->cfg->default_group_timer);
     pp->set_rcomp_timer(self->cfg->default_rcomp_timer);
@@ -96,7 +96,7 @@ int describe_parameters(htself_t *self)
 static int describe_comp_cb(hal_comp_t *comp,  void *arg)
 {
     htself_t *self = (htself_t *) arg;
-    pb::Component *c = self->tx.add_comp();
+    machinetalk::Component *c = self->tx.add_comp();
     halpr_describe_component(comp, c);
     return 0;
 }
@@ -104,7 +104,7 @@ static int describe_comp_cb(hal_comp_t *comp,  void *arg)
 static int describe_sig_cb(hal_sig_t *sig,  void *arg)
 {
     htself_t *self = (htself_t *) arg;
-    pb::Signal *s = self->tx.add_signal();
+    machinetalk::Signal *s = self->tx.add_signal();
     halpr_describe_signal(sig, s);
     return 0;
 }
@@ -112,7 +112,7 @@ static int describe_sig_cb(hal_sig_t *sig,  void *arg)
 static int describe_group_cb(hal_group_t *g,  void *arg)
 {
     htself_t *self = (htself_t *) arg;
-    pb::Group *pbgroup = self->tx.add_group();
+    machinetalk::Group *pbgroup = self->tx.add_group();
     halpr_describe_group(g, pbgroup);
     return 0;
 }
@@ -120,7 +120,7 @@ static int describe_group_cb(hal_group_t *g,  void *arg)
 static int describe_funct_cb(hal_funct_t *funct,  void *arg)
 {
     htself_t *self = (htself_t *) arg;
-    pb::Function *f = self->tx.add_function();
+    machinetalk::Function *f = self->tx.add_function();
     halpr_describe_funct(funct, f);
     return 0;
 }
@@ -128,7 +128,7 @@ static int describe_funct_cb(hal_funct_t *funct,  void *arg)
 static int describe_ring_cb(hal_ring_t *ring,  void *arg)
 {
     htself_t *self = (htself_t *) arg;
-    pb::Ring *r = self->tx.add_ring();
+    machinetalk::Ring *r = self->tx.add_ring();
     halpr_describe_ring(ring, r);
     return 0;
 }
@@ -136,7 +136,7 @@ static int describe_ring_cb(hal_ring_t *ring,  void *arg)
 static int describe_thread_cb(hal_thread_t *thread,  void *arg)
 {
     htself_t *self = (htself_t *) arg;
-    pb::Thread *t = self->tx.add_thread();
+    machinetalk::Thread *t = self->tx.add_thread();
     halpr_describe_thread(thread, t);
     return 0;
 }

--- a/src/machinetalk/haltalk/haltalk_rcomp.cc
+++ b/src/machinetalk/haltalk/haltalk_rcomp.cc
@@ -71,7 +71,7 @@ handle_rcomp_input(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
 				    self->cfg->progname, topic);
 
 		// not found, publish an error message on this topic
-		self->tx.set_type(pb::MT_HALRCOMP_ERROR);
+		self->tx.set_type(machinetalk::MT_HALRCOMP_ERROR);
 		note_printf(self->tx, "component '%s' does not exist", topic);
 		retval = send_pbcontainer(topic, self->tx, self->mksock[SVC_HALRCOMP].socket);
 		assert(retval == 0);
@@ -79,7 +79,7 @@ handle_rcomp_input(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
 	    } else {
 		// compiled component found, schedule a full update
 		rcomp_t *g = self->rcomps[topic];
-		self->tx.set_type(pb::MT_HALRCOMP_FULL_UPDATE);
+		self->tx.set_type(machinetalk::MT_HALRCOMP_FULL_UPDATE);
 		self->tx.set_uuid(self->netopts.proc_uuid, sizeof(self->netopts.proc_uuid));
 		self->tx.set_serial(g->serial++);
 		describe_parameters(self);
@@ -284,13 +284,13 @@ int comp_report_cb(int phase,  hal_compiled_comp_t *cc,
 {
     rcomp_t *rc = (rcomp_t *) cb_data;
     htself_t *self =  rc->self;
-    pb::Pin *p;
+    machinetalk::Pin *p;
     int retval;
 
     switch (phase) {
 
     case REPORT_BEGIN:	// report initialisation
-	self->tx.set_type(pb::MT_HALRCOMP_INCREMENTAL_UPDATE);
+	self->tx.set_type(machinetalk::MT_HALRCOMP_INCREMENTAL_UPDATE);
 	self->tx.set_serial(rc->serial++);
 	break;
 
@@ -336,7 +336,7 @@ int ping_comps(htself_t *self)
 {
     for (compmap_iterator c = self->rcomps.begin();
 	 c != self->rcomps.end(); c++) {
-	self->tx.set_type(pb::MT_PING);
+	self->tx.set_type(machinetalk::MT_PING);
 	int retval = send_pbcontainer(c->first.c_str(), self->tx,
 				      self->mksock[SVC_HALRCOMP].socket);
 	assert(retval == 0);

--- a/src/machinetalk/include/container.h
+++ b/src/machinetalk/include/container.h
@@ -16,17 +16,17 @@ extern "C"
 #if defined(GOOGLE_PROTOBUF_VERSION)
 #include <protobuf/protobuf/types.pb.h>
 
-#define MSGTYPE          pb::ContainerType
-#define EMCMOT_LOWER     pb::MT_EMCMOT_LOWER
-#define EMCMOT_UPPER     pb::MT_EMCMOT_UPPER
-#define EMC_NML_LOWER    pb::MT_EMC_NML_LOWER
-#define EMC_NML_UPPER    pb::MT_EMC_NML_UPPER
-#define CONTAINER        pb::Container
+#define MSGTYPE          machinetalk::ContainerType
+#define EMCMOT_LOWER     machinetalk::MT_EMCMOT_LOWER
+#define EMCMOT_UPPER     machinetalk::MT_EMCMOT_UPPER
+#define EMC_NML_LOWER    machinetalk::MT_EMC_NML_LOWER
+#define EMC_NML_UPPER    machinetalk::MT_EMC_NML_UPPER
+#define CONTAINER        machinetalk::Container
 
 #elif defined(PROTOBUF_C_MAJOR)
 #include <protobuf/protobuf/types.pb-c.h>
 
-#define MSGTYPE          _Pb__ContainerType
+#define MSGTYPE          _Machinetalk__ContainerType
 #define EMCMOT_LOWER     MSG_TYPE__MT_EMCMOT_LOWER
 #define EMCMOT_UPPER     MSG_TYPE__MT_EMCMOT_UPPER
 #define EMC_NML_LOWER    MSG_TYPE__MT_EMC_NML_LOWER
@@ -36,12 +36,12 @@ extern "C"
 #elif defined(NANOPB_VERSION)
 #include <machinetalk/protobuf/types.npb.h>
 #include <machinetalk/protobuf/message.npb.h>
-#define MSGTYPE          pb_ContainerType
-#define EMCMOT_LOWER     pb_ContainerType_MT_EMCMOT_LOWER
-#define EMCMOT_UPPER     pb_ContainerType_MT_EMCMOT_UPPER
-#define EMC_NML_LOWER    pb_ContainerType_MT_EMC_NML_LOWER
-#define EMC_NML_UPPER    pb_ContainerType_MT_EMC_NML_UPPER
-#define CONTAINER        struct pb_Container
+#define MSGTYPE          machinetalk_ContainerType
+#define EMCMOT_LOWER     machinetalk_ContainerType_MT_EMCMOT_LOWER
+#define EMCMOT_UPPER     machinetalk_ContainerType_MT_EMCMOT_UPPER
+#define EMC_NML_LOWER    machinetalk_ContainerType_MT_EMC_NML_LOWER
+#define EMC_NML_UPPER    machinetalk_ContainerType_MT_EMC_NML_UPPER
+#define CONTAINER        struct machinetalk_Container
 #else
 #error "include container.h after protobuf-specific headers"
 #endif

--- a/src/machinetalk/include/halpb.hh
+++ b/src/machinetalk/include/halpb.hh
@@ -27,14 +27,14 @@
 #include <machinetalk/protobuf/message.pb.h>
 
 // in halpb.cc:
-int halpr_describe_signal(hal_sig_t *sig, pb::Signal *pbsig);
-int halpr_describe_pin(hal_pin_t *pin, pb::Pin *pbpin);
-int halpr_describe_ring(hal_ring_t *ring, pb::Ring *pbring);
-int halpr_describe_funct(hal_funct_t *funct, pb::Function *pbfunct);
-int halpr_describe_thread(hal_thread_t *thread, pb::Thread *pbthread);
-int halpr_describe_component(hal_comp_t *comp, pb::Component *pbcomp);
-int halpr_describe_group(hal_group_t *g, pb::Group *pbgroup);
-int halpr_describe_member(hal_member_t *member, pb::Member *pbmember);
+int halpr_describe_signal(hal_sig_t *sig, machinetalk::Signal *pbsig);
+int halpr_describe_pin(hal_pin_t *pin, machinetalk::Pin *pbpin);
+int halpr_describe_ring(hal_ring_t *ring, machinetalk::Ring *pbring);
+int halpr_describe_funct(hal_funct_t *funct, machinetalk::Function *pbfunct);
+int halpr_describe_thread(hal_thread_t *thread, machinetalk::Thread *pbthread);
+int halpr_describe_component(hal_comp_t *comp, machinetalk::Component *pbcomp);
+int halpr_describe_group(hal_group_t *g, machinetalk::Group *pbgroup);
+int halpr_describe_member(hal_member_t *member, machinetalk::Member *pbmember);
 
 
 static inline const hal_data_u *hal_sig2u(const hal_sig_t *sig)
@@ -57,7 +57,7 @@ static inline const hal_data_u *hal_param2u(const hal_param_t *param)
     return (hal_data_u *)SHMPTR(param->data_ptr);
 }
 
-static inline int hal_pin2pb(const hal_pin_t *hp, pb::Pin *p)
+static inline int hal_pin2pb(const hal_pin_t *hp, machinetalk::Pin *p)
 {
     const hal_data_u *vp  = hal_pin2u(hp);
     switch (hp->type) {
@@ -79,7 +79,7 @@ static inline int hal_pin2pb(const hal_pin_t *hp, pb::Pin *p)
     return 0;
 }
 
-static inline int hal_sig2pb(const hal_sig_t *sp, pb::Signal *s)
+static inline int hal_sig2pb(const hal_sig_t *sp, machinetalk::Signal *s)
 {
     const hal_data_u *vp = hal_sig2u(sp);
     switch (sp->type) {
@@ -101,7 +101,7 @@ static inline int hal_sig2pb(const hal_sig_t *sp, pb::Signal *s)
     return 0;
 }
 
-static inline int hal_param2pb(const hal_param_t *pp, pb::Param *p)
+static inline int hal_param2pb(const hal_param_t *pp, machinetalk::Param *p)
 {
     const hal_data_u *vp = hal_param2u(pp);
 
@@ -124,7 +124,7 @@ static inline int hal_param2pb(const hal_param_t *pp, pb::Param *p)
     return 0;
 }
 
-static inline int hal_pbpin2u(const pb::Pin *p, hal_data_u *vp)
+static inline int hal_pbpin2u(const machinetalk::Pin *p, hal_data_u *vp)
 {
     switch (p->type()) {
     default:
@@ -145,7 +145,7 @@ static inline int hal_pbpin2u(const pb::Pin *p, hal_data_u *vp)
     return 0;
 }
 
-static inline int hal_pbsig2u(const pb::Signal *s, hal_data_u *vp)
+static inline int hal_pbsig2u(const machinetalk::Signal *s, hal_data_u *vp)
 {
     switch (s->type()) {
     default:

--- a/src/machinetalk/include/pbutil.hh
+++ b/src/machinetalk/include/pbutil.hh
@@ -29,8 +29,8 @@ typedef ::google::protobuf::RepeatedPtrField< ::std::string> pbstringarray_t;
 // send a protobuf - encoded Container message
 // optionally prepend destination field
 // log any failure to RTAPI
-int send_pbcontainer(const std::string &dest, pb::Container &c, void *socket);
-int send_pbcontainer(zmsg_t *dest, pb::Container &c, void *socket);
+int send_pbcontainer(const std::string &dest, machinetalk::Container &c, void *socket);
+int send_pbcontainer(zmsg_t *dest, machinetalk::Container &c, void *socket);
 
 // add an printf-formatted string to the 'note' repeated string in a
 // Container
@@ -39,7 +39,7 @@ int send_pbcontainer(zmsg_t *dest, pb::Container &c, void *socket);
 // MAX_NOTESIZE-4 and the string "..." appended, indicating truncation
 #define MAX_NOTESIZE 4096
 int
-note_printf(pb::Container &c, const char *fmt, ...);
+note_printf(machinetalk::Container &c, const char *fmt, ...);
 
 // fold a RepeatedPtrField into a std::string, separated by delim
 std::string pbconcat(const pbstringarray_t &args, const std::string &delim = " ", const std::string &quote = "");

--- a/src/machinetalk/lib/pbutil.cc
+++ b/src/machinetalk/lib/pbutil.cc
@@ -25,7 +25,7 @@
 int __attribute__((weak)) print_container;
 
 int
-send_pbcontainer(const std::string &dest, pb::Container &c, void *socket)
+send_pbcontainer(const std::string &dest, machinetalk::Container &c, void *socket)
 {
     int retval = 0;
     zmsg_t *msg = zmsg_new();
@@ -38,7 +38,7 @@ send_pbcontainer(const std::string &dest, pb::Container &c, void *socket)
 
 // send_pbcontainer: destination can contain multiple routing points
 int
-send_pbcontainer(zmsg_t *dest, pb::Container &c, void *socket)
+send_pbcontainer(zmsg_t *dest, machinetalk::Container &c, void *socket)
 {
     int retval = 0;
     zframe_t *f;
@@ -90,7 +90,7 @@ send_pbcontainer(zmsg_t *dest, pb::Container &c, void *socket)
 
 
 int
-note_printf(pb::Container &c, const char *fmt, ...)
+note_printf(machinetalk::Container &c, const char *fmt, ...)
 {
     va_list ap;
     int n;

--- a/src/machinetalk/msgcomponents/pbring.c
+++ b/src/machinetalk/msgcomponents/pbring.c
@@ -21,7 +21,7 @@ typedef struct {
     hal_u32_t *decodefail;	// number of messages which failed to protobuf decode
     ringbuffer_t to_rt_rb;      // incoming ringbuffer
     ringbuffer_t from_rt_rb;    // outgoing ringbuffer
-    pb_Container rx, tx;
+    machinetalk_Container rx, tx;
 } pbring_inst_t;
 
 enum {
@@ -43,19 +43,19 @@ MODULE_LICENSE("GPL");
 RTAPI_TAG(HAL, HC_INSTANTIABLE);
 
 static int txnoencode = 0;
-RTAPI_MP_INT(txnoencode, "pass unencoded pb_Container struct instead of pb message");
+RTAPI_MP_INT(txnoencode, "pass unencoded machinetalk_Container struct instead of pb message");
 
 static int rxnodecode = 0;
-RTAPI_MP_INT(rxnodecode, "expect unencoded pb_Container struct instead of pb message");
+RTAPI_MP_INT(rxnodecode, "expect unencoded machinetalk_Container struct instead of pb message");
 
 
-static void rtapi_format_pose(char *buf, unsigned long int size,  pb_EmcPose *p)
+static void rtapi_format_pose(char *buf, unsigned long int size,  machinetalk_EmcPose *p)
 {
     unsigned sz = size;
     char *b = buf; // FIXME guard against buffer overflow
     int n;
 
-    pb_PmCartesian *c = &p->tran;
+    machinetalk_PmCartesian *c = &p->tran;
     if (c->has_x) { n = rtapi_snprintf(b, sz, "x=%f ", c->x); b += n; }
     if (c->has_y) { n = rtapi_snprintf(b, sz, "y=%f ", c->y); b += n; }
     if (c->has_z) { n = rtapi_snprintf(b, sz, "z=%f ", c->z); b += n; }
@@ -127,7 +127,7 @@ static int npb_send_msg(const void *msg, const pb_field_t *fields,
 
 static int decode_msg(pbring_inst_t *p,  pb_istream_t *stream,  const hal_funct_args_t *fa)
 {
-    if (!pb_decode(stream, pb_Container_fields, &p->rx)) {
+    if (!pb_decode(stream, machinetalk_Container_fields, &p->rx)) {
 	*(p->decodefail) += 1;
 	rtapi_print_msg(RTAPI_MSG_ERR, "%s: pb_decode(Container) failed: '%s'\n",
 			fa_funct_name(fa), PB_GET_ERROR(stream));
@@ -165,14 +165,14 @@ static int update_pbring(void *arg, const hal_funct_args_t *fa)
 	// process command here
 	// prepare reply
 	p->tx.has_motstat = true;
-	p->tx.type =  pb_ContainerType_MT_MOTSTATUS;
+	p->tx.type =  machinetalk_ContainerType_MT_MOTSTATUS;
 	p->tx.note.funcs.encode = npb_encode_string;
 	p->tx.note.arg = "hi there!";
 
-	p->tx.motstat = (pb_MotionStatus) {
+	p->tx.motstat = (machinetalk_MotionStatus) {
 	    .commandEcho = p->rx.motcmd.command,
 	    .commandNumEcho = p->rx.motcmd.commandNum,
-	    .commandStatus = pb_cmd_status_t_EMCMOT_COMMAND_OK,
+	    .commandStatus = machinetalk_cmd_status_t_EMCMOT_COMMAND_OK,
 	    .has_carte_pos_fb = true,
 	    .carte_pos_fb = {
 		.tran = {
@@ -186,7 +186,7 @@ static int update_pbring(void *arg, const hal_funct_args_t *fa)
 		.a = 3.14
 	    }
 	};
-	if ((retval = npb_send_msg(&p->tx, pb_Container_fields,
+	if ((retval = npb_send_msg(&p->tx, machinetalk_Container_fields,
 				   &p->from_rt_rb, 0))) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,"error reply failed %d", retval);
 	    *(p->sendfailed) +=1;
@@ -201,13 +201,13 @@ static int update_pbring(void *arg, const hal_funct_args_t *fa)
 		       cmdsize,
 		       PB_GET_ERROR(&stream));
 
-	p->tx = (pb_Container) {
-	    .type = pb_ContainerType_MT_MOTSTATUS, // FIXME
+	p->tx = (machinetalk_Container) {
+	    .type = machinetalk_ContainerType_MT_MOTSTATUS, // FIXME
 	    .note.funcs.encode = npb_encode_string,
 	    .note.arg = (void *) errmsg
 	};
 	int retval;
-	if ((retval = npb_send_msg(&p->tx, pb_Container_fields,
+	if ((retval = npb_send_msg(&p->tx, machinetalk_Container_fields,
 				   &p->from_rt_rb, 0))) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,"error reply failed %d", retval);
 	    *(p->sendfailed) += 1;

--- a/src/machinetalk/proto/Makefile
+++ b/src/machinetalk/proto/Makefile
@@ -26,7 +26,8 @@ ECHO := @echo
 
 DESTDIR := /usr/local
 # all protobuf definitions live here
-NAMESPACEDIR := machinetalk/protobuf
+PROJECT := machinetalk
+NAMESPACEDIR := $(PROJECT)/protobuf
 SRCDIR := src
 SRCDIRINV := $(shell realpath --relative-to=$(SRCDIR) .)
 PROTODIR := $(SRCDIR)/$(NAMESPACEDIR)
@@ -70,9 +71,9 @@ OBJDIR := $(BUILDDIR)/objects
 # see note on PBDEP_OPT below
 vpath %.proto  $(PROTODIR):$(GPBINCLUDE):$(DESCDIR)/compiler
 
-# machinetalk/proto/*.proto derived Python bindings
+# $(PROJECT)/proto/*.proto derived Python bindings
 PROTO_PY_TARGETS := ${PROTO_SPECS:$(SRCDIR)/%.proto=$(PYGEN)/%_pb2.py}
-PROTO_PY_EXTRAS := $(PYGEN)/setup.py $(PYGEN)/machinetalk/__init__.py $(PYGEN)/machinetalk/protobuf/__init__.py
+PROTO_PY_EXTRAS := $(PYGEN)/setup.py $(PYGEN)/$(PROJECT)/__init__.py $(PYGEN)/$(PROJECT)/protobuf/__init__.py
 
 # generated C++ includes
 PROTO_CXX_INCS := ${PROTO_SPECS:$(SRCDIR)/%.proto=$(CXXGEN)/%.pb.h}
@@ -81,7 +82,7 @@ PROTO_CXX_INCS := ${PROTO_SPECS:$(SRCDIR)/%.proto=$(CXXGEN)/%.pb.h}
 PROTO_CXX_SRCS  :=  ${PROTO_SPECS:$(SRCDIR)/%.proto=$(CXXGEN)/%.pb.cc}
 
 # generated doc file
-DOC_TARGET := $(DOCGEN)/machinetalk-protobuf.$(DOCEXT)
+DOC_TARGET := $(DOCGEN)/$(PROJECT)-protobuf.$(DOCEXT)
 
 # ---- generate dependcy files for .proto files
 #

--- a/src/machinetalk/proto/python/.gitignore
+++ b/src/machinetalk/proto/python/.gitignore
@@ -1,0 +1,1 @@
+machinetalk

--- a/src/machinetalk/proto/python/machinetalk/__init__.py
+++ b/src/machinetalk/proto/python/machinetalk/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/src/machinetalk/proto/python/machinetalk/protobuf/__init__.py
+++ b/src/machinetalk/proto/python/machinetalk/protobuf/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/src/machinetalk/proto/src/machinetalk/protobuf/canon.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/canon.proto
@@ -7,7 +7,7 @@ import "machinetalk/protobuf/types.proto";
 import "machinetalk/protobuf/emcclass.proto";
 import "machinetalk/protobuf/motcmds.proto";
 
-package pb;
+package machinetalk;
 
 // communicated by message type only since no params:
 // Emc_Start_Change

--- a/src/machinetalk/proto/src/machinetalk/protobuf/config.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/config.proto
@@ -3,7 +3,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 200
 
-package pb;
+package machinetalk;
 
 enum ApplicationType {
     QT5_QML    = 1;

--- a/src/machinetalk/proto/src/machinetalk/protobuf/emcclass.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/emcclass.proto
@@ -3,7 +3,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 300
 
-package pb;
+package machinetalk;
 
 // this encoding method of encoding supports NULL values
 // using code needs to inspect the has_<name> property

--- a/src/machinetalk/proto/src/machinetalk/protobuf/firmware.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/firmware.proto
@@ -18,7 +18,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 380
 
-package pb;
+package machinetalk;
 
 /// describes a connector
 message Connector {

--- a/src/machinetalk/proto/src/machinetalk/protobuf/log.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/log.proto
@@ -1,4 +1,4 @@
-package pb;
+package machinetalk;
 // see README.msgid
 // msgid base: 400
 

--- a/src/machinetalk/proto/src/machinetalk/protobuf/message.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/message.proto
@@ -4,7 +4,7 @@
 // see README.msgid
 // msgid base: 500
 
-package pb;
+package machinetalk;
 
 
 import "machinetalk/protobuf/nanopb.proto";

--- a/src/machinetalk/proto/src/machinetalk/protobuf/motcmds.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/motcmds.proto
@@ -1,4 +1,4 @@
-package pb;
+package machinetalk;
 
 // see README.msgid
 // msgid base: 600

--- a/src/machinetalk/proto/src/machinetalk/protobuf/object.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/object.proto
@@ -7,7 +7,7 @@
 import "machinetalk/protobuf/nanopb.proto";
 import "machinetalk/protobuf/types.proto";
 
-package pb;
+package machinetalk;
 
 // describes a RTAPI/HAL/LinuxCNC instance
 message Instance {

--- a/src/machinetalk/proto/src/machinetalk/protobuf/preview.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/preview.proto
@@ -1,4 +1,4 @@
-package pb;
+package machinetalk;
 
 // see README.msgid
 // msgid base: 800

--- a/src/machinetalk/proto/src/machinetalk/protobuf/rtapi_message.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/rtapi_message.proto
@@ -4,7 +4,7 @@ import "machinetalk/protobuf/value.proto";
 // see README.msgid
 // msgid base: 1000
 
-package pb;
+package machinetalk;
 
 message RTAPI_Message {
 

--- a/src/machinetalk/proto/src/machinetalk/protobuf/rtapicommand.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/rtapicommand.proto
@@ -2,7 +2,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 900
 
-package pb;
+package machinetalk;
 
 message RTAPICommand {
 

--- a/src/machinetalk/proto/src/machinetalk/protobuf/status.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/status.proto
@@ -7,7 +7,7 @@ import "machinetalk/protobuf/motcmds.proto";
 // see README.msgid
 // msgid base: 1100
 
-package pb;
+package machinetalk;
 
 /**
  *  Types for EMC task execution state.

--- a/src/machinetalk/proto/src/machinetalk/protobuf/task.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/task.proto
@@ -41,7 +41,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 1200
 
-package pb;
+package machinetalk;
 
 
 message TaskPlanExecute {

--- a/src/machinetalk/proto/src/machinetalk/protobuf/test.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/test.proto
@@ -3,7 +3,7 @@
 import "machinetalk/protobuf/emcclass.proto";
 import "machinetalk/protobuf/nanopb.proto";
 
-package pb;
+package machinetalk;
 
 // see README.msgid
 // msgid base: 1300

--- a/src/machinetalk/proto/src/machinetalk/protobuf/types.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/types.proto
@@ -4,7 +4,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 1400
 
-package pb;
+package machinetalk;
 
 enum ValueType {
     //  the following tags correspond to hal.h: hal_type_t;

--- a/src/machinetalk/proto/src/machinetalk/protobuf/value.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/value.proto
@@ -6,7 +6,7 @@ import "machinetalk/protobuf/types.proto";
 // see README.msgid
 // msgid base: 1500
 
-package pb;
+package machinetalk;
 
 
 // a value for 'passing around'.

--- a/src/machinetalk/support/encdec.cc
+++ b/src/machinetalk/support/encdec.cc
@@ -16,7 +16,7 @@
 
 #include <json2pb.hh>
 
-using namespace pb;
+using namespace machinetalk;
 using namespace std;
 using namespace google::protobuf;
 

--- a/src/machinetalk/support/linmove.cc
+++ b/src/machinetalk/support/linmove.cc
@@ -29,28 +29,28 @@ enum axis_mask {
 
 
 void STRAIGHT_FEED(unsigned mask,
-		   pb::Container &msg,
+		   machinetalk::Container &msg,
 		   int lineno,
 		   double x, double y, double z,
 		   double a, double b, double c,
 		   double u, double v, double w)
 {
     // Container type tag
-    msg.set_type(pb::MT_EMC_TRAJ_LINEAR_MOVE);
+    msg.set_type(machinetalk::MT_EMC_TRAJ_LINEAR_MOVE);
 
     // Container has a optional line_number field.
     // use it - unused ones carry no cost in space and time
     msg.set_line_number(lineno);
 
     // this instantiates an optional submessage of Container
-    pb::Emc_Traj_Linear_Move *m = msg.mutable_traj_linear_move();
+    machinetalk::Emc_Traj_Linear_Move *m = msg.mutable_traj_linear_move();
 
     // the move type
-    m->set_type(pb::_EMC_MOTION_TYPE_FEED);
+    m->set_type(machinetalk::_EMC_MOTION_TYPE_FEED);
 
     // fill in the optional axes as commanded by mask
-    pb::EmcPose *p = m->mutable_end();
-    pb::PmCartesian *t = p->mutable_tran();
+    machinetalk::EmcPose *p = m->mutable_end();
+    machinetalk::PmCartesian *t = p->mutable_tran();
 
     if (mask & X_AXIS) t->set_x(x);
     if (mask & Y_AXIS) t->set_y(y);
@@ -83,7 +83,7 @@ int main(int argc, char* argv[])
     GOOGLE_PROTOBUF_VERIFY_VERSION;
 
 
-    pb::Container c; // all messages are wrapped in a Container
+    machinetalk::Container c; // all messages are wrapped in a Container
 
     STRAIGHT_FEED(axes, c,
 		  42,
@@ -108,7 +108,7 @@ int main(int argc, char* argv[])
 
     // convert from text representation to instance:
     // easy to create a message with an editor
-    pb::Container got;
+    machinetalk::Container got;
     if (!TextFormat::ParseFromString(text, &got)) {
 	cerr << "Failed to parse '" << text << "'" << endl;
 	return -1;
@@ -121,7 +121,7 @@ int main(int argc, char* argv[])
     // and parsed back from json into a message instance with full
     // type checking:
 
-    pb::Container fromjson;
+    machinetalk::Container fromjson;
 
     try{
 	json2pb(fromjson, json.c_str(), strlen(json.c_str()));

--- a/src/machinetalk/support/npbdecode.c
+++ b/src/machinetalk/support/npbdecode.c
@@ -46,7 +46,7 @@ bool callback(pb_istream_t *stream, uint8_t *buf, size_t count);
 int bufsize = 10240;
 const char *progname;
 
-void print_value(pb_Value *v, char *tag)
+void print_value(machinetalk_Value *v, char *tag)
 {
     printf("%s.value.type = %d\n", tag, v->type);
 
@@ -54,7 +54,7 @@ void print_value(pb_Value *v, char *tag)
 	printf("%s.value.double = %f\n",tag, v->v_double);
 
     if (v->has_pose) {
-	pb_EmcPose *e = &v->pose;
+	machinetalk_EmcPose *e = &v->pose;
       printf("%s.pose: ", tag);
       if (e->tran.has_x)
 	  printf("x=%f ", e->tran.x);
@@ -79,7 +79,7 @@ void print_value(pb_Value *v, char *tag)
 }
 
 #if 0
-void print_object_detail(pb_Object *o, char *tag)
+void print_object_detail(machinetalk_Object *o, char *tag)
 {
     printf("%s.object.type = %d\n", tag, o->type);
 #ifndef ARGS_CALLBACK
@@ -87,7 +87,7 @@ void print_object_detail(pb_Object *o, char *tag)
 	printf("%s.object.name = '%s'\n", tag, o->name);
 #endif
     if (o->has_pin) {
-	pb_Pin *p = &o->pin;
+	machinetalk_Pin *p = &o->pin;
 	printf("%s.pin.type = %d\n", tag, p->type);
 #ifndef ARGS_CALLBACK
 	if (p->has_name)
@@ -135,8 +135,8 @@ bool print_member(pb_istream_t *stream, const pb_field_t *field, void *cbdata)
 #if 0
 bool print_object(pb_istream_t *stream, const pb_field_t *field, char *tag)
 {
-    pb_Object obj = {0};
-    obj = (pb_Object) {
+    machinetalk_Object obj = {0};
+    obj = (machinetalk_Object) {
 	.name.funcs.decode = print_string,
 	.name.arg = "object.name = '%s'\n",
 	.pin.name.funcs.decode = print_string,
@@ -173,7 +173,7 @@ bool print_object(pb_istream_t *stream, const pb_field_t *field, char *tag)
 	.thread.name.arg = "origin.name = '%s'\n",
     };
 
-    if (!pb_decode(stream, pb_Object_fields, &obj)) {
+    if (!pb_decode(stream, machinetalk_Object_fields, &obj)) {
         return false;
     }
     print_object_detail(&obj, tag);
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
     pb_istream_t stdin_stream = {&callback, stdin, SIZE_MAX};
 
     pb_istream_t stream;
-    pb_Container c;
+    machinetalk_Container c;
 
     progname = argv[0];
     memset(&c, 0, sizeof(c));
@@ -209,13 +209,13 @@ int main(int argc, char **argv)
     } else
 	stream = stdin_stream;
 
-    c.type = pb_ContainerType_MT_HALUPDATE;
+    c.type = machinetalk_ContainerType_MT_HALUPDATE;
 #ifdef ARGS_CALLBACK
     /* c.arg.funcs.decode = &print_object; */
     /* c.arg.arg = "arg"; */
 #endif
 
-    if (!pb_decode(&stream, pb_Container_fields, &c)) {
+    if (!pb_decode(&stream, machinetalk_Container_fields, &c)) {
 	fprintf(stderr, "%s: pb_decode(container) failed: '%s'\n",
 			progname, PB_GET_ERROR(&stream));
 	exit(1);

--- a/src/machinetalk/support/position.cc
+++ b/src/machinetalk/support/position.cc
@@ -12,7 +12,7 @@
 #include <machinetalk/protobuf/message.pb.h>
 #include <json2pb.hh>
 
-using namespace pb;
+using namespace machinetalk;
 using namespace std;
 using namespace google::protobuf;
 

--- a/src/machinetalk/support/rtprintf.c
+++ b/src/machinetalk/support/rtprintf.c
@@ -54,10 +54,10 @@ static int get_code(const char **fmt_io, int *modifier_l) {
     return *fmt;
 }
 
-int pbvprintf( pb_RTAPI_Message *msg, int level, const char *fmt, va_list ap)
+int pbvprintf( machinetalk_RTAPI_Message *msg, int level, const char *fmt, va_list ap)
 {
     int modifier_l, code;
-    pb_Value *v;
+    machinetalk_Value *v;
 
     msg->msglevel = level;
     strncpy(msg->format, fmt, MIN(strlen(fmt),
@@ -77,14 +77,14 @@ int pbvprintf( pb_RTAPI_Message *msg, int level, const char *fmt, va_list ap)
             if(modifier_l) {
 	    case 'p':
 		// dbuf_put_long(o, va_arg(ap, long));
-		v->type = pb_ValueType_INT32;
+		v->type = machinetalk_ValueType_INT32;
 		v->has_v_int32 = true;
 		v->v_int32 =  va_arg(ap, long);
 		msg->arg_count++;
             } else {
 		// XXX not sure about long vs int encoding in protobuf types
                 // dbuf_put_int(o, va_arg(ap, int));
-		v->type = pb_ValueType_INT32;
+		v->type = machinetalk_ValueType_INT32;
 		v->has_v_int32 = true;
 		v->v_int32 =  va_arg(ap, long);
 		msg->arg_count++;
@@ -93,14 +93,14 @@ int pbvprintf( pb_RTAPI_Message *msg, int level, const char *fmt, va_list ap)
             break;
         case 'e': case 'E': case 'f': case 'F': case 'g': case 'G':
 	    //            dbuf_put_double(o, va_arg(ap, double));
-	    v->type = pb_ValueType_DOUBLE;
+	    v->type = machinetalk_ValueType_DOUBLE;
 	    v->has_v_double = true;
 	    v->v_double =  va_arg(ap, double);
 	    msg->arg_count++;
             break;
         case 's':
             // dbuf_put_string(o, va_arg(ap, const char *));
-	    v->type = pb_ValueType_STRING;
+	    v->type = machinetalk_ValueType_STRING;
 	    v->has_v_string = true;
 	    strncpy(v->v_string,va_arg(ap, const char *), sizeof(v->v_string));
 	    msg->arg_count++;
@@ -115,7 +115,7 @@ int pbvprintf( pb_RTAPI_Message *msg, int level, const char *fmt, va_list ap)
     return 0;
 }
 
-int pbprintf(pb_RTAPI_Message *msg, int level, const char *fmt, ...) {
+int pbprintf(machinetalk_RTAPI_Message *msg, int level, const char *fmt, ...) {
     va_list ap;
     int result;
 
@@ -132,7 +132,7 @@ int main (int argc, char *argv[ ])
     pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
     int result;
 
-    pb_RTAPI_Message msg;
+    machinetalk_RTAPI_Message msg;
     memset(&msg, 0, sizeof(msg));
 
     switch (argc) {
@@ -158,7 +158,7 @@ int main (int argc, char *argv[ ])
 	break;
     }
 
-    if ((result = pb_encode(&stream, pb_RTAPI_Message_fields, &msg))) {
+    if ((result = pb_encode(&stream, machinetalk_RTAPI_Message_fields, &msg))) {
 	fwrite(buffer, 1, stream.bytes_written, stdout);
         exit(0);
     } else {

--- a/src/machinetalk/support/sizes.c
+++ b/src/machinetalk/support/sizes.c
@@ -19,13 +19,13 @@ int main()
     printf("emcmot_config_t = %zu\n", sizeof(emcmot_config_t));
     printf("emcmot_debug_t = %zu\n", sizeof(emcmot_debug_t));
 
-    printf("npb Container = %zu\n", sizeof(pb_Container));
-    printf("npb Test1 = %zu\n", sizeof(pb_Test1));
-    printf("npb Value = %zu\n", sizeof(pb_Value));
+    printf("npb Container = %zu\n", sizeof(machinetalk_Container));
+    printf("npb Test1 = %zu\n", sizeof(machinetalk_Test1));
+    printf("npb Value = %zu\n", sizeof(machinetalk_Value));
 
-    printf("npb MotionCommand = %zu\n", sizeof(pb_MotionCommand));
-    printf("npb MotionStatus = %zu\n", sizeof(pb_MotionStatus));
-    pb_Container c[1];
+    printf("npb MotionCommand = %zu\n", sizeof(machinetalk_MotionCommand));
+    printf("npb MotionStatus = %zu\n", sizeof(machinetalk_MotionStatus));
+    machinetalk_Container c[1];
     //  printf("npb Task cmds = %zu\n", c->has_traj_set_g5x-c->has_tpexecute);
     printf("npb Canon cmds = %zu\n", (void *)&c[1]- (void *)&(c->has_traj_set_g5x));
 

--- a/src/machinetalk/webtalk/webtalk.hh
+++ b/src/machinetalk/webtalk/webtalk.hh
@@ -211,8 +211,8 @@ typedef struct wtself {
     bool interrupted;
     pid_t pid;
 
-    pb::Container rx; // any ParseFrom.. function does a Clear() first
-    pb::Container tx; // tx must be Clear()'d after or before use
+    machinetalk::Container rx; // any ParseFrom.. function does a Clear() first
+    machinetalk::Container tx; // tx must be Clear()'d after or before use
 
     zlist_t *policies;
 #ifdef LWS_NEW_API

--- a/src/machinetalk/webtalk/webtalk_jsonpolicy.cc
+++ b/src/machinetalk/webtalk/webtalk_jsonpolicy.cc
@@ -20,7 +20,7 @@ json_policy(wtself_t *self,
     lwsl_debug("%s op=%d\n",__func__,  type);
     zmsg_t *m;
     zframe_t *f;
-    static pb::Container c; // fast; threadsafe???
+    static machinetalk::Container c; // fast; threadsafe???
 
     switch (type) {
 
@@ -69,11 +69,11 @@ json_policy(wtself_t *self,
 		    case ZMQ_SUB:
 			// inspect message for inband subscribe/unsubscribe
 			for (int i = 0; i < c.note_size(); i++) {
-				if (c.type() == pb::MT_ZMQ_SUBSCRIBE) {
+				if (c.type() == machinetalk::MT_ZMQ_SUBSCRIBE) {
 				lwsl_fromws("%s: subscribe to '%s'\n", __func__, c.note(i).c_str());
 				zsocket_set_subscribe (wss->socket, c.note(i).c_str());
 			    }
-			    if (c.type() == pb::MT_ZMQ_UNSUBSCRIBE) {
+			    if (c.type() == machinetalk::MT_ZMQ_UNSUBSCRIBE) {
 				lwsl_fromws("%s: unsubscribe from '%s'\n", __func__, c.note(i).c_str());
 				zsocket_set_unsubscribe (wss->socket, c.note(i).c_str());
 			    }

--- a/src/rtapi/rtapi_msgd.cc
+++ b/src/rtapi/rtapi_msgd.cc
@@ -565,8 +565,8 @@ message_poll_cb(zloop_t *loop, int  timer_id, void *args)
     size_t payload_length;
     int retval;
     char *cp;
-    pb::Container container;
-    pb::LogMessage *logmsg;
+    machinetalk::Container container;
+    machinetalk::LogMessage *logmsg;
     zframe_t *z_pbframe;
     int current_interval = msg_poll;
 
@@ -601,7 +601,7 @@ message_poll_cb(zloop_t *loop, int  timer_id, void *args)
 
 	    if (logpub.socket) {
 		// publish protobuf-encoded log message
-		container.set_type(pb::MT_LOG_MESSAGE);
+		container.set_type(machinetalk::MT_LOG_MESSAGE);
 
 		struct timespec timestamp;
 		clock_gettime(CLOCK_REALTIME, &timestamp);
@@ -609,9 +609,9 @@ message_poll_cb(zloop_t *loop, int  timer_id, void *args)
 		container.set_tv_nsec(timestamp.tv_nsec);
 
 		logmsg = container.mutable_log_message();
-		logmsg->set_origin((pb::MsgOrigin)msg->origin);
+		logmsg->set_origin((machinetalk::MsgOrigin)msg->origin);
 		logmsg->set_pid(msg->pid);
-		logmsg->set_level((pb::MsgLevel) msg->level);
+		logmsg->set_level((machinetalk::MsgLevel) msg->level);
 		logmsg->set_tag(msg->tag);
 		logmsg->set_text(msg->buf, strlen(msg->buf));
 


### PR DESCRIPTION
The patch renames the machinetalk-protobuf package name from `pb` to `machinetalk`. The reason is that the name `pb` is too generic. The Machinetalk package name now aligns with the Machinetalk project name which makes vendor specific Protobuf definitions easily possible (e.g. namespace `machinetalk` and `<vendor_name>` in the same project).