### PR TITLE
Harden local copies of string variables in instantiated components.

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
@@ -528,7 +528,7 @@ static int instantiate(const int argc, const char**argv)
                 continue;
             }
             if(strncmp(brd->argv[x], "descriptor=", 11) == 0)
-                brd->config = halg_strdup(1, &brd->argv[x][11]);
+                brd->descriptor = halg_strdup(1, &brd->argv[x][11]);
         }
     }
     if(!brd->argc || brd->config == NULL){

--- a/src/hal/lib/hal_lib.c
+++ b/src/hal/lib/hal_lib.c
@@ -359,6 +359,8 @@ EXPORT_SYMBOL(hal_comp_name);
 EXPORT_SYMBOL(halg_malloc);
 EXPORT_SYMBOL(halg_strdup);
 EXPORT_SYMBOL(halg_free_str);
+EXPORT_SYMBOL(halg_dupargv);
+EXPORT_SYMBOL(halg_free_argv);
 
 // hal_pin.c:
 // EXPORT_SYMBOL(halg_pin_new);


### PR DESCRIPTION
In instantiated components created with instcomp,
make local_argv a char** to a locally allocated array of strings,
protecting against overwriting of the original args by subsequent calls,
in case required after instantiation.

Create a delete() function by default to explicitly free those strings.

This explicit free protects against the case where components are created
and deleted within a realtime system that continues to run,
thus reducing the heap memory available.
When realtime is stopped, the whole heap will be freed anyway.

Also fix stupid copy and paste typo in hm2_soc_ol, which would have
overwritten brd->config if anyone ever used the descriptor field.

Signed-off-by: Mick <arceye@mgware.co.uk>