### PR TITLE
Add hardware revision a22042 to comparisons

### DIFF
--- a/src/hal/drivers/cpuinfo.c
+++ b/src/hal/drivers/cpuinfo.c
@@ -70,7 +70,8 @@ int get_rpi_revision(void)
             (strcmp(revision, "1000006") == 0 ))
       return 2;
    else if ((strcmp(revision, "a01041") == 0) ||
-            (strcmp(revision, "a21041") == 0 ))
+            (strcmp(revision, "a21041") == 0) ||
+	    (strcmp(revision, "a22042") == 0))
       return 3;
    else if ((strcmp(revision, "a22082") == 0) ||
 	    (strcmp(revision, "a02082") == 0))


### PR DESCRIPTION
Is a hardware revision correct for Pi 2 Model B v1.2 but is not recognised and returns rev 5, with fatal error resulting.

Fixes Issue #1223