### PR TITLE
debian/configure: add support for KDE Neon

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -176,6 +176,7 @@ do_tcl_tk_version() {
 	    Debian)  test "${DISTRO_RELEASE/.*/}" -lt 8 && TCL_TK_VER=8.5 ;;
 	    Raspbian)test "${DISTRO_RELEASE/.*/}" -lt 8 && TCL_TK_VER=8.5 ;;
 	    Ubuntu)  test "${DISTRO_RELEASE/.*/}" -lt 14 && TCL_TK_VER=8.5 ;;
+	    neon)  test "${DISTRO_RELEASE/.*/}" -lt 14 && TCL_TK_VER=8.5 ;;
 	    *)  usage "Unknown distro '${DISTRO_ID}'" ;;
 	esac
     fi


### PR DESCRIPTION
KDE Neon is a Ubuntu (LTS) based distro featuring a current version of KDE and Qt. This patch adds the neon tag to the supported distros check.