### PR TITLE
Add accessor macros to install.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -531,6 +531,7 @@ HEADERS := \
     emc/rs274ngc/modal_state.hh \
     emc/rs274ngc/rs274ngc.hh \
     hal/lib/hal_accessor.h \
+    hal/lib/hal_accessor_macros.h \
     hal/lib/config_module.h \
     hal/lib/hal_group.h \
     hal/lib/hal.h \


### PR DESCRIPTION
`hal_accessor_macros.h` is currently used undocumented by instcomp to define macros
used within the function code for atomic operation accessors.

Add to install, in preparation for rolling out info regards v2 components.

Will be in the main /include dir in a RIP, or in the machinekit-dev package.

Signed-off-by: Mick <arceye@mgware.co.uk>