### PR TITLE
lib/fdm: use STEPGEN_MIN_VEL

### DIFF
--- a/configs/ARM/BeagleBone/Fabrikator-Mini-CRAMPS/fabrikator-mini.ini
+++ b/configs/ARM/BeagleBone/Fabrikator-Mini-CRAMPS/fabrikator-mini.ini
@@ -189,6 +189,7 @@ MAX_VELOCITY =       200.0
 MAX_ACCELERATION =   3000.0
 # Set Stepgen max 20% higher than the axis
 STEPGEN_MAX_VEL =    240.0
+STEPGEN_MIN_VEL =    0.001
 STEPGEN_MAX_ACC =    3600.0
 
 BACKLASH =           0.000
@@ -222,19 +223,6 @@ DIRHOLD    =              200
 STEPLEN    =              1000
 STEPSPACE  =              1000
 
-# PID tuning params for
-# workaround for PRU dir pin problems
-DEADBAND =              0
-P =                     90
-I =                     0
-D =                     0
-FF0 =                   0
-FF1 =                   1
-FF2 =                   0.00005
-BIAS =                  0
-MAX_OUTPUT =            0
-MAX_ERROR =             0.0005
-
 INCREMENTS = 1 10
 
 
@@ -245,6 +233,7 @@ MAX_VELOCITY =       200.0
 MAX_ACCELERATION =   3000.0
 # Set Stepgen max 20% higher than the axis
 STEPGEN_MAX_VEL =    240.0
+STEPGEN_MIN_VEL =    0.001
 STEPGEN_MAX_ACC =    3600.0
 
 BACKLASH =           0.000
@@ -276,19 +265,6 @@ DIRHOLD    =              200
 STEPLEN    =              1000
 STEPSPACE  =              1000
 
-# PID tuning params for
-# workaround for PRU dir pin problems
-DEADBAND =              0
-P =                     90
-I =                     0
-D =                     0
-FF0 =                   0
-FF1 =                   1
-FF2 =                   0.00005
-BIAS =                  0
-MAX_OUTPUT =            0
-MAX_ERROR =             0.0005
-
 INCREMENTS = 1 10
 
 
@@ -299,6 +275,7 @@ MAX_VELOCITY =      4.0
 MAX_ACCELERATION =  30.0
 # Set Stepgen max 20% higher than the axis
 STEPGEN_MAX_VEL =    4.8
+STEPGEN_MIN_VEL =    0.001
 STEPGEN_MAX_ACC =    36.0
 
 BACKLASH =           0.000
@@ -328,19 +305,6 @@ DIRSETUP   =              200
 DIRHOLD    =              200
 STEPLEN    =              1000
 STEPSPACE  =              1000
-
-# PID tuning params for
-# workaround for PRU dir pin problems
-DEADBAND =              0
-P =                     90
-I =                     0
-D =                     0
-FF0 =                   0
-FF1 =                   1
-FF2 =                   0.00005
-BIAS =                  0
-MAX_OUTPUT =            0
-MAX_ERROR =             0.0005
 
 INCREMENTS = 0.01 0.1 1
 
@@ -378,6 +342,7 @@ MAX_VELOCITY = 32.0
 MAX_ACCELERATION = 3000.0
 # Set Stepgen max 20% higher than the axis
 STEPGEN_MAX_VEL = 37.0
+STEPGEN_MIN_VEL = 0.001
 STEPGEN_MAX_ACC = 3600.0
 
 #SCALE = -486.15 -- Artifex

--- a/configs/ARM/BeagleBone/MendelMax-CRAMPS/CRAMPS.ini
+++ b/configs/ARM/BeagleBone/MendelMax-CRAMPS/CRAMPS.ini
@@ -189,6 +189,7 @@ MAX_VELOCITY =       200.0
 MAX_ACCELERATION =   3000.0
 # Set Stepgen max 20% higher than the axis
 STEPGEN_MAX_VEL =    240.0
+STEPGEN_MIN_VEL =    0.001
 STEPGEN_MAX_ACC =    3600.0
 
 BACKLASH =           0.000
@@ -222,19 +223,6 @@ DIRHOLD    =              200
 STEPLEN    =              1000
 STEPSPACE  =              1000
 
-# PID tuning params for
-# workaround for PRU dir pin problems
-DEADBAND =              0
-P =                     90
-I =                     0
-D =                     0
-FF0 =                   0
-FF1 =                   1
-FF2 =                   0.00005
-BIAS =                  0
-MAX_OUTPUT =            0
-MAX_ERROR =             0.0005
-
 # Jog increments
 INCREMENTS = 1 10
 
@@ -246,6 +234,7 @@ MAX_VELOCITY =       200.0
 MAX_ACCELERATION =   3000.0
 # Set Stepgen max 20% higher than the axis
 STEPGEN_MAX_VEL =    240.0
+STEPGEN_MIN_VEL =    0.001
 STEPGEN_MAX_ACC =    3600.0
 
 BACKLASH =           0.000
@@ -277,20 +266,6 @@ DIRHOLD    =              200
 STEPLEN    =              1000
 STEPSPACE  =              1000
 
-# PID tuning params for
-# workaround for PRU dir pin problems
-DEADBAND =              0
-P =                     90
-I =                     0
-D =                     0
-FF0 =                   0
-FF1 =                   1
-FF2 =                   0.00005
-BIAS =                  0
-MAX_OUTPUT =            0
-MAX_ERROR =             0.0005
-
-
 # Jog increments
 INCREMENTS = 1 10
 
@@ -302,6 +277,7 @@ MAX_VELOCITY =      4.0
 MAX_ACCELERATION =  30.0
 # Set Stepgen max 20% higher than the axis
 STEPGEN_MAX_VEL =    4.8
+STEPGEN_MIN_VEL =    0.001
 STEPGEN_MAX_ACC =    36.0
 
 BACKLASH =           0.000
@@ -332,21 +308,6 @@ DIRSETUP   =              200
 DIRHOLD    =              200
 STEPLEN    =              1000
 STEPSPACE  =              1000
-
-
-# PID tuning params for
-# workaround for PRU dir pin problems
-DEADBAND =              0
-P =                     90
-I =                     0
-D =                     0
-FF0 =                   0
-FF1 =                   1
-FF2 =                   0.00005
-BIAS =                  0
-MAX_OUTPUT =            0
-MAX_ERROR =             0.0005
-
 
 # Jog increments
 INCREMENTS = 0.01 0.1 1
@@ -384,6 +345,7 @@ MAX_VELOCITY = 32.0
 MAX_ACCELERATION = 3000.0
 # Set Stepgen max 20% higher than the axis
 STEPGEN_MAX_VEL = 37.0
+STEPGEN_MIN_VEL = 0.001
 STEPGEN_MAX_ACC = 3600.0
 
 #SCALE = -486.15 -- Artifex

--- a/lib/python/fdm/config/base.py
+++ b/lib/python/fdm/config/base.py
@@ -57,22 +57,7 @@ def usrcomp_watchdog(comps, enableSignal, thread,
 def setup_stepper(stepgenIndex, section, axisIndex=None,
                   stepgenType='hpg.stepgen', gantry=False,
                   gantryJoint=0, velocitySignal=None, thread=None):
-    prufix = not velocitySignal
-    if prufix:
-        pid = 'pid.pru-stepgen-%i' % stepgenIndex
-        pidComp = rt.newinst('pid', pid)
-        hal.addf('%s.do-pid-calcs' % pidComp.name, thread)
-        pidComp.pin('Pgain').set(c.find(section, 'P'))
-        pidComp.pin('Igain').set(c.find(section, 'I'))
-        pidComp.pin('Dgain').set(c.find(section, 'D'))
-        pidComp.pin('bias').set(c.find(section, 'BIAS'))
-        pidComp.pin('FF0').set(c.find(section, 'FF0'))
-        pidComp.pin('FF1').set(c.find(section, 'FF1'))
-        pidComp.pin('FF2').set(c.find(section, 'FF2'))
-        pidComp.pin('deadband').set(c.find(section, 'DEADBAND'))
-        pidComp.pin('maxoutput').set(c.find(section, 'MAX_OUTPUT'))
-        pidComp.pin('maxerror').set(c.find(section, 'MAX_ERROR'))
-        pidComp.pin('error-previous-target').set(True)
+    prufix = bool(c.find(section, 'STEPGEN_MIN_VEL'))
 
     stepgen = '%s.%02i' % (stepgenType, stepgenIndex)
     if axisIndex is not None:
@@ -88,8 +73,6 @@ def setup_stepper(stepgenIndex, section, axisIndex=None,
     if hasMotionAxis:
         enable.link('%s.amp-enable-out' % axis)
     enable.link('%s.enable' % stepgen)
-    if prufix:
-        enable.link('%s.enable' % pid)
 
     # expose timing parameters so we can multiplex them later
     sigBase = 'stepgen-%i' % stepgenIndex
@@ -101,6 +84,8 @@ def setup_stepper(stepgenIndex, section, axisIndex=None,
     maxVel = hal.newsig('%s-max-vel' % sigBase, hal.HAL_FLOAT)
     maxAcc = hal.newsig('%s-max-acc' % sigBase, hal.HAL_FLOAT)
     controlType = hal.newsig('%s-control-type' % sigBase, hal.HAL_BIT)
+    if prufix:
+        minVel = hal.newsig('%s-min-vel' % sigBase, hal.HAL_FLOAT)
 
     hal.Pin('%s.dirsetup' % stepgen).link(dirsetup)
     hal.Pin('%s.dirhold' % stepgen).link(dirhold)
@@ -119,6 +104,9 @@ def setup_stepper(stepgenIndex, section, axisIndex=None,
     hal.Pin('%s.maxaccel' % stepgen).link(maxAcc)
     maxVel.set(c.find(section, 'STEPGEN_MAX_VEL'))
     maxAcc.set(c.find(section, 'STEPGEN_MAX_ACC'))
+    if prufix:
+        hal.Pin('%s.minvel' % stepgen).link(minVel)
+        minVel.set(c.find(section, 'STEPGEN_MIN_VEL'))
 
     hal.Pin('%s.control-type' % stepgen).link(controlType)
 
@@ -128,23 +116,13 @@ def setup_stepper(stepgenIndex, section, axisIndex=None,
             posCmd = hal.newsig('emcmot-%i-pos-cmd' % axisIndex, hal.HAL_FLOAT)
             posCmd.link('%s.motor-pos-cmd' % axis)
             if not gantry:
-                if prufix:
-                    posCmd.link('%s.command' % pid)
-                else:
-                    posCmd.link('%s.position-cmd' % stepgen)
+                posCmd.link('%s.position-cmd' % stepgen)
             else:
                 posCmd.link('gantry.%i.position-cmd' % axisIndex)
-
-            if prufix:
-                velCmd = hal.newsig('emcmot-%i-vel-cmd' % axisIndex, hal.HAL_FLOAT)
-                velCmd.link('%s.joint-vel-cmd' % axis)
-                velCmd.link('%s.command-deriv' % pid)
 
             posFb = hal.newsig('emcmot-%i-pos-fb' % axisIndex, hal.HAL_FLOAT)
             posFb.link('%s.motor-pos-fb' % axis)
             if not gantry:
-                if prufix:
-                    posFb.link('%s.feedback' % pid)
                 posFb.link('%s.position-fb' % stepgen)
             else:
                 posFb.link('gantry.%i.position-fb' % axisIndex)
@@ -152,24 +130,13 @@ def setup_stepper(stepgenIndex, section, axisIndex=None,
         if gantry:  # per joint fb and cmd
             posCmd = hal.newsig('emcmot-%i-%i-pos-cmd' % (axisIndex, gantryJoint), hal.HAL_FLOAT)
             posCmd.link('gantry.%i.joint.%02i.pos-cmd' % (axisIndex, gantryJoint))
-            if prufix:
-                posCmd.link('%s.command' % pid)
-            else:
-                posCmd.link('%s.position-cmd' % stepgen)
+            posCmd.link('%s.position-cmd' % stepgen)
 
             posFb = hal.newsig('emcmot-%i-%i-pos-fb' % (axisIndex, gantryJoint), hal.HAL_FLOAT)
-            if prufix:
-                posFb.link('%s.feedback' % pid)
             posFb.link('%s.position-fb' % stepgen)
             posFb.link('gantry.%i.joint.%02i.pos-fb' % (axisIndex, gantryJoint))
     else:  # velocity control
         hal.net(velocitySignal, '%s.velocity-cmd' % stepgen)
-        controlType.set(1)  # enable velocity control
-
-    if prufix:
-        command = hal.newsig('stepgen-%i-command' % stepgenIndex, hal.HAL_FLOAT)
-        command.link('%s.output' % pid)
-        command.link('%s.velocity-cmd' % stepgen)
         controlType.set(1)  # enable velocity control
 
     # limits


### PR DESCRIPTION
To make use of the new fix for PRU pin hunting we look for `STEPGEN_MIN_VEL` in the INI config. The PR makes the code easier to read and removes any errors potentially introduced by the additional PID loop and its parameters.

Thanks again to [Nectar3D](nectar3d.com) for the original patch for the PRU driver.