### PR TITLE
Fix current ini file detection by gremlin_view

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -290,6 +290,9 @@ fi
 if [ ! -n "$INIFILE" ] ; then
     # still nothing specified, exit
     exit 0
+else
+    # make it easier for gremlin_view to get the active ini file
+    export INIFILE
 fi
 
 # delete directories from path, save name only


### PR DESCRIPTION
Recently used above in project and found that it failed.
pgrep was failing to detect the inifile name from the running linuxcncsvr.

An errant sed operation had changed it to 'machinekitsvr', but even
when this was corrected, pgrep still errored thus

```
Traceback (most recent call last):
  File "/usr/src/machinekit/bin/gremlin_view", line 3, in <module>
    gremlin_view.standalone_gremlin_view()
  File "/usr/src/machinekit/lib/python/gremlin_view.py", line 597, in standalone_gremlin_view
    ,yoffset=yoffset
  File "/usr/src/machinekit/lib/python/gremlin_view.py", line 157, in __init__
    if ini_setup():
  File "/usr/src/machinekit/lib/python/gremlin_view.py", line 108, in ini_setup
    ini_filename = get_linuxcnc_ini_file()
  File "/usr/src/machinekit/lib/python/gremlin_view.py", line 135, in get_linuxcnc_ini_file
    ans = p.split()[p.split().index('-ini')+1]
ValueError: '-ini' is not in list
```

Amended linuxcnc script to export the inifile name to the environment as INIFILE

Amended gremlin_view to search env for INIFILE and it works

Added ability to offset the display window with a screen for repeatable placement.

Signed-off-by: Mick <arceye@mgware.co.uk>