### PR TITLE
More memory tidying

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
@@ -595,6 +595,13 @@ static int delete(const char *name, void *inst, const int inst_size)
     hm2_soc_t *brd = (hm2_soc_t *)inst;
     char buf[MAXNAMELEN];
 
+    // explicitly free locally allocated strings in case realtime
+    // continues to run after shutdown of this driver
+    if(brd->config != NULL)
+	halg_free_single_str(brd->config);
+    if(brd->descriptor != NULL)
+	halg_free_single_str(brd->descriptor);
+
     hm2_unregister(&brd->llio);
     int r = hm2_soc_munmap(brd);
     rtapi_snprintf(buf, sizeof(buf), configfs_dir, name);

--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.h
@@ -42,8 +42,8 @@ typedef struct {
     int uio_fd;
     int firmware_given;
     const char *name;
-    const char *config;
-    const char *descriptor;
+    char *config;
+    char *descriptor;
     const char *uio_dev;
     // local copy of calling args
     int argc;

--- a/src/hal/lib/hal_lib.c
+++ b/src/hal/lib/hal_lib.c
@@ -361,6 +361,7 @@ EXPORT_SYMBOL(halg_strdup);
 EXPORT_SYMBOL(halg_free_str);
 EXPORT_SYMBOL(halg_dupargv);
 EXPORT_SYMBOL(halg_free_argv);
+EXPORT_SYMBOL(halg_free_single_str);
 
 // hal_pin.c:
 // EXPORT_SYMBOL(halg_pin_new);

--- a/src/hal/lib/hal_memory.c
+++ b/src/hal/lib/hal_memory.c
@@ -207,6 +207,14 @@ int halg_free_str(char **s)
     return 0;
 }
 
+int halg_free_single_str(char *s)
+{
+    CHECK_NULL(s);
+    hal_data->str_freed += strlen(s) + 1;
+    rtapi_free(global_heap, s);
+    s = NULL;
+    return 0;
+}
 
 char **halg_dupargv(const bool use_hal_mutex,
 		    const int argc,

--- a/src/hal/lib/hal_priv.h
+++ b/src/hal/lib/hal_priv.h
@@ -854,7 +854,10 @@ int halg_signal_propagate_barriers(const int use_hal_mutex,
 void report_memory_usage(void);
 
 char *halg_strdup(const int use_hal_mutex, const char *paramptr);
-int halg_free_str(char **s);  // will set s to NULL
+int halg_free_str(char **s);  // will set *s to NULL
+char **halg_dupargv(const bool use_hal_mutex, const int argc, const char **argv);
+int halg_free_argv(const bool use_hal_mutex, char **argv);
+int halg_free_single_str(char *s);
 
 // for rtapi_app shutdown
 int hal_exit_usercomps(char *name);


### PR DESCRIPTION
Explicit release of strdup'd memory upon closure of hm2_soc_ol

Remove const type from char pointers in brd struct that receive the
strdup pointers, to prevent compiler warnings

Add memory funcs to hal_memory.c / hal_priv.h and export
in hal_lib.c

Signed-off-by: Mick <arceye@mgware.co.uk>