### PR TITLE
Compiler warning fixes

### DIFF
--- a/src/hal/components/delayline.c
+++ b/src/hal/components/delayline.c
@@ -214,6 +214,7 @@ static void write_sample_to_ring(void *arg, long period)
 		case HAL_U64:
 		    set_u64_value(hd->pins_out[j], get_u64_value(hd->pins_in[j]));
 		    break;
+		case HAL_TYPE_MAX:
 		case HAL_TYPE_UNSPECIFIED:
 		    // an error - should fail loudly TBD
 		    ;
@@ -252,6 +253,7 @@ static void write_sample_to_ring(void *arg, long period)
 	    case HAL_U64:
 		set_u64_value(&s->value[j], get_u64_value(hd->pins_in[j]));
 		break;
+	    case HAL_TYPE_MAX:
 	    case HAL_TYPE_UNSPECIFIED:
 		// an error - should fail loudly TBD
 		;
@@ -294,6 +296,7 @@ static inline void apply(const sample_t *s, const hal_delayline_t *hd)
 	case HAL_U64:
 	    set_u64_value(hd->pins_out[i], get_u64_value(&s->value[i]));
 	    break;
+	case HAL_TYPE_MAX:
 	case HAL_TYPE_UNSPECIFIED:
 	    // an error - should fail loudly TBD
 	    ;
@@ -479,6 +482,13 @@ static int export_delayline(int n)
 	case HAL_S32:
 	    str_type = "s32";
 	    break;
+	case HAL_S64:
+	    str_type = "s64";
+	    break;
+	case HAL_U64:
+	    str_type = "u64";
+	    break;
+	case HAL_TYPE_MAX:
 	case HAL_TYPE_UNSPECIFIED:
 	    // do nothing
 	    break;

--- a/src/hal/cython/machinekit/hal_component.pyx
+++ b/src/hal/cython/machinekit/hal_component.pyx
@@ -8,7 +8,7 @@ cdef class Component(HALObject):
     cdef dict _itemdict
     cdef int _handle
 
-    def __cinit__(self, name, mode=TYPE_USER, int userarg1=0, int userarg2=0,
+    def __cinit__(self, char *name, mode=TYPE_USER, int userarg1=0, int userarg2=0,
                   wrap=False, noexit=False, lock=True):
         global _comps
         hal_required()
@@ -16,7 +16,7 @@ cdef class Component(HALObject):
         with HALMutexIf(lock):
             self._cc = NULL
             if not wrap:
-                self._o.comp = halg_xinitf(0, mode, userarg1, userarg2, NULL, NULL, name)
+                self._o.comp = halg_xinitf(0, mode, userarg1, userarg2, NULL, NULL, "%s", name)
                 if self._o.comp == NULL:
                     raise RuntimeError("Failed to create component '%s': - %s" %
                                        (name, hal_lasterror()))

--- a/src/hal/cython/machinekit/hal_pin.pyx
+++ b/src/hal/cython/machinekit/hal_pin.pyx
@@ -12,6 +12,8 @@ def describe_hal_dir(haldir):
 cdef class _Pin(HALObject):
 
     def __cinit__(self, *args,  init=None, eps=0, wrap=True, lock=True):
+        cdef bytes c_bytes
+        cdef char *c_name
         hal_required()
 
         # _Pin() has slightly different calling conventions due to
@@ -39,9 +41,11 @@ cdef class _Pin(HALObject):
                     raise RuntimeError("pin %s : epsilon"
                                        " index out of range" % (name, eps))
 
+                c_bytes = name.encode()
+                c_name = c_bytes
                 self._o.pin = halg_pin_newf(0,  t, dir,
                                             NULL, #v2 # <void **>(self._storage),
-                                            (<Component>comp).id,name,)
+                                            (<Component>comp).id, "%s", c_name)
                 if self._o.pin == NULL:
                     raise RuntimeError("Fail to create pin %s:"
                                        " %d %s" % (name, _halerrno, hal_lasterror()))

--- a/src/hal/cython/machinekit/hal_priv.pxd
+++ b/src/hal/cython/machinekit/hal_priv.pxd
@@ -181,7 +181,7 @@ cdef extern from "hal_priv.h":
                              const int dir,
                              void **data_ptr_addr,
                              const int owner_id,
-                             const char *name)
+                             const char *name, ...)
 
     # accessors
     hal_sig_t *signal_of(const hal_pin_t *pin)

--- a/src/hal/cython/machinekit/rtapi.pyx
+++ b/src/hal/cython/machinekit/rtapi.pyx
@@ -105,8 +105,9 @@ cdef class RTAPILogger:
         self._tag = tag
 
     def write(self,line):
-        l = line.rstrip(" \t\f\v\n\r")
-        rtapi_print_msg(self._level, l)
+        cdef bytes py_bytes = line.rstrip(" \t\f\v\n\r").encode()
+        cdef char *c_string = py_bytes
+        rtapi_print_msg(self._level, "%s", c_string)
 
     def flush(self):
         pass

--- a/src/hal/drivers/serport.comp
+++ b/src/hal/drivers/serport.comp
@@ -105,7 +105,7 @@ FUNCTION(read) {
     pin_9_in_not = (i & RI) == RI;
 
     pin_1_in = (i & DCD) == 0;
-    pin_1_in_not = !(i & DCD) == DCD;
+    pin_1_in_not = (i & DCD) == DCD;
 
     pin_6_in = (i & DSR) == 0;
     pin_6_in_not = (i & DSR) == DSR;

--- a/src/hal/lib/halmodule.cc
+++ b/src/hal/lib/halmodule.cc
@@ -43,6 +43,8 @@ union paramunion {
     hal_bit_t b;
     hal_u32_t u32;
     hal_s32_t s32;
+    hal_u64_t u64;
+    hal_s64_t s64;
     hal_float_t f;
 };
 
@@ -51,6 +53,8 @@ union pinunion {
     hal_bit_t *b;
     hal_u32_t *u32;
     hal_s32_t *s32;
+    hal_u64_t *u64;
+    hal_s64_t *s64;
     hal_float_t *f;
 };
 
@@ -273,7 +277,10 @@ static PyObject *pyhal_read_common(halitem *item) {
             case HAL_BIT: return PyBool_FromLong(*(item->u->pin.b));
             case HAL_U32: return PyLong_FromUnsignedLong(*(item->u->pin.u32));
             case HAL_S32: return PyInt_FromLong(*(item->u->pin.s32));
+            case HAL_U64: return PyLong_FromUnsignedLong(*(item->u->pin.u64));
+            case HAL_S64: return PyInt_FromLong(*(item->u->pin.s64));
             case HAL_FLOAT: return PyFloat_FromDouble(*(item->u->pin.f));
+            case HAL_TYPE_MAX: /* fallthrough */ ;
             case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
         }
     } else {
@@ -281,7 +288,10 @@ static PyObject *pyhal_read_common(halitem *item) {
             case HAL_BIT: return PyBool_FromLong(item->u->param.b);
             case HAL_U32: return PyLong_FromUnsignedLong(item->u->param.u32);
             case HAL_S32: return PyInt_FromLong(item->u->param.s32);
+            case HAL_U64: return PyLong_FromUnsignedLong(item->u->param.u64);
+            case HAL_S64: return PyInt_FromLong(item->u->param.s64);
             case HAL_FLOAT: return PyFloat_FromDouble(item->u->param.f);
+            case HAL_TYPE_MAX: /* fallthrough */ ;
             case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
         }
     }

--- a/src/rtapi/rtapi_pci.c
+++ b/src/rtapi/rtapi_pci.c
@@ -618,7 +618,7 @@ void __iomem *pci_ioremap_bar(struct pci_dev *dev, int bar)
 	return mmio;
 }
 
-inline void iounmap(volatile void __iomem *addr)
+void iounmap(volatile void __iomem *addr)
 {
 	unsigned int i;
 

--- a/src/rtapi/rtapi_pci.h
+++ b/src/rtapi/rtapi_pci.h
@@ -104,7 +104,7 @@ int pci_disable_device(struct pci_dev *dev);
           pci_resource_start((dev), (bar)) + 1))
 
 void __iomem *pci_ioremap_bar(struct pci_dev *pdev, int bar);
-inline void iounmap(volatile void __iomem *addr);
+void iounmap(volatile void __iomem *addr);
 
 static inline const char *pci_name(const struct pci_dev *pdev)
 {


### PR DESCRIPTION
Another set of compiler warning fixes:

@ArcEye The inline keyword in the `iounmap` function is useless since GCC requires inline function to be defined and declared in the same translation unit. See <https://gcc.gnu.org/gcc-5/porting_to.html>

Please also take a close look at `halmodule.cc`