### PR TITLE
Add drawbotkins kinematic module

### DIFF
--- a/configs/sim/axis/README
+++ b/configs/sim/axis/README
@@ -6,6 +6,7 @@ axis.ini          basic demo (in)
 axis_9axis.ini    9 axes
 axis_foam         foam cutter
 axis_mm.ini       basic demo (mm)
+axis_mm_drawbot   demo that module loads and allows homing - do not use to run gcode yet
 canterp           libcanterp.so
 gantry.ini        gantry demo
 lathe.ini         lathe demo

--- a/configs/sim/axis/axis_mm_drawbot.ini
+++ b/configs/sim/axis/axis_mm_drawbot.ini
@@ -1,0 +1,224 @@
+# EMC controller parameters for a simulated machine.
+
+# General note: Comments can either be preceded with a # or ; - either is
+# acceptable, although # is in keeping with most linux config files.
+
+# General section -------------------------------------------------------------
+[EMC]
+
+# Version of this INI file
+VERSION =               $Revision$
+
+# Name of machine, for use with display, etc.
+MACHINE =               Machinekit-Drawbotkins-SIM-AXIS
+
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+# DEBUG =               0x7FFFFFFF
+DEBUG = 0
+
+# Sections for display options ------------------------------------------------
+[DISPLAY]
+
+# Name of display program, e.g., xemc
+DISPLAY =             axis
+
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.100
+
+# Path to help file
+HELP_FILE =             doc/help.txt
+
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.2
+MAX_SPINDLE_OVERRIDE =  1.0
+# Prefix to be used
+PROGRAM_PREFIX = ../../nc_files/
+
+# Introductory graphic
+INTRO_GRAPHIC = machinekit.gif
+INTRO_TIME = 5
+
+EDITOR = gedit
+
+INCREMENTS = 1 mm, .01 in, .1mm, 1 mil, .1 mil, 1/8000 in
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+
+# Task controller section -----------------------------------------------------
+[TASK]
+
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.001
+
+# Part program interpreter section --------------------------------------------
+[RS274NGC]
+
+# File containing interpreter variables
+PARAMETER_FILE = sim_mm.var
+
+# Motion control section ------------------------------------------------------
+[EMCMOT]
+
+EMCMOT =              motmod
+
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+
+# Interval between tries to emcmot, in seconds
+COMM_WAIT =             0.010
+
+# if both BASE_PERIOD and SERVO_PERIOD are unset or 0, motion will not create any threads.
+# in this case, threads need to be created explicitly by 'newthread'
+# see HALFILE=newthread and [HAL]SERVO_PERIOD below
+
+# BASE_PERIOD is unused in this configuration but specified in core_sim.hal
+BASE_PERIOD  =               0
+# Servo task period, in nano-seconds
+SERVO_PERIOD =               0
+
+# Hardware Abstraction Layer section --------------------------------------------------
+[HAL]
+
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+#
+
+# used in configs/common/newthread.hal
+# Servo task period, in nano-seconds
+SERVO_PERIOD =               1000000
+
+
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+HALFILE = newthread.hal
+HALFILE = core_sim_drawbot.hal
+HALFILE = sim_spindle_encoder.hal
+HALFILE = axis_manualtoolchange.hal
+HALFILE = simulated_home.hal
+
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =                    save neta
+
+# Single file that is executed after the GUI has started.  Only supported by
+# AXIS at this time (only AXIS creates a HAL component of its own)
+#POSTGUI_HALFILE = test_postgui.hal
+
+HALUI = halui
+
+# Trajectory planner section --------------------------------------------------
+[TRAJ]
+
+AXES =                  3
+COORDINATES =           X Y Z
+HOME =                  0 0 0
+LINEAR_UNITS =          mm
+ANGULAR_UNITS =         degree
+CYCLE_TIME =            0.010
+DEFAULT_VELOCITY =      30.48
+MAX_VELOCITY =          53.34
+DEFAULT_ACCELERATION =  508
+MAX_ACCELERATION =      508
+POSITION_FILE = position_mm.txt
+ARC_BLEND_ENABLE =      1
+ARC_BLEND_FALLBACK_ENABLE = 1
+ARC_BLEND_OPTIMIZATION_DEPTH = 50
+#Use this setting for no smoothing (for debugging and stress-testing)
+ARC_BLEND_SMOOTHING_THRESHOLD = .75
+#Use this setting for "normal" smoothing, i.e. if we blend over more than 40% of a segment
+#ARC_BLEND_SMOOTHING_THRESHOLD = 0.40
+
+# Axes sections ---------------------------------------------------------------
+
+# First axis
+[AXIS_0]
+
+TYPE =                          LINEAR
+HOME =                          0.000
+MAX_VELOCITY =                  30.48
+MAX_ACCELERATION =              508
+BACKLASH = 0.000
+INPUT_SCALE =                   157.48
+OUTPUT_SCALE = 1.000
+MIN_LIMIT =                     -254
+MAX_LIMIT =                     254
+FERROR = 1.27
+MIN_FERROR = .254
+HOME_OFFSET =                    0.0
+HOME_SEARCH_VEL =                127
+HOME_LATCH_VEL =                 25.4
+HOME_USE_INDEX =                 NO
+HOME_IGNORE_LIMITS =             NO
+HOME_SEQUENCE = 1
+HOME_IS_SHARED = 1
+
+# Second axis
+[AXIS_1]
+
+TYPE =                          LINEAR
+HOME =                          0.000
+MAX_VELOCITY =                  30.48
+MAX_ACCELERATION =              508
+BACKLASH = 0.000
+INPUT_SCALE =                   157.48
+OUTPUT_SCALE = 1.000
+MIN_LIMIT =                     -254
+MAX_LIMIT =                     254
+FERROR = 1.27
+MIN_FERROR = .254
+HOME_OFFSET =                    0.0
+HOME_SEARCH_VEL =                127
+HOME_LATCH_VEL =                 25.4
+HOME_USE_INDEX =                 NO
+HOME_IGNORE_LIMITS =             NO
+HOME_SEQUENCE = 1
+
+# Third axis
+[AXIS_2]
+
+TYPE =                          LINEAR
+HOME =                          0.0
+MAX_VELOCITY =                  30.48
+MAX_ACCELERATION =              508
+BACKLASH = 0.000
+INPUT_SCALE =                   157.48
+OUTPUT_SCALE = 1.000
+MIN_LIMIT =                     -50.8
+MAX_LIMIT =                     101.6
+FERROR = 1.27
+MIN_FERROR = .254
+HOME_OFFSET =                    25.4
+HOME_SEARCH_VEL =                127
+HOME_LATCH_VEL =                 25.4
+HOME_USE_INDEX =                 NO
+HOME_IGNORE_LIMITS =             NO
+HOME_SEQUENCE = 0
+HOME_IS_SHARED = 1
+
+# section for main IO controller parameters -----------------------------------
+[EMCIO]
+
+# Name of IO controller program, e.g., io
+EMCIO = 		io
+
+# cycle time, in seconds
+CYCLE_TIME =    0.100
+
+# tool table file
+TOOL_TABLE = sim_mm.tbl
+TOOL_CHANGE_POSITION = 0 0 50.8

--- a/configs/sim/axis/core_sim_drawbot.hal
+++ b/configs/sim/axis/core_sim_drawbot.hal
@@ -1,0 +1,53 @@
+# core HAL config file for simulation
+
+# first load all the RT modules that will be needed
+# kinematics
+loadrt drawbotkins
+# trajectory planner
+loadrt tp
+# motion controller, get name and thread periods from ini file
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES kins=drawbotkins tp=tp
+# load 6 differentiators (for velocity and accel signals
+loadrt ddt names=ddt_x,ddt_xv,ddt_y,ddt_yv,ddt_z,ddt_zv
+# load additional blocks
+loadrt hypot names=vel_xy,vel_xyz
+
+# add motion controller functions to servo thread
+addf motion-command-handler servo-thread
+addf motion-controller servo-thread
+# link the differentiator functions into the code
+addf ddt_x servo-thread
+addf ddt_xv servo-thread
+addf ddt_y servo-thread
+addf ddt_yv servo-thread
+addf ddt_z servo-thread
+addf ddt_zv servo-thread
+addf vel_xy servo-thread
+addf vel_xyz servo-thread
+
+# create HAL signals for position commands from motion module
+# loop position commands back to motion module feedback
+net Xpos axis.0.motor-pos-cmd => axis.0.motor-pos-fb ddt_x.in
+net Ypos axis.1.motor-pos-cmd => axis.1.motor-pos-fb ddt_y.in
+net Zpos axis.2.motor-pos-cmd => axis.2.motor-pos-fb ddt_z.in
+
+# send the position commands thru differentiators to
+# generate velocity and accel signals
+net Xvel ddt_x.out => ddt_xv.in vel_xy.in0
+net Xacc <= ddt_xv.out
+net Yvel ddt_y.out => ddt_yv.in vel_xy.in1
+net Yacc <= ddt_yv.out
+net Zvel ddt_z.out => ddt_zv.in vel_xyz.in0
+net Zacc <= ddt_zv.out
+
+# Cartesian 2- and 3-axis velocities
+net XYvel vel_xy.out => vel_xyz.in1
+net XYZvel <= vel_xyz.out
+
+# estop loopback
+net estop-loop iocontrol.0.user-enable-out iocontrol.0.emc-enable-in
+
+# create signals for tool loading loopback
+net tool-prep-loop iocontrol.0.tool-prepare iocontrol.0.tool-prepared
+net tool-change-loop iocontrol.0.tool-change iocontrol.0.tool-changed
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -1570,6 +1570,11 @@ genserkins-objs := emc/kinematics/genserkins.o
 genserkins-objs += libnml/posemath/gomath.o
 genserkins-objs += libnml/posemath/sincos.o $(MATHSTUB)
 
+obj-m += drawbotkins.o
+drawbotkins-objs := emc/kinematics/drawbotkins.o
+drawbotkins-objs += libnml/posemath/gomath.o
+drawbotkins-objs += libnml/posemath/sincos.o $(MATHSTUB)
+
 obj-m += pumakins.o
 pumakins-objs := emc/kinematics/pumakins.o
 pumakins-objs += libnml/posemath/_posemath.o
@@ -1873,6 +1878,7 @@ $(RTLIBDIR)/tripodkins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(tripodkins-objs))
 $(RTLIBDIR)/lineardeltakins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(lineardeltakins-objs))
 $(RTLIBDIR)/genhexkins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(genhexkins-objs))
 $(RTLIBDIR)/genserkins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(genserkins-objs))
+$(RTLIBDIR)/drawbotkins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(drawbotkins-objs))
 $(RTLIBDIR)/pumakins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(pumakins-objs))
 $(RTLIBDIR)/scarakins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(scarakins-objs))
 $(RTLIBDIR)/hal_gm$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hal_gm-objs))

--- a/src/emc/kinematics/Submakefile
+++ b/src/emc/kinematics/Submakefile
@@ -4,6 +4,11 @@ GENSERKINSSRCS := \
 	emc/kinematics/genserkins.c
 USERSRCS += $(GENSERKINSSRCS)
 
+DRAWBOTKINSSRCS := \
+	emc/kinematics/drawbotkins.c
+USERSRCS += $(DRAWBOTKINSSRCS)
+
+
 DELTAMODULESRCS := emc/kinematics/lineardeltakins.cc
 PYSRCS += $(DELTAMODULESRCS)
 $(call TOOBJS, $(DELTAMODULESRCS)): CFLAGS += -x c++ -Wno-declaration-after-statement
@@ -21,6 +26,15 @@ PYTARGETS += $(DELTAMODULE)
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CC) $(LDFLAGS) -o $@ $^
 TARGETS += ../bin/genserkins
+
+../bin/drawbotkins: $(call TOOBJS, $(GENSERKINSSRCS)) \
+	../lib/liblinuxcnchal.so \
+	../lib/libposemath.so \
+	../lib/librtapi_math.so.0
+	$(ECHO) Linking $(notdir $@)
+	$(Q)$(CC) $(LDFLAGS) -o $@ $^
+TARGETS += ../bin/drawbotkins
+
 
 ../include/%.h: ./emc/kinematics/%.h
 	cp $^ $@

--- a/src/emc/kinematics/drawbotkins.c
+++ b/src/emc/kinematics/drawbotkins.c
@@ -1,0 +1,395 @@
+/*
+# This file is part of The Telus Spark Drawbot Code.  It free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# 
+# The project was designed and constructed by David Bynoe - http://www.davidbynoe.com
+# This software authored by Kevin Loney - http://brainsinjars.com/
+#
+# Copyright (C) 2013 David Bynoe
+
+# Amended for vtable use with Machinekit ArcEye 02052017
+*/
+
+#include <float.h>
+
+#include "kinematics.h"
+#include "rtapi.h"
+#include "rtapi_app.h"
+#include "rtapi_math.h"
+#include "posemath.h"
+#include "hal.h"
+
+#define VTVERSION VTKINEMATICS_VERSION1
+
+struct hal_joint_t {
+  hal_bit_t *homed;
+  hal_bit_t *home_switch;
+  hal_bit_t *home;
+
+  hal_float_t *jog;
+  hal_bit_t *position;
+
+  hal_bit_t started, tripped;
+};
+
+struct haldata {
+  hal_float_t *radius;  // radius of the drawing surface
+  hal_float_t *limit;   // distance from the carriage pivot to the magnet
+
+  // Dimensions of the drawbot
+  hal_float_t *dimx;
+  hal_float_t *dimy;
+  hal_float_t *dimz;
+
+  // Size of the drawing bed
+  hal_float_t *limx;
+  hal_float_t *limy;
+
+  hal_bit_t *homing;
+  hal_bit_t *occupied;
+  hal_bit_t *headless;
+
+  struct hal_joint_t joint[4];
+} *haldata = 0;
+
+int kinematicsForward(const double *joints, EmcPose *pos, const KINEMATICS_FORWARD_FLAGS *fflags, KINEMATICS_INVERSE_FLAGS *iflags);
+KINEMATICS_TYPE kinematicsType(void);
+int kinematicsHome(EmcPose *world, double *joints, KINEMATICS_FORWARD_FLAGS *fflags, KINEMATICS_INVERSE_FLAGS *iflags);
+int kinematicsInverse(const EmcPose *pos, double *joints, const KINEMATICS_INVERSE_FLAGS *iflags,KINEMATICS_FORWARD_FLAGS *fflags);
+
+#ifdef LEGACY_KINS_API
+EXPORT_SYMBOL(kinematicsType);
+EXPORT_SYMBOL(kinematicsForward);
+EXPORT_SYMBOL(kinematicsInverse);
+EXPORT_SYMBOL(kinematicsHome);
+#endif
+
+static vtkins_t vtk = {
+    .kinematicsForward = kinematicsForward,
+    .kinematicsInverse  = kinematicsInverse,
+    .kinematicsHome = kinematicsHome,
+    .kinematicsType = kinematicsType
+};
+
+
+static int comp_id, vtable_id;
+static const char *name = "drawbotkins";
+
+int export_joint(int, struct hal_joint_t*);
+
+void drawbot_home(void*, long);
+void drawbot_home_x(struct hal_joint_t*);
+void drawbot_home_y(struct hal_joint_t*);
+void drawbot_home_z(struct hal_joint_t*);
+void drawbot_home_a(struct hal_joint_t*);
+
+//int comp_id;
+
+int rtapi_app_main(void) {
+  int status = 0;
+
+comp_id = hal_init(name);
+    if(comp_id > 0) {
+        vtable_id = hal_export_vtable(name, VTVERSION, &vtk, comp_id);
+
+        if (vtable_id < 0) {
+           rtapi_print_msg(RTAPI_MSG_ERR,
+               "%s: ERROR: hal_export_vtable(%s,%d,%p) failed: %d\n",
+               name, name, VTVERSION, &vtk, vtable_id );
+           return -ENOENT;
+        }
+    else
+        return comp_id;
+    }
+
+  do {
+    haldata = hal_malloc(sizeof(struct haldata));
+    if(!haldata) {
+      status = -1;
+      break;
+    }
+
+    // Maximum draw area extents
+    if((status = hal_pin_float_new("drawbot.extent.radius", HAL_IN, &(haldata->radius), comp_id)) < 0) break;
+    if((status = hal_pin_float_new("drawbot.extent.limit", HAL_IN, &(haldata->limit), comp_id)) < 0) break;
+
+    if((status = hal_pin_float_new("drawbot.extent.dim-x", HAL_IN, &(haldata->dimx), comp_id)) < 0) break;
+    if((status = hal_pin_float_new("drawbot.extent.dim-y", HAL_IN, &(haldata->dimy), comp_id)) < 0) break;
+    if((status = hal_pin_float_new("drawbot.extent.dim-z", HAL_IN, &(haldata->dimz), comp_id)) < 0) break;
+
+    if((status = hal_pin_float_new("drawbot.extent.lim-x", HAL_IN, &(haldata->limx), comp_id)) < 0) break;
+    if((status = hal_pin_float_new("drawbot.extent.lim-y", HAL_IN, &(haldata->limy), comp_id)) < 0) break;
+
+    if((status = hal_pin_bit_new("drawbot.is-homing", HAL_IN, &(haldata->homing), comp_id)) < 0) break;
+    if((status = hal_pin_bit_new("drawbot.is-occupied", HAL_IN, &(haldata->occupied), comp_id)) < 0) break;
+    if((status = hal_pin_bit_new("drawbot.is-headless", HAL_IN, &(haldata->headless), comp_id)) < 0) break;
+
+    if((status = export_joint(0, &(haldata->joint[0]))) < 0) break;
+    if((status = export_joint(1, &(haldata->joint[1]))) < 0) break;
+    if((status = export_joint(2, &(haldata->joint[2]))) < 0) break;
+    if((status = export_joint(3, &(haldata->joint[3]))) < 0) break;
+
+    if((status = hal_export_funct("drawbot.home", drawbot_home, NULL, 1, 0, comp_id)) < 0) break;
+  } while(0);
+
+  if(status) {
+    hal_exit(comp_id);
+  } else {
+    hal_ready(comp_id);
+  }
+  return status;
+}
+
+void rtapi_app_exit(void)
+{
+    int retval = hal_remove_vtable(vtable_id);
+    if (retval < 0)
+       rtapi_print_msg(RTAPI_MSG_ERR, "%s: vtable %d not removed rc=%d\n",
+               name, vtable_id, retval);
+    hal_exit(comp_id);
+}
+
+int export_joint(int num, struct hal_joint_t *joint) {
+  int status = 0;
+
+  do {
+    joint->started = 0;
+    joint->tripped = 0;
+
+    if((status = hal_pin_bit_newf(HAL_IN, &(joint->homed), comp_id, "drawbot.%d.is-homed", num)) < 0) break;
+    if((status = hal_pin_bit_newf(HAL_IN, &(joint->home_switch), comp_id, "drawbot.%d.home-sw", num)) < 0) break;
+    if((status = hal_pin_bit_newf(HAL_OUT, &(joint->home), comp_id, "drawbot.%d.home", num)) < 0) break;
+
+    if((status = hal_pin_float_newf(HAL_OUT, &(joint->jog), comp_id, "drawbot.%d.jog", num)) < 0) break;
+    if((status = hal_pin_bit_newf(HAL_IN, &(joint->position), comp_id, "drawbot.%d.in-position", num)) < 0) break;
+  } while(0);
+
+  return status;
+}
+
+double fmin(const double x, const double y) {
+  return x < y ? x : y;
+}
+
+double fmax(const double x, const double y) {
+  return x > y ? x : y;
+}
+
+double fclamp(double v, double lo, double hi) {
+    return fmax(fmin(v, hi), lo);
+}
+
+int kinematicsForward(const double *joints,
+              EmcPose *pos,
+              const KINEMATICS_FORWARD_FLAGS *fflags,
+              KINEMATICS_INVERSE_FLAGS *iflags)
+{
+  return -1;
+}
+
+int kinematicsInverse(const EmcPose *pos,
+              double *joints,
+              const KINEMATICS_INVERSE_FLAGS *iflags,
+              KINEMATICS_FORWARD_FLAGS *fflags)
+{
+  const double rt2 = rtapi_sqrt(2.0);
+
+  int idx, sx = -1, sy = 1, nx, ny;
+  double dx, dy, dz, px, py, pz;
+
+  double limx = fmin(*(haldata->dimx) - 2.0 * *(haldata->limit), *(haldata->limx));
+  double limy = fmin(*(haldata->dimy) - 2.0 * *(haldata->limit), *(haldata->limy));
+  double limz = *(haldata->dimz);
+
+  px = fclamp(pos->tran.x, -0.5 * limx, 0.5 * limx);
+  py = fclamp(pos->tran.y, -0.5 * limy, 0.5 * limy);
+  pz = fclamp(pos->tran.z, 0.0, limz);
+
+  //rtapi_print("(%d %d %d) -> ", (int)(1000*pos->tran.x), (int)(1000*pos->tran.y), (int)(1000*pos->tran.z));
+  //rtapi_print("(%d %d %d)\n", (int)(1000*px), (int)(1000*py), (int)(1000*pz));
+
+    // TODO: This needs to compensate for the carriage tipping the further it gets from the center
+  for(idx = 0; idx < 4; ++idx) {
+    double tower_x = 0.5 * sx * *(haldata->dimx);
+    double tower_y = 0.5 * sy * *(haldata->dimy);
+
+    double carriage_x = px + rt2 * sx * *(haldata->radius);
+    double carriage_y = py + rt2 * sy * *(haldata->radius);
+
+    dx = carriage_x - tower_x;
+    dy = carriage_y - tower_y;
+    dz = limz - pz;
+
+    joints[idx] = rtapi_sqrt(dx*dx + dy*dy + dz*dz) - *(haldata->limit);
+    if(joints[idx] < 0.0) {
+      joints[idx] = 0.0;
+    }
+
+    nx = sy; ny = -sx;
+    sx = nx; sy = ny;
+  }
+
+  for(; idx < 9; ++idx) {
+    joints[idx] = 0.0;
+  }
+
+  return 0;
+}
+
+int kinematicsHome(EmcPose *world,
+           double *joints,
+           KINEMATICS_FORWARD_FLAGS *fflags,
+           KINEMATICS_INVERSE_FLAGS *iflags)
+{
+  int idx;
+  double hypot = rtapi_sqrt(*(haldata->dimx) * *(haldata->dimx) + *(haldata->dimy) * *(haldata->dimy));
+
+  *fflags = 0;
+  *iflags = 0;
+
+  for(idx = 0; idx < 9; ++ idx) {
+    joints[idx] = idx < 4 ? 0.5 * hypot - *(haldata->radius) : 0.0;
+  }
+
+  // Because of the way the ZERO_EMC_POSE macro the extra parens are mandatory
+  ZERO_EMC_POSE((*world));
+
+  return 0;
+}
+
+KINEMATICS_TYPE kinematicsType(void) {
+  return KINEMATICS_BOTH;
+}
+
+int in_position(struct hal_joint_t *joints) {
+  int idx;
+  for(idx = 0; idx < 4; ++idx) {
+    if(!*(joints[idx].position)) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+void halt_motion(struct hal_joint_t *joints) {
+  int idx = 0;
+  for(idx = 0; idx < 4; ++idx) {
+    *(joints[idx].jog) = 0.0;
+  }
+}
+
+void drawbot_home(void *args, long period) {
+  int idx;
+  hal_bit_t homing = 0;
+
+  for(idx = 0; idx < 4; ++idx) {
+    *(haldata->joint[idx].home) = 0;
+  }
+  if(*(haldata->occupied)) {
+    return;
+  }
+
+  if(*(haldata->homing)) {
+    // Home order X -> Z -> Y -> A
+    if(*(haldata->headless)) {
+      for(idx = 0; idx < 4; ++idx) {
+    if(*(haldata->joint[idx].homed)) {
+      continue;
+    }
+    if(*(haldata->joint[idx].position)) {
+      *(haldata->joint[idx].home) = 1;
+    } else {
+      *(haldata->joint[idx].jog) = 0.0;
+    }
+      }
+    } else {
+      if(!*(haldata->joint[0].homed)) {
+    drawbot_home_x(haldata->joint);
+      } else if(!*(haldata->joint[2].homed)) {
+    drawbot_home_z(haldata->joint);
+      } else if(!*(haldata->joint[1].homed)) {
+    drawbot_home_y(haldata->joint);
+      } else if(!*(haldata->joint[3].homed)) {
+    drawbot_home_a(haldata->joint);
+      }
+    }
+  } else {
+    for(idx = 0; idx < 4; ++idx) {
+      *(haldata->joint[idx].jog) = 0.0;
+      haldata->joint[idx].started = 0;
+      haldata->joint[idx].tripped = 0;
+    }
+  }
+}
+
+void drawbot_home_x(struct hal_joint_t *joint) {
+  if(joint[0].tripped) {
+    if(*(joint[0].position)) {
+      *(joint[0].home) = 1;
+    }
+  } else if(*(joint[0].home_switch)) {
+    joint[0].tripped = 1;
+    halt_motion(joint);
+  } else if(!joint[0].started) {
+    joint[0].started = 1;
+
+    *(joint[0].jog) = -1.0;
+    *(joint[2].jog) = *(joint[2].homed) ? 1.0 : 0.62;
+  }
+}
+
+void drawbot_home_y(struct hal_joint_t *joint) {
+  if(joint[1].tripped) {
+    if(*(joint[1].position)) {
+      *(joint[1].home) = 1;
+    }
+  } else if(*(joint[1].home_switch)) {
+    joint[1].tripped = 1;
+    halt_motion(joint);
+  } else if(!joint[1].started) {
+    joint[1].started = 1;
+    *(joint[1].jog) = -1.0;
+    *(joint[2].jog) = 1.0;
+    *(joint[3].jog) = 0.41;
+  }
+}
+
+void drawbot_home_z(struct hal_joint_t *joint) {
+  if(joint[2].tripped) {
+    if(*(joint[2].position)) {
+      *(joint[2].home) = 1;
+    }
+  } else if(*(joint[2].home_switch)) {
+    joint[2].tripped = 1;
+    halt_motion(joint);
+  } else if(!joint[2].started) {
+    joint[2].started = 1;
+    *(joint[0].jog) = *(joint[0].homed) ? 1.0 : 0.62;
+    *(joint[2].jog) = -1.0;
+  }
+}
+
+void drawbot_home_a(struct hal_joint_t *joint) {
+  if(joint[3].tripped) {
+    if(in_position(joint)) {
+      *(joint[3].home) = 1;
+    }
+  } else if(*(joint[3].home_switch)) {
+    joint[3].tripped = 1;
+    halt_motion(joint);
+  } else if(!joint[3].started) {
+    joint[3].started;
+    *(joint[1].jog) = 1.0;
+    *(joint[3].jog) = -1.0;
+  }
+}

--- a/src/emc/kinematics/kinematics.h
+++ b/src/emc/kinematics/kinematics.h
@@ -129,7 +129,7 @@ typedef KINEMATICS_TYPE  (*vtk_kinematicsType_t)(void);
 typedef struct {
     vtk_kinematicsForward_t kinematicsForward;
     vtk_kinematicsInverse_t kinematicsInverse;
-    //    vtk_kinematicsHome_t    kinematicsHome; // unused
+    vtk_kinematicsHome_t    kinematicsHome; // used by drawbotkins
     vtk_kinematicsType_t    kinematicsType;
 } vtkins_t;
 


### PR DESCRIPTION
Add demo axis sim which allows loading and homing, needs work beyond that

Amend kinematics vtable struct to allow for `vtk_kinematicsHome_t`
which is used in drawbotkins, but unused eleswhere.

Added necessary vtable code to original drawbotkins.c to enable it to
function with updated machinekit kinematics code.

Signed-off-by: Mick <arceye@mgware.co.uk>