### PR TITLE
hal_pru_generic: Fixup depend file generation

### DIFF
--- a/src/hal/drivers/hal_pru_generic/Submakefile
+++ b/src/hal/drivers/hal_pru_generic/Submakefile
@@ -38,7 +38,7 @@ PRU_DBGS := $(patsubst %,objects/%,$(patsubst %,$(PRU_SRC_DIR)/%.dbg,$(PRU_MAINS
 $(PRU_DEPS): objects/%.d : %.p
 	$(Q)mkdir -p $(dir $@)
 	$(ECHO) generate PRU dependency $@ from $<
-	$(Q)cpp -MM -MG -MT objects/$(patsubst %.p,%.bin,$<)  $< $@
+	$(Q)cpp -x c -MM -MG -MT objects/$(patsubst %.p,%.bin,$<) -o $@ $<
 
 objects/%.bin objects/%.dbg : %.p objects/%.d $(PASM)
 	$(Q)mkdir -p $(RTLIBDIR)


### PR DESCRIPTION
Explicitly set the file type to 'c' and set the output filename
using -o

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>