### PR TITLE
Fix error with flavor being unable to discern correct kernel

### DIFF
--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -61,6 +61,8 @@
 #include <search.h>
 #include <inifile.h>
 
+#define CMD_BUF_LEN 200
+
 static int get_input(FILE *srcfile, char *buf, size_t bufsize);
 static void print_help_general(int showR);
 static int release_HAL_mutex(void);
@@ -86,7 +88,7 @@ int main(int argc, char **argv)
     int filemode = 0;
     char *filename = NULL;
     FILE *srcfile = NULL;
-    char raw_buf[MAX_CMD_LEN+1];
+    char raw_buf[CMD_BUF_LEN+1];
     int linenumber = 1;
     char *cf=NULL, *cw=NULL, *cl=NULL;
     char *uri = NULL; // NULL - use service discovery
@@ -279,18 +281,17 @@ int main(int argc, char **argv)
         return 1;
     }
     {
-	// MAX_CMD_LEN set in halcmd.h at 1024
-	char cmdline[MAX_CMD_LEN];
+	char cmdline[CMD_BUF_LEN];
 	cmdline[0] = '\0';
 	int i, len = 0;
 	for (i=1; i < argc; i++) {
 	    len += strlen(argv[i]) + 1;
-	    if (len < MAX_CMD_LEN) {
+	    if (len < CMD_BUF_LEN) {
 		strcat(cmdline, argv[i]);
 		strcat(cmdline, " ");
 	    }
 	    else {
-		fprintf(stderr, "halcmd commandline exceeds %i chars", MAX_CMD_LEN);
+		fprintf(stderr, "halcmd commandline exceeds %i chars", CMD_BUF_LEN);
 		exit(-1);
 	    }
 	}
@@ -316,7 +317,7 @@ int main(int argc, char **argv)
         }
     } else {
 	/* read command line(s) from 'srcfile' */
-	while (get_input(srcfile, raw_buf, MAX_CMD_LEN)) {
+	while (get_input(srcfile, raw_buf, CMD_BUF_LEN)) {
 	    char *tokens[MAX_TOK+1];
 	    halcmd_set_linenumber(linenumber++);
 	    /* remove comments, do var substitution, and tokenise */

--- a/src/rtapi/rtapi_compat.c
+++ b/src/rtapi/rtapi_compat.c
@@ -116,29 +116,26 @@ int xenomai_gid()
 int user_in_xenomai_group()
 {
     int numgroups, i;
-    gid_t *grouplist = NULL;
+    gid_t *grouplist;
     int gid = xenomai_gid();
 
     if (gid < 0)
 	return gid;
 
     numgroups = getgroups(0,NULL);
-    if(numgroups > 0) // if there was an error will return -1, if none 0
-	{
-	grouplist = (gid_t *) calloc( numgroups, sizeof(gid_t));
-        if (grouplist == NULL)
-	    return -ENOMEM;
-        if (getgroups( numgroups, grouplist) > 0) {
-	    for (i = 0; i < numgroups; i++) {
-		if (grouplist[i] == (unsigned) gid) {
-		    free(grouplist);
-		    return 1;
-		}
+    grouplist = (gid_t *) calloc( numgroups, sizeof(gid_t));
+    if (grouplist == NULL)
+	return -ENOMEM;
+    if (getgroups( numgroups, grouplist) > 0) {
+	for (i = 0; i < numgroups; i++) {
+	    if (grouplist[i] == (unsigned) gid) {
+		free(grouplist);
+		return 1;
 	    }
-	} else {
-	    free(grouplist);
-	    return errno;
 	}
+    } else {
+	free(grouplist);
+	return errno;
     }
     return 0;
 }
@@ -246,11 +243,6 @@ flavor_ptr flavor_byid(int flavor_id)
 flavor_ptr default_flavor(void)
 {
     char *fname = getenv("FLAVOR");
-    if(strlen(fname) > RTAPI_NAME_LEN){ // will overrun buffer if it is
-	fprintf(stderr, "flavour name in env =  %s, which exceeds valid length\n", fname);
-	exit(-1);
-    }
-
     flavor_ptr f, flavor;
 
     if (fname) {
@@ -704,16 +696,11 @@ int rtapi_get_tags(const char *mod_name)
 	    perror("cant get  RTLIB_DIR ?\n");
 	    return -1;
 	}
-	if((strlen(modpath) + 1) < PATH_MAX)
-	    strcat(modpath,"/");
-	if((strlen(modpath) + strlen(flavor->name)) < PATH_MAX)
-	    strcat(modpath, flavor->name);
-	if((strlen(modpath) + 1) < PATH_MAX)
-	    strcat(modpath,"/");
-	if((strlen(modpath) + strlen(mod_name)) < PATH_MAX)
-	    strcat(modpath,mod_name);
-	if((strlen(modpath) + strlen(flavor->mod_ext)) < PATH_MAX)
-	    strcat(modpath, flavor->mod_ext);
+	strcat(modpath,"/");
+	strcat(modpath, flavor->name);
+	strcat(modpath,"/");
+	strcat(modpath,mod_name);
+	strcat(modpath, flavor->mod_ext);
     }
     const char **caps = get_caps(modpath);
 


### PR DESCRIPTION
Was a unexpected knock on from 187f851 in fixing potential buffer
overruns etc detected by coverity scan

Also tidied halcmd_main buffer length to locally defined 200
(albeit this turned out not to be connected to the problem)

Signed-off-by: Mick <arceye@mgware.co.uk>