### PR TITLE
Include the nosetest subdir in machinekit package

### DIFF
--- a/debian/machinekit.install.in
+++ b/debian/machinekit.install.in
@@ -13,6 +13,7 @@ usr/lib/python*/*/gladevcp/*.glade
 usr/lib/python*/*/machinekit/*.so
 usr/lib/python*/*/machinetalk/protobuf/*.py
 usr/lib/python*/*/machinetalk/*.py
+usr/lib/python*/*/machinekit/nosetests/*.py
 usr/libexec/linuxcnc/pci_read
 usr/libexec/linuxcnc/pci_write
 usr/libexec/linuxcnc/inivar

--- a/src/Makefile
+++ b/src/Makefile
@@ -1023,6 +1023,7 @@ install-python: install-dirs
 	$(DIR) $(DESTDIR)$(SITEPY)/gladevcp
 	$(DIR) $(DESTDIR)$(SITEPY)/stepconf
 	$(DIR) $(DESTDIR)$(SITEPY)/machinekit
+	$(DIR) $(DESTDIR)$(SITEPY)/machinekit/nosetests
 	$(DIR) $(DESTDIR)$(SITEPY)/machinetalk
 	$(DIR) $(DESTDIR)$(SITEPY)/machinetalk/protobuf
 	$(DIR) $(DESTDIR)$(SITEPY)/fdm
@@ -1037,6 +1038,7 @@ install-python: install-dirs
 	$(FILE) ../lib/python/gladevcp/*.glade $(DESTDIR)$(SITEPY)/gladevcp
 	$(FILE) ../lib/python/stepconf/*.py $(DESTDIR)$(SITEPY)/stepconf
 	$(FILE) ../lib/python/machinekit/*.py $(DESTDIR)$(SITEPY)/machinekit/
+	$(FILE) ../lib/python/machinekit/nosetests/*.py $(DESTDIR)$(SITEPY)/machinekit/nosetests
 	$(FILE) ../lib/python/machinekit/*.so $(DESTDIR)$(SITEPY)/machinekit/
 	$(FILE) ../lib/python/machinetalk/*.py $(DESTDIR)$(SITEPY)/machinetalk/
 	$(FILE) ../lib/python/machinetalk/protobuf/*.py $(DESTDIR)$(SITEPY)/machinetalk/protobuf/


### PR DESCRIPTION
Adds minor extra python methods

Fixes #1139

Signed-off-by: Mick <arceye@mgware.co.uk>