### PR TITLE
Fix type mismatch in Machinetalk Protobuf and hal.h

### DIFF
--- a/src/machinetalk/proto/src/machinetalk/protobuf/types.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/types.proto
@@ -12,8 +12,11 @@ enum ValueType {
     HAL_FLOAT = 2;
     HAL_S32   = 3;
     HAL_U32   = 4;
-    STRING    = 5;
-    BYTES     = 6;
+    HAL_S64   = 5;
+    HAL_U64   = 6;
+    // STRING and BYTES not currently used
+    STRING    = 7;
+    BYTES     = 8;
 
     INT32     = 20;
     UINT32    = 30;


### PR DESCRIPTION
enums for s64 and u64 were missing and allocated to other fields

Fixes #1155

Signed-off-by: Mick <arceye@mgware.co.uk>