### PR TITLE
Fix rtapi_maths functions for use with gcc-6.3.1

### DIFF
--- a/src/rtapi/rtapi_math/e_asin.c
+++ b/src/rtapi/rtapi_math/e_asin.c
@@ -85,23 +85,26 @@ qS4 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
 
 	GET_HIGH_WORD(hx,x);
 	ix = hx&0x7fffffff;
-	if(ix>= 0x3ff00000) {		/* |x|>= 1 */
+	if(ix>= 0x3ff00000){	/* |x|>= 1 */
 	    u_int32_t lx;
 	    GET_LOW_WORD(lx,x);
 	    if(((ix-0x3ff00000)|lx)==0)
 		    /* asin(1)=+-pi/2 with inexact */
 		return x*pio2_hi+x*pio2_lo;	
 	    return (x-x)/(x-x);		/* asin(|x|>1) is NaN */   
-	} else if (ix<0x3fe00000) {	/* |x|<0.5 */
-	    if(ix<0x3e400000) {		/* if |x| < 2**-27 */
-		if(huge+x>one) return x;/* return x with inexact if x!=0*/
-	    } else 
+	} 
+	else if (ix<0x3fe00000){   /* |x|<0.5 */
+	    if(ix<0x3e400000){	/* if |x| < 2**-27 */
+		if(huge+x>one)
+		    return x; /* return x with inexact if x!=0*/
+	    }else{ 
 		t = x*x;
 		p = t*(pS0+t*(pS1+t*(pS2+t*(pS3+t*(pS4+t*pS5)))));
 		q = one+t*(qS1+t*(qS2+t*(qS3+t*qS4)));
 		w = p/q;
 		return x+x*w;
-	}
+	    }
+        }
 	/* 1> |x|>= 0.5 */
 	w = one-rtapi_fabs(x);
 	t = w*0.5;
@@ -120,5 +123,8 @@ qS4 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
 	    q  = pio4_hi-2.0*w;
 	    t  = pio4_hi-(p-q);
 	}    
-	if(hx>0) return t; else return -t;    
+	if(hx>0) 
+	    return t; 
+	else 
+	    return -t;    
 }

--- a/src/rtapi/rtapi_math/k_rem_pio2.c
+++ b/src/rtapi/rtapi_math/k_rem_pio2.c
@@ -189,7 +189,10 @@ twon24  =  5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
 
     /* compute q[0],q[1],...q[jk] */
 	for (i=0;i<=jk;i++) {
-	    for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j]; q[i] = fw;
+	    for(j=0,fw=0.0;j<=jx;j++){
+		fw += x[j]*f[jx+i-j]; 
+		q[i] = fw;
+	    }
 	}
 
 	jz = jk;


### PR DESCRIPTION
Debian Stretch uses gcc-6.3.1 which has much stricter checking.

e_asin.c looks like C code written by a python programmer, it seems
to rely upon indentation to group operations, but in fact ends up with
only the first operation acted upon in the else option.
gcc-6.3.1 throws an error at this as previously noted in #1092

The www.scs.stanford.edu/histar/src/pkg/uclibc/libm/e_asin.c version of this
code where all indented operations are within else {} bracketing
appears to be the correct answer and code amended in that manner.

Uninitialised local double t, initialised to 0.0 instead of current 0

k_rem_pio2.c has 2 unbracketed operations after a for() loop on the same line.
This likewise was likely to be being rationalised so that only the first
operation was acted upon, which can't have been the intention.

Signed-off-by: Mick <arceye@mgware.co.uk>