### PR TITLE
Add commandline switch to gremlin_view, to specify it is a child window.

### DIFF
--- a/lib/python/gremlin_view.py
+++ b/lib/python/gremlin_view.py
@@ -89,6 +89,7 @@ g_delta_pixels    = 10
 g_move_delay_secs = 0.2
 g_progname        = os.path.basename(sys.argv[0])
 g_verbose         = False
+g_childwindow	  = False
 
 LOCALEDIR = linuxcnc.SHARE + "/locale"
 gettext.install("linuxcnc", localedir=LOCALEDIR, unicode=True)
@@ -267,7 +268,7 @@ class GremlinView():
             xoffset = '0'
         if (yoffset is None):
             yoffset = '0'
-            
+
         # err from gremlin if omit this
         self.halg.width  = width
         self.halg.height = height
@@ -340,8 +341,11 @@ class GremlinView():
         self.ct +=1
         self.halg.poll()
 
-        if self.parent is None:
-            self.topwindow.deiconify()
+	# prevent it forcing to the top when embedded into another window
+	# that gremlin_view knows nothing about
+	if g_childwindow == False:
+	    if self.parent is None:
+        	self.topwindow.deiconify()
 
         if (self.parent is not None) and (self.ct) == 2:
             # not sure why delay is needed for reparenting
@@ -528,11 +532,13 @@ class GremlinView():
 #-----------------------------------------------------------------------------
 # Standalone (and demo) usage:
 
-# x and yoffset added to allow placement in a screen from 
+# x and yoffset added to allow placement in a screen from QtAxis
 # ArcEye 2015
 
 def standalone_gremlin_view():
     global ini_file
+    global g_childwindow
+
     import getopt
     #---------------------------------------
     def usage(msg=None):
@@ -545,6 +551,7 @@ Options: [-h | --help]
          [-H | --height] height
          [-X | --xoffset] xoffset
          [-Y | --yoffset] yoffset
+         [-c | --childwindow] is a child window
          [-f | --file]   glade_file
 
 Note: linuxcnc must be running on same machine
@@ -559,15 +566,17 @@ Note: linuxcnc must be running on same machine
     xoffset     = None
     yoffset     = None
     vbose       = False
+
     try:
         options,remainder = getopt.getopt(sys.argv[1:]
-                                         , 'f:hH:vW:X:Y:'
+                                         , 'f:hH:vW:X:Y:c'
                                          , ['file='
                                            ,'help'
                                            ,'width='
                                            ,'height='
                                            ,'xoffset='
                                            ,'yoffset='
+					   ,'childwindow'
                                            ]
                                          )
     except getopt.GetoptError,msg:
@@ -580,10 +589,15 @@ Note: linuxcnc must be running on same machine
         if opt in ('-v','--verbose'):
             g_verbose = True
             continue
+	if opt in ('-c','--childwindow'): 
+	    g_childwindow = True
+	    continue
+
         if opt in ('-W','--width' ): width=arg
         if opt in ('-H','--height'): height=arg
         if opt in ('-X','--xoffset'): xoffset=arg
         if opt in ('-Y','--yoffset'): yoffset=arg
+
         if opt in ('-f','--file'):   glade_file=arg
     if remainder:
         usage('unknown argument:%s' % remainder)


### PR DESCRIPTION
Allows gremlin_view to be X embedded within another window after creation
as a standalone.

The switch -c | --childwindow prevents its top window being deiconified
at every poll, a mechanism which has the effect of raising the window
and keeping it on top.

This is very undesirable if embedding within a tab widget for example,
where switching tabs should render gremlin_view hidden

Signed-off-by: Mick <arceye@mgware.co.uk>