### PR TITLE
Revert "Deprecate send container string dest"

### DIFF
--- a/src/emc/rs274ngc/previewmodule.cc
+++ b/src/emc/rs274ngc/previewmodule.cc
@@ -60,12 +60,10 @@ static void publish_istat(machinetalk::InterpreterStateType state)
     if (state ^ last_state) {
 	istat.set_type(machinetalk::MT_INTERP_STAT);
 	istat.set_interp_state(state);
-	istat.set_interp_name("preview");
-	zmsg_t *istat_topic_msg = zmsg_new();
-	zmsg_pushstr(istat_topic_msg, istat_topic);
+    istat.set_interp_name("preview");
 
 	// NB: this will also istat.Clear()
-	retval = send_pbcontainer(istat_topic_msg, istat, z_status);
+	retval = send_pbcontainer(istat_topic, istat, z_status);
 	assert(retval == 0);
 
 	last_state = state; // change tracking
@@ -78,14 +76,12 @@ static void send_preview(const char *client, bool flush = false)
 {
     int retval;
     n_messages++;
-    zmsg_t *client_msg = zmsg_new();
-    zmsg_pushstr(client_msg, client);
 
     if ((output.preview_size() > batch_limit) || flush) {
 	n_containers++;
 	n_bytes += output.ByteSize();
 	output.set_type(machinetalk::MT_PREVIEW);
-	retval = send_pbcontainer(client_msg, output, z_preview);
+	retval = send_pbcontainer(client, output, z_preview);
 	assert(retval == 0);
     }
 }

--- a/src/machinetalk/haltalk/haltalk_command.cc
+++ b/src/machinetalk/haltalk/haltalk_command.cc
@@ -72,6 +72,7 @@ handle_command_input(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
         dispatch_request(self, msg, poller->socket);
     }
     zframe_destroy(&f);
+    zmsg_destroy(&msg);
 
     return retval;
 }

--- a/src/machinetalk/haltalk/haltalk_group.cc
+++ b/src/machinetalk/haltalk/haltalk_group.cc
@@ -117,9 +117,7 @@ handle_group_input(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
 		     g != self->groups.end(); g++) {
 		    note_printf(self->tx, "    %s", g->first.c_str());
 		}
-		zmsg_t *topic_msg = zmsg_new();
-		zmsg_pushstr(topic_msg, topic);
-		int retval = send_pbcontainer(topic_msg, self->tx,
+		int retval = send_pbcontainer(topic, self->tx,
 					      self->mksock[SVC_HALGROUP].socket);
 		assert(retval == 0);
 	    }
@@ -305,9 +303,7 @@ group_report_cb(int phase, hal_compiled_group_t *cgroup,
 	break;
 
     case REPORT_END: // finalize & send
-	zmsg_t *groupname_msg = zmsg_new();
-        zmsg_pushstr(groupname_msg, ho_name(cgroup->group));
-	retval = send_pbcontainer(groupname_msg, self->tx,
+	retval = send_pbcontainer(ho_name(cgroup->group), self->tx,
 				  self->mksock[SVC_HALGROUP].socket);
 	assert(retval == 0);
 
@@ -337,9 +333,7 @@ int ping_groups(htself_t *self)
 {
     for (groupmap_iterator g = self->groups.begin(); g != self->groups.end(); g++) {
 	self->tx.set_type(machinetalk::MT_PING);
-	zmsg_t *groupname_msg = zmsg_new();
-        zmsg_pushstr(groupname_msg, g->first.c_str());
-	int retval = send_pbcontainer(groupname_msg, self->tx,
+	int retval = send_pbcontainer(g->first.c_str(), self->tx,
 				      self->mksock[SVC_HALGROUP].socket);
 	assert(retval == 0);
     }

--- a/src/machinetalk/haltalk/haltalk_introspect.cc
+++ b/src/machinetalk/haltalk/haltalk_introspect.cc
@@ -66,15 +66,13 @@ describe_group(htself_t *self,
 	       void *socket)
 {
     WITH_HAL_MUTEX();
-    zmsg_t *from_msg = zmsg_new();
-    zmsg_pushstr(from_msg, from.c_str());
     int ret = halg_object2pb(0, &self->tx, group, HAL_GROUP, 0);
     if (ret != 1)  {
 	self->tx.set_type(machinetalk::MT_HALRCOMP_ERROR);
 	note_printf(self->tx, "no such group: '%s'", group);
-	return send_pbcontainer(from_msg, self->tx, socket);
+	return send_pbcontainer(from, self->tx, socket);
     }
-    return send_pbcontainer(from_msg, self->tx, socket);
+    return send_pbcontainer(from, self->tx, socket);
 }
 
 
@@ -86,15 +84,13 @@ describe_comp(htself_t *self,
 	      void *socket)
 {
     WITH_HAL_MUTEX();
-    zmsg_t *from_msg = zmsg_new();
-    zmsg_pushstr(from_msg, from.c_str());
     int ret = halg_object2pb(0, &self->tx, comp, HAL_COMPONENT, 0);
     if (ret != 1)  {
 	self->tx.set_type(machinetalk::MT_HALRCOMP_ERROR);
 	note_printf(self->tx, "no such component: '%s'", comp);
-	return send_pbcontainer(from_msg, self->tx, socket);
+	return send_pbcontainer(from, self->tx, socket);
     }
-    return send_pbcontainer(from_msg, self->tx, socket);
+    return send_pbcontainer(from, self->tx, socket);
 }
 
 // add protocol parameters the subscriber might want to know about

--- a/src/machinetalk/haltalk/haltalk_rcomp.cc
+++ b/src/machinetalk/haltalk/haltalk_rcomp.cc
@@ -63,8 +63,6 @@ handle_rcomp_input(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
     char *data = (char *) zframe_data(f);
     assert(data);
     char *topic = data + 1;
-	zmsg_t *topic_msg = zmsg_new();
-	zmsg_pushstr(topic_msg, topic);
 
     switch (*data) {
 
@@ -81,7 +79,7 @@ handle_rcomp_input(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
         // not found, publish an error message on this topic
         self->tx.set_type(machinetalk::MT_HALRCOMP_ERROR);
         note_printf(self->tx, "component '%s' does not exist", topic);
-        retval = send_pbcontainer(topic_msg, self->tx, self->mksock[SVC_HALRCOMP].socket);
+        retval = send_pbcontainer(topic, self->tx, self->mksock[SVC_HALRCOMP].socket);
         assert(retval == 0);
 
         } else {
@@ -313,11 +311,11 @@ comp_report_cb(const int phase,
     break;
 
     case REPORT_END: // finalize & send
-	zmsg_t *compname_msg = zmsg_new();
-        zmsg_pushstr(compname_msg, ho_name(cc->comp));
-	retval = send_pbcontainer(compname_msg, self->tx, self->mksock[SVC_HALRCOMP].socket);
-	assert(retval == 0);
-	break;
+    retval = send_pbcontainer(ho_name(cc->comp),
+                  self->tx,
+                  self->mksock[SVC_HALRCOMP].socket);
+    assert(retval == 0);
+    break;
     }
     return 0;
 }
@@ -352,13 +350,11 @@ add_pins_to_items(const int phase,
 int ping_comps(htself_t *self)
 {
     for (compmap_iterator c = self->rcomps.begin();
-	 c != self->rcomps.end(); c++) {
-	self->tx.set_type(machinetalk::MT_PING);
-	zmsg_t *compname_msg = zmsg_new();
-	zmsg_pushstr(compname_msg, c->first.c_str());
-	int retval = send_pbcontainer(compname_msg, self->tx,
-				      self->mksock[SVC_HALRCOMP].socket);
-	assert(retval == 0);
+     c != self->rcomps.end(); c++) {
+    self->tx.set_type(machinetalk::MT_PING);
+    int retval = send_pbcontainer(c->first.c_str(), self->tx,
+                      self->mksock[SVC_HALRCOMP].socket);
+    assert(retval == 0);
     }
     return 0;
 }

--- a/src/machinetalk/include/pbutil.hh
+++ b/src/machinetalk/include/pbutil.hh
@@ -29,6 +29,7 @@ typedef ::google::protobuf::RepeatedPtrField< ::std::string> pbstringarray_t;
 // send a protobuf - encoded Container message
 // optionally prepend destination field
 // log any failure to RTAPI
+int send_pbcontainer(const std::string &dest, machinetalk::Container &c, void *socket);
 int send_pbcontainer(zmsg_t *dest, machinetalk::Container &c, void *socket);
 
 // add an printf-formatted string to the 'note' repeated string in a


### PR DESCRIPTION
Reverts machinekit/machinekit#1201

Use throws undefined symbol error, suggesting that instances of the old syntax call remain in the code.
```ImportError: /usr/lib/python2.7/dist-packages/preview.x86_64-linux-gnu.so: undefined symbol: _Z16send_pbcontainerRKSsRN11machinetalk9ContainerEPv```