### PR TITLE
Fix time and timev2 instcomps

### DIFF
--- a/src/hal/i_components/time.icomp
+++ b/src/hal/i_components/time.icomp
@@ -57,22 +57,28 @@ In your post-gui.hal file you might use the following to connect it up
  net cycle-minutes pyvcp.time-minutes <= time.0.minutes
  net cycle-hours pyvcp.time-hours <= time.0.hours
 
+The start pin will start or restart the counter cumulatively
+
+The zero pin will zero the counter for a fresh count
+attach to a momentary push button
+
 """;
 
-author "John Thornton";
+author "John Thornton  - adapted by ArcEye to instcomp";
 
 license "GPL";
 
 // Input Pins
-pin in bit start "Timer On";
+pin in bit start = 0 "Timer On";
+pin in bit zero  = 0 "Zero timer";
 
 // Output Pins
-pin out u32 seconds "Seconds";
-pin out u32 minutes "Minutes";
-pin out u32 hours "Hours";
+pin out u32 seconds  = 0 "Seconds";
+pin out u32 minutes = 0 "Minutes";
+pin out u32 hours = 0 "Hours";
 
 // Variables
-variable hal_u32_t totalsecs = 0;
+variable long totalnsecs = 0;
 variable hal_bit_t old_start = false;
 
 function _;
@@ -83,15 +89,24 @@ function _;
 
 FUNCTION(_)
 {
+long lperiod = fa_current_period(fa);
+hal_u32_t totalsecs;
+
+    if(zero){
+	// cater for a zeroing the counter
+	totalnsecs = totalsecs = 0;
+	seconds = minutes = hours = 0;
+    }
 
     if(start && !old_start) 
-		totalsecs = 0;
+	totalsecs = 0;
 
     if(start){
-    totalsecs += (hal_u32_t)(period / 1e9);
-    seconds = totalsecs % 60;
-    minutes = (totalsecs / 60) % 60;
-    hours = totalsecs / 3600;
+        totalnsecs += lperiod;
+        totalsecs = (hal_u32_t)(totalnsecs / 1e9);
+        seconds = totalsecs % 60;
+        minutes = (totalsecs / 60) % 60;
+        hours = totalsecs / 3600;
     }
     old_start = start;
 

--- a/src/hal/i_components/timev2.icomp
+++ b/src/hal/i_components/timev2.icomp
@@ -57,22 +57,27 @@ In your post-gui.hal file you might use the following to connect it up
  net cycle-minutes pyvcp.time-minutes <= time.0.minutes
  net cycle-hours pyvcp.time-hours <= time.0.hours
 
+The start pin will start or restart the counter cumulatively
+
+The zero pin will zero the counter for a fresh count
+attach to a momentary push button
 """;
 
-author "John Thornton";
+author "John Thornton - adapted by ArcEye to instcomp";
 
 license "GPL";
 
 // Input Pins
-pin_ptr in bit start "Timer On";
+pin_ptr in bit start = 0 "Timer On";
+pin_ptr in bit zero = 0 "Timer On";
 
 // Output Pins
-pin_ptr out u32 seconds "Seconds";
-pin_ptr out u32 minutes "Minutes";
-pin_ptr out u32 hours "Hours";
+pin_ptr out u32 seconds = 0 "Seconds";
+pin_ptr out u32 minutes = 0 "Minutes";
+pin_ptr out u32 hours = 0 "Hours";
 
 // Global Variables
-variable hal_u32_t totalsecs = 0;
+variable long totalnsecs = 0;
 variable hal_bit_t old_start = false;
 
 function _;
@@ -83,11 +88,24 @@ function _;
 
 FUNCTION(_)
 {
+long lperiod = fa_current_period(fa);
+hal_u32_t totalsecs;
+
+    if(gb(zero)){
+	// cater for restart	
+	totalnsecs = totalsecs = 0; 
+	su(seconds, 0);
+	su(minutes, 0);
+	su(hours, 0);
+    }
+
     if(gb(start) && !old_start) 
 		totalsecs = 0;
 
     if(gb(start)){
-        totalsecs += (hal_u32_t)(period / 1e9);
+        totalnsecs += lperiod;
+        totalsecs = (hal_u32_t)(totalnsecs / 1e9);
+
         su(seconds, totalsecs % 60);
         su(minutes, (totalsecs / 60) % 60);
         su(hours, totalsecs / 3600);


### PR DESCRIPTION
A complete line had been deleted from the function code,
with the effect that they did not update.

Upgraded to use fa_current_period() so that updates are more accurate.
Also catered for restart, which was never in original
by adding a zeroing pin.

Timings now can either be cumulative, with stops and starts
or reset to zero whilst timing or after a stop.

Signed-off-by: Mick <arceye@mgware.co.uk>