### PR TITLE
Haltalk bind fix

### DIFF
--- a/src/hal/lib/hal_misc.c
+++ b/src/hal/lib/hal_misc.c
@@ -47,10 +47,15 @@ int halpr_pin_count(const char *name)
     if (comp == 0)
 	HALFAIL_RC(ENOENT, "no such comp: '%s'", name);
 
-    foreach_args_t args =  {
-	.type = HAL_PIN,
-	.owning_comp = ho_id(comp),
-    };
+    foreach_args_t args =  {};
+    args.type = HAL_PIN;
+    if (comp->type == TYPE_REMOTE) {
+        args.owner_id = ho_id(comp);
+    }
+    else {
+        args.owning_comp = ho_id(comp);
+    }
+
     return halg_foreach(0, &args, NULL);
 }
 

--- a/src/hal/lib/hal_object.c
+++ b/src/hal/lib/hal_object.c
@@ -296,6 +296,7 @@ static int halg_foreach_from(bool use_hal_mutex,
 	    // 4. by owning comp (directly-legacy case, or indirectly -
 	    // for pins, params and functs owned by an instance).
 	    // see comments near the foreach_args definition in hal_object.h.
+	    // ATTENTION: this operation may be computation intensive!
 	    if (args->owning_comp) {
 		hal_comp_t *oc = halpr_find_owning_comp(hh_get_owner_id(hh));
 		if (oc == NULL)

--- a/src/hal/lib/halpb.cc
+++ b/src/hal/lib/halpb.cc
@@ -65,7 +65,12 @@ halpr_describe_component(hal_comp_t *comp, machinetalk::Component *pbcomp)
     pbcomp->set_userarg2(comp->userarg2);
 
     foreach_args_t args = {};
-    args.owning_comp = ho_id(comp);
+    if (comp->type == TYPE_REMOTE) {
+        args.owner_id = ho_id(comp);
+    }
+    else {
+        args.owning_comp = ho_id(comp);
+    }
     args.user_ptr1 = (void *)pbcomp;
     halg_foreach(0, &args, pbadd_owned);
     return 0;


### PR DESCRIPTION
Fix for https://github.com/machinekit/machinekit/issues/1187

Please review this patch carefully. I'm not 100 percent sure if looking for the *owner_id* is correct in all cases where `halpr_pin_count` and `halpr_describe_component` might be called.