### PR TITLE
Remove deprecated `singleton` option from charge_pump instcomps

### DIFF
--- a/src/hal/i_components/charge_pump.icomp
+++ b/src/hal/i_components/charge_pump.icomp
@@ -3,7 +3,6 @@
 //
 
 component charge_pump "Create a square-wave for the 'charge pump' input of some controller boards";
-option singleton yes;
 
 pin out bit out "Square wave if 'enable' is TRUE or unconnected, low if 'enable' is FALSE";
 pin out bit out-2 "Square wave at half the frequency of 'out'";

--- a/src/hal/i_components/charge_pumpv2.icomp
+++ b/src/hal/i_components/charge_pumpv2.icomp
@@ -3,7 +3,6 @@
 //
 
 component charge_pumpv2 "Create a square-wave for the 'charge pump' input of some controller boards";
-option singleton yes;
 
 pin_ptr out bit out "Square wave if 'enable' is TRUE or unconnected, low if 'enable' is FALSE";
 pin_ptr out bit out-2 "Square wave at half the frequency of 'out'";


### PR DESCRIPTION
Signed-off-by: Mick <arceye@mgware.co.uk>