### PR TITLE
hal_pru_generic: add minvel pin

### DIFF
--- a/src/hal/drivers/hal_pru_generic/hal_pru_generic.h
+++ b/src/hal/drivers/hal_pru_generic/hal_pru_generic.h
@@ -115,6 +115,7 @@ typedef struct {
             hal_float_t     *position_scale;
             hal_float_t     *maxvel;
             hal_float_t     *maxaccel;
+            hal_float_t     *minvel;
 
             hal_u32_t       *steplen;
             hal_u32_t       *stepspace;


### PR DESCRIPTION
This patch fixes the PRU DIR "pin hunting" problem by adding a minimum velocity pin.

This patch is sponsored by [Nectar 3D](http://nectar3d.com/).