### PR TITLE
Static analysis fixes

### DIFF
--- a/src/machinetalk/haltalk/haltalk_command.cc
+++ b/src/machinetalk/haltalk/haltalk_command.cc
@@ -317,6 +317,7 @@ create_rcomp(htself_t *self,  const machinetalk::Component *pbcomp,
     if (comp_id > 0)
 	hal_exit(comp_id);
  ERROR:
+    if (rc) delete rc;
     return NULL;
 }
 

--- a/src/machinetalk/support/rtprintf.c
+++ b/src/machinetalk/support/rtprintf.c
@@ -102,7 +102,8 @@ int pbvprintf( machinetalk_RTAPI_Message *msg, int level, const char *fmt, va_li
             // dbuf_put_string(o, va_arg(ap, const char *));
 	    v->type = machinetalk_ValueType_STRING;
 	    v->has_v_string = true;
-	    strncpy(v->v_string,va_arg(ap, const char *), sizeof(v->v_string));
+	    *(v->v_string) = '\0';
+	    strncat(v->v_string, va_arg(ap, const char *), sizeof(v->v_string) - 1);
 	    msg->arg_count++;
             break;
         default:


### PR DESCRIPTION
The first two fixes for a set of problems detected by the Coverity static analyzer. A lot more will follow.

See https://github.com/machinekit/machinekit/issues/391