### PR TITLE
Fix use of untested zframe_t pointers in haltalk

### DIFF
--- a/src/machinetalk/lib/pbutil.cc
+++ b/src/machinetalk/lib/pbutil.cc
@@ -64,9 +64,13 @@ send_pbcontainer(zmsg_t *dest, machinetalk::Container &c, void *socket)
 	goto DONE;
     }
 
-    for (size_t i = 0; i < nsize; ++i)
-    {
+    for (size_t i = 0; i < nsize; ++i){
         zframe_t *f = zmsg_pop (dest); 
+	if(f == NULL){                          
+	    syslog_async(LOG_ERR, "send_pbcontainer(): NULL zframe_t 'f' passed");
+	    retval = -1;
+	    goto DONE;
+	    }
         if (zframe_size(f)) {
             retval = zframe_send (&f, socket, ZMQ_MORE);
             if (retval) {

--- a/src/rtapi/rtapi_app.cc
+++ b/src/rtapi/rtapi_app.cc
@@ -862,6 +862,11 @@ static int rtapi_request(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
     zframe_t *request_frame  = zmsg_pop (r);
     static bool force_exit = false;
 
+    if(request_frame == NULL){
+	rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_request(): NULL zframe_t 'request_frame' passed");
+	return -1;
+	}
+
     machinetalk::Container pbreq, pbreply;
 
     if (!pbreq.ParseFromArray(zframe_data(request_frame),
@@ -1057,6 +1062,11 @@ static int rtapi_request(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
 
     size_t reply_size = pbreply.ByteSize();
     zframe_t *reply = zframe_new (NULL, reply_size);
+    if(reply == NULL){
+	rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_request(): NULL zframe_t 'reply' passed");
+	return -1;
+	}
+
     if (!pbreply.SerializeWithCachedSizesToArray(zframe_data (reply))) {
 	zframe_destroy(&reply);
 	rtapi_print_msg(RTAPI_MSG_ERR,


### PR DESCRIPTION
Arises from Issue #1197, where program is crashed , 
by a call to zframe_size(zframe_t *ptr) with a NULL pointer,
which triggers a failed assert()within zmq, which should never arise.

Signed-off-by: Mick <arceye@mgware.co.uk>