### PR TITLE
Makefile: fix ptyhon fdm/config deployment

### DIFF
--- a/debian/machinekit.install.in
+++ b/debian/machinekit.install.in
@@ -14,6 +14,8 @@ usr/lib/python*/*/machinekit/*.so
 usr/lib/python*/*/machinetalk/protobuf/*.py
 usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
+usr/lib/python*/*/fdm/*.py
+usr/lib/python*/*/fdm/config/*.py
 usr/libexec/linuxcnc/pci_read
 usr/libexec/linuxcnc/pci_write
 usr/libexec/linuxcnc/inivar

--- a/src/Makefile
+++ b/src/Makefile
@@ -1031,6 +1031,7 @@ install-python: install-dirs
 	$(DIR) $(DESTDIR)$(SITEPY)/machinetalk
 	$(DIR) $(DESTDIR)$(SITEPY)/machinetalk/protobuf
 	$(DIR) $(DESTDIR)$(SITEPY)/fdm
+	$(DIR) $(DESTDIR)$(SITEPY)/fdm/config
 	$(DIR) $(DESTDIR)$(datadir)/fdm/thermistor_tables
 	$(DIR) $(DESTDIR)$(SITEPY)/drivers
 	$(FILE) ../lib/python/*.py ../lib/python/*.so $(DESTDIR)$(SITEPY)
@@ -1047,6 +1048,7 @@ install-python: install-dirs
 	$(FILE) ../lib/python/machinetalk/*.py $(DESTDIR)$(SITEPY)/machinetalk/
 	$(FILE) ../lib/python/machinetalk/protobuf/*.py $(DESTDIR)$(SITEPY)/machinetalk/protobuf/
 	$(FILE) ../lib/python/fdm/*.py $(DESTDIR)$(SITEPY)/fdm
+	$(FILE) ../lib/python/fdm/config/*.py $(DESTDIR)$(SITEPY)/fdm/config
 	$(FILE) ../lib/python/drivers/*.py $(DESTDIR)$(SITEPY)/drivers
 	$(EXE) ../bin/stepconf $(DESTDIR)$(bindir)
 	$(EXE) ../bin/pncconf $(DESTDIR)$(bindir)


### PR DESCRIPTION
The FDM configs will not work without deploying the Python libraries.