### PR TITLE
Added Packet UART 8 bit filter option

### DIFF
--- a/src/hal/components/mesa_pktgyro_test.comp
+++ b/src/hal/components/mesa_pktgyro_test.comp
@@ -148,6 +148,8 @@ EXTRA_SETUP(){ // the names parameters are passed in 'prefix'. You just have to 
 	 /* http://freeby.mesanet.com/regmap
 	  The PktUARTrMode register is used for setting and checking the PktUARTr's
 	  operation mode, timing, and status
+      Bit  31..30      Unused
+      Bit  29..22      Filter Register
 	  Bit  21	       FrameBuffer has data
 	  Bits 20..16      Frames received
 	  Bits 15..8       InterFrame delay in bit times
@@ -168,7 +170,7 @@ EXTRA_SETUP(){ // the names parameters are passed in 'prefix'. You just have to 
 	   Then we read out whatever is in the buffer, send the DISABLE STREAM
 	   datagram and only then set RXEnable bit.
 	*/
-	int retval=hm2_pktuart_setup(name, BAUDRATE , 0x0ff20,  0x007f00,1,1);
+	int retval=hm2_pktuart_setup(name, BAUDRATE , 0x0ff20,  0x007f00, -1, 1, 1);
 	if (retval<0)
 	{
 	    rtapi_print_msg(1, "PktUART for gyro setup problem: %d\n", retval);
@@ -228,7 +230,7 @@ EXTRA_SETUP(){ // the names parameters are passed in 'prefix'. You just have to 
 	}
 
 	// Now we set RxEnable bit and clear Rx/Tx registers
-	retval=hm2_pktuart_setup(name, BAUDRATE , 0x0ff20,  0x007f08,1,1);
+	retval=hm2_pktuart_setup(name, BAUDRATE , 0x0ff20,  0x007f08, -1, 1, 1);
 	if (retval<0)
 	{
 	 rtapi_print_msg(1, "PktUART for gyro setup problem: %d\n", retval);

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -1401,7 +1401,7 @@ void hm2_pktuart_write(hostmot2_t *hm2);
 void hm2_pktuart_force_write(hostmot2_t *hm2); // ??
 void hm2_pktuart_prepare_tram_write(hostmot2_t *hm2, long period); //??
 void hm2_pktuart_process_tram_read(hostmot2_t *hm2, long period);  //  ??
-int hm2_pktuart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode, int txclear, int rxclear);
+int hm2_pktuart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode, int filter_reg, int txclear, int rxclear);
 int hm2_pktuart_send(char *name,  unsigned char data[], u8 *num_frames, u16 frame_sizes[]);
 int hm2_pktuart_read(char *name, unsigned char data[],  u8 *num_frames, u16 *max_frame_length, u16 frame_sizes[]);
 

--- a/src/hal/drivers/mesa-hostmot2/pktuart.c
+++ b/src/hal/drivers/mesa-hostmot2/pktuart.c
@@ -229,9 +229,12 @@ int hm2_pktuart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode, int fil
     */
     if (rx_mode >= 0)  {
         // if filter_reg==-1, we calculate the FilterReg value as floor( (0.5*BitTime*ClockLow - 1) )
-        if (filter_reg==-1)
+        if (filter_reg==-1) {
             filter_reg = rtapi_floor(0.5*inst->clock_freq/inst->bitrate - 1.0);
-        buff = ( ((u32)rx_mode) & 0xffff ) | ((filter_reg & 0xff) << 22) ; // =0011 1111 1100 0000 1111 1111 1111 1111
+            if (filter_reg > 255)
+                filter_reg = 255;
+        }
+        buff = ( ((u32)rx_mode) & 0xffff ) | (( ((u32)filter_reg) & 0xff ) << 22) ; 
         r += hm2->llio->write(hm2->llio, inst->rx_mode_addr, &buff, sizeof(u32));
     }
 

--- a/src/hal/drivers/mesa-hostmot2/pktuart.c
+++ b/src/hal/drivers/mesa-hostmot2/pktuart.c
@@ -158,7 +158,8 @@ fail0:
 EXPORT_SYMBOL_GPL(hm2_pktuart_setup);
 // use -1 for tx_mode and rx_mode to leave the mode unchanged
 // use 1 for txclear or rxclear to issue a clear command for Tx or Rx registers
-int hm2_pktuart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode, int txclear, int rxclear){
+// use -1 for filter_reg to calculate a standard filter value or for backwards compatibilty
+int hm2_pktuart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode, int filter_reg, int txclear, int rxclear){
     hostmot2_t *hm2;
     hm2_pktuart_instance_t *inst = 0;
     u32 buff;
@@ -212,6 +213,8 @@ int hm2_pktuart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode, int txc
     /* http://freeby.mesanet.com/regmap
       The PktUARTrMode register is used for setting and checking the PktUARTr's 
       operation mode, timing, and status
+      Bit  31..30      Unused
+      Bit  29..22      Filter Register
       Bit  21          FrameBuffer has data 
       Bits 20..16      Frames received
       Bits 15..8       InterFrame delay in bit times
@@ -224,8 +227,11 @@ int hm2_pktuart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode, int txc
       Bit  1           Overrun error (no stop bit when expected) (sticky)
       Bit  0           False Start bit error (sticky)
     */
-    if (rx_mode >= 0) {
-        buff = ((u32)rx_mode) & 0xffff;
+    if (rx_mode >= 0)  {
+        // if filter_reg==-1, we calculate the FilterReg value as floor( (0.5*BitTime*ClockLow - 1) )
+        if (filter_reg==-1)
+            filter_reg = rtapi_floor(0.5*inst->clock_freq/inst->bitrate - 1.0);
+        buff = ( ((u32)rx_mode) & 0xffff ) | ((filter_reg & 0xff) << 22) ; // =0011 1111 1100 0000 1111 1111 1111 1111
         r += hm2->llio->write(hm2->llio, inst->rx_mode_addr, &buff, sizeof(u32));
     }
 


### PR DESCRIPTION
-- this change is backwards compatible to older MESA VHDL

`int hm2_pktuart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode, int filter_reg, int txclear, int rxclear)` : `filter_reg` is either  -1 or an 8 bit value calculated by the user.

In case of `filter_reg=-1` a FilterReg value is calculated according to `floor((0.5*BitTime*ClockLow - 1))` .
An expert user can pass his own 8 bit filter value by using `filter_reg` argument. 

See also https://forum.linuxcnc.org/27-driver-boards/32811-mesa-digital-filters 
and https://github.com/machinekit/machinekit/issues/877#issuecomment-302886330