### PR TITLE
docker_run.sh: Add default value for TRAVIS_PULL_REQUEST

### DIFF
--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -9,7 +9,7 @@ COMMITTER_EMAIL="$(git log -1 --pretty=format:%ae)"
 COMMIT_TIMESTAMP="$(git log -1 --pretty=format:%at)"
 DISTRO=${TAG%-*}
 MARCH=${TAG#*-}
-test ${TRAVIS_PULL_REQUEST} = false && IS_PR=false || IS_PR=true
+test ${TRAVIS_PULL_REQUEST:=false} = false && IS_PR=false || IS_PR=true
 # Verbose RIP build output:  "true" or "false"
 MK_BUILD_VERBOSE=${MK_BUILD_VERBOSE:-"false"}
 # Verbose package build output:  "true" or "false"


### PR DESCRIPTION
Set a default value for TRAVIS_PULL_REQUEST if it is not already
defined in the environment.  This makes it easier to do manual
cross-builds.

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>