### PR TITLE
python/fdm: make motion loading more modular

### DIFF
--- a/lib/python/fdm/config/motion.py
+++ b/lib/python/fdm/config/motion.py
@@ -3,16 +3,18 @@ from machinekit import rtapi as rt
 from machinekit import config as c
 
 
-def setup_motion(kinematics='trivkins'):
+def setup_motion(kinematics='trivkins', tp='tp', num_aio=50, num_dio=21):
     rt.loadrt(kinematics)
-    rt.loadrt('tp')
+    rt.loadrt(tp)
 
     # motion controller, get name and thread periods from ini file
     rt.loadrt(c.find('EMCMOT', 'EMCMOT'),
               servo_period_nsec=c.find('EMCMOT', 'SERVO_PERIOD'),
               num_joints=c.find('TRAJ', 'AXES'),
-              num_aio=51,
-              num_dio=21)
+              num_aio=num_aio,
+              num_dio=num_dio,
+              tp=tp,
+              kins=kinematics)
 
 
 def setup_temperature_io(name):


### PR DESCRIPTION
Fixes problems with Delta-type printers and allows changing the motion pin counts for custom configurations.

Sponsored by [Nectar 3D](http://nectar3d.com/)