### PR TITLE
mkwrapper.py: support unicode text messages for update_error()

### DIFF
--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: UTF-8 -*
 import os
 import sys
 from stat import *
@@ -1433,6 +1434,7 @@ class LinuxCNCWrapper():
             return
 
         kind, text = error
+        text = unicode(text, 'utf-8')
         self.txError.note.append(text)
 
         if (kind == linuxcnc.NML_ERROR):

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -13096,7 +13096,7 @@ msgstr ""
 #: src/emc/rs274ngc/interp_read.cc:1147
 #, c-format
 msgid "Bad character '%c' used"
-msgstr ""
+msgstr "使用了错误字元 '%c'"
 
 #: src/emc/rs274ngc/interp_read.cc:1671
 msgid "Left bracket missing after 'while'"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -12346,7 +12346,7 @@ msgstr ""
 #: src/emc/rs274ngc/interp_read.cc:1147
 #, c-format
 msgid "Bad character '%c' used"
-msgstr ""
+msgstr "使用了錯誤字元 '%c'"
 
 #: src/emc/rs274ngc/interp_read.cc:1671
 msgid "Left bracket missing after 'while'"


### PR DESCRIPTION
1. mkwrapper.py: update_error(), convert text from str to unicode type
2. Update zh_CN.po and zh_TW.po for Chinese translations