### PR TITLE
Coverity error checking fixes

### DIFF
--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -164,6 +164,8 @@ int main(int argc, char **argv)
                 proto_debug = 1;
 		break;
 	    case 'C':
+		// Coverity doesn't like this and you can see why
+		// not going to mess with it for now
                 cl = getenv("COMP_LINE");
                 cw = getenv("COMP_POINT");
                 if (!cl || !cw) exit(0);
@@ -277,12 +279,21 @@ int main(int argc, char **argv)
         return 1;
     }
     {
-	char cmdline[200];
+	// MAX_CMD_LEN set in halcmd.h at 1024
+	char cmdline[MAX_CMD_LEN];
 	cmdline[0] = '\0';
-	int i;
+	int i, len = 0;
 	for (i=1; i < argc; i++) {
-	    strcat(cmdline, argv[i]);
-	    strcat(cmdline, " ");
+	    len += strlen(argv[i]) + 1;
+	    if(len < 200){
+		strcat(cmdline, argv[i]);
+		strcat(cmdline, " ");
+	    }
+	    else{
+		rtapi_print_msg(RTAPI_MSG_DBG, 
+		    "halcmd commandline exceeds 200 chars");
+		exit(-1);
+	    }
 	}
 	rtapi_print_msg(RTAPI_MSG_DBG, "--halcmd %s", cmdline);
     }

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
 		strcat(cmdline, " ");
 	    }
 	    else {
-		fprintf("halcmd commandline exceeds %i chars", MAX_CMD_LEN);
+		fprintf(stderr, "halcmd commandline exceeds %i chars", MAX_CMD_LEN);
 		exit(-1);
 	    }
 	}

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -285,13 +285,12 @@ int main(int argc, char **argv)
 	int i, len = 0;
 	for (i=1; i < argc; i++) {
 	    len += strlen(argv[i]) + 1;
-	    if(len < 200){
+	    if (len < MAX_CMD_LEN) {
 		strcat(cmdline, argv[i]);
 		strcat(cmdline, " ");
 	    }
-	    else{
-		rtapi_print_msg(RTAPI_MSG_DBG, 
-		    "halcmd commandline exceeds 200 chars");
+	    else {
+		fprintf("halcmd commandline exceeds %i chars", MAX_CMD_LEN);
 		exit(-1);
 	    }
 	}

--- a/src/rtapi/rtapi_compat.c
+++ b/src/rtapi/rtapi_compat.c
@@ -116,26 +116,29 @@ int xenomai_gid()
 int user_in_xenomai_group()
 {
     int numgroups, i;
-    gid_t *grouplist;
+    gid_t *grouplist = NULL;
     int gid = xenomai_gid();
 
     if (gid < 0)
 	return gid;
 
     numgroups = getgroups(0,NULL);
-    grouplist = (gid_t *) calloc( numgroups, sizeof(gid_t));
-    if (grouplist == NULL)
-	return -ENOMEM;
-    if (getgroups( numgroups, grouplist) > 0) {
-	for (i = 0; i < numgroups; i++) {
-	    if (grouplist[i] == (unsigned) gid) {
-		free(grouplist);
-		return 1;
+    if(numgroups > 0) // if there was an error will return -1, if none 0
+	{
+	grouplist = (gid_t *) calloc( numgroups, sizeof(gid_t));
+        if (grouplist == NULL)
+	    return -ENOMEM;
+        if (getgroups( numgroups, grouplist) > 0) {
+	    for (i = 0; i < numgroups; i++) {
+		if (grouplist[i] == (unsigned) gid) {
+		    free(grouplist);
+		    return 1;
+		}
 	    }
+	} else {
+	    free(grouplist);
+	    return errno;
 	}
-    } else {
-	free(grouplist);
-	return errno;
     }
     return 0;
 }
@@ -243,6 +246,11 @@ flavor_ptr flavor_byid(int flavor_id)
 flavor_ptr default_flavor(void)
 {
     char *fname = getenv("FLAVOR");
+    if(strlen(fname) > RTAPI_NAME_LEN){ // will overrun buffer if it is
+	fprintf(stderr, "flavour name in env =  %s, which exceeds valid length\n", fname);
+	exit(-1);
+    }
+
     flavor_ptr f, flavor;
 
     if (fname) {
@@ -696,11 +704,16 @@ int rtapi_get_tags(const char *mod_name)
 	    perror("cant get  RTLIB_DIR ?\n");
 	    return -1;
 	}
-	strcat(modpath,"/");
-	strcat(modpath, flavor->name);
-	strcat(modpath,"/");
-	strcat(modpath,mod_name);
-	strcat(modpath, flavor->mod_ext);
+	if((strlen(modpath) + 1) < PATH_MAX)
+	    strcat(modpath,"/");
+	if((strlen(modpath) + strlen(flavor->name)) < PATH_MAX)
+	    strcat(modpath, flavor->name);
+	if((strlen(modpath) + 1) < PATH_MAX)
+	    strcat(modpath,"/");
+	if((strlen(modpath) + strlen(mod_name)) < PATH_MAX)
+	    strcat(modpath,mod_name);
+	if((strlen(modpath) + strlen(flavor->mod_ext)) < PATH_MAX)
+	    strcat(modpath, flavor->mod_ext);
     }
     const char **caps = get_caps(modpath);
 


### PR DESCRIPTION
Potentially overunning fixed length buffers,
possible negative return used as param to calloc() etc.

Signed-off-by: Mick <arceye@mgware.co.uk>