### PR TITLE
machinekit/launcher: fix HAL file using wrong namespace

### DIFF
--- a/lib/python/machinekit/launcher.py
+++ b/lib/python/machinekit/launcher.py
@@ -117,7 +117,8 @@ def load_hal_file(filename, ini=None):
         if ini is not None:
             from machinekit import config
             config.load_ini(ini)
-        execfile(filename)
+        globals = {}
+        execfile(filename, globals)
     else:
         command = 'halcmd'
         if ini is not None:


### PR DESCRIPTION
`execfile` per default uses the namespace it is executed in which is not really what we want here.

I found this bug because it prevents functions using imports from working in Python HAL files.

For the records:
```
loading chip.py... Traceback (most recent call last):
  File "./run.py", line 18, in <module>
    launcher.load_hal_file('chip.py')
  File "/home/alexander/bin/machinekit-1/lib/python/machinekit/launcher.py", line 121, in load_hal_file
    execfile(filename)
  File "chip.py", line 7, in <module>
    test_func()
  File "chip.py", line 5, in test_func
    sig = hal.newsig('foo', hal.HAL_FLOAT)
NameError: global name 'hal' is not defined
```