### PR TITLE
Fix armhf builds so that required elements exist for comp OOT builds.

### DIFF
--- a/.travis/upload_packagecloud.sh
+++ b/.travis/upload_packagecloud.sh
@@ -25,7 +25,7 @@ if [ "${TRAVIS_TEST_RESULT}" -eq 0 ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] \
     # have already been uploaded
     if [ "${FLAV}" == "rt_preempt" ] || [ "${FLAV}" == "xenomai" ]; then
         rm -f ${TRAVIS_BUILD_DIR}/deploy/machinekit_*
-        rm -f ${TRAVIS_BUILD_DIR}/deploy/machinekit-dev*
+#        rm -f ${TRAVIS_BUILD_DIR}/deploy/machinekit-dev* ## no more machinekit-dev packages
     fi
 
     package_cloud push ${repo} ${TRAVIS_BUILD_DIR}/deploy/*deb

--- a/debian/control.in
+++ b/debian/control.in
@@ -20,20 +20,24 @@ Build-Depends: debhelper (>= 6),
     python-pyftpdlib, @BUILD_DEPS@ @TCL_TK_BUILD_DEPS@
 Standards-Version: 2.1.0
 
-Package: machinekit-dev
-Architecture: any
-Depends: make, g++, @TCL_TK_BUILD_DEPS@,
-    ${shlibs:Depends}, ${misc:Depends},
-    machinekit (= ${binary:Version}),
-    yapps2-runtime
-Section: libs
-Description: PC based motion controller for real-time Linux
- Machinekit is the next-generation Enhanced Machine Controller which
- provides motion control for CNC machine tools and robotic
- applications (milling, cutting, routing, etc.).
- .
- This package includes files needed to build new realtime components and
- alternate front-ends for machinekit
+#########################################################################
+## not built any more, components of it are in flavour packages
+##
+#Package: machinekit-dev
+#Architecture: any
+#Depends: make, g++, @TCL_TK_BUILD_DEPS@,
+#    ${shlibs:Depends}, ${misc:Depends},
+#    machinekit (= ${binary:Version}),
+#    yapps2-runtime
+#Section: libs
+#Description: PC based motion controller for real-time Linux
+# Machinekit is the next-generation Enhanced Machine Controller which
+# provides motion control for CNC machine tools and robotic
+# applications (milling, cutting, routing, etc.).
+# .
+# This package includes files needed to build new realtime components and
+# alternate front-ends for machinekit
+#########################################################################
 
 Package: machinekit
 Breaks: linuxcnc

--- a/debian/machinekit-posix.install
+++ b/debian/machinekit-posix.install
@@ -1,3 +1,0 @@
-usr/lib/linuxcnc/posix/*.so
-usr/lib/linuxcnc/ulapi-posix.so
-usr/libexec/linuxcnc/rtapi_app_posix

--- a/debian/machinekit-posix.install.in
+++ b/debian/machinekit-posix.install.in
@@ -1,8 +1,11 @@
+usr/lib/linuxcnc/posix/*.so
+usr/lib/linuxcnc/ulapi-posix.so
+usr/libexec/linuxcnc/rtapi_app_posix
 usr/include/linuxcnc/*.hh
 usr/include/linuxcnc/*.h
-usr/include/linuxcnc/userpci/*.h
 usr/lib/*.a
 usr/lib/*.so
 usr/bin/comp
 usr/share/linuxcnc/Makefile.modinc
 usr/share/linuxcnc/Makefile.inc
+

--- a/debian/machinekit-rt-preempt.install
+++ b/debian/machinekit-rt-preempt.install
@@ -1,3 +1,0 @@
-usr/lib/linuxcnc/rt-preempt/*.so
-usr/lib/linuxcnc/ulapi-rt-preempt.so
-usr/libexec/linuxcnc/rtapi_app_rt-preempt

--- a/debian/machinekit-rt-preempt.install.in
+++ b/debian/machinekit-rt-preempt.install.in
@@ -1,0 +1,11 @@
+usr/lib/linuxcnc/rt-preempt/*.so
+usr/lib/linuxcnc/ulapi-rt-preempt.so
+usr/libexec/linuxcnc/rtapi_app_rt-preempt
+usr/include/linuxcnc/*.hh
+usr/include/linuxcnc/*.h
+usr/lib/*.a
+usr/lib/*.so
+usr/bin/comp
+usr/share/linuxcnc/Makefile.modinc
+usr/share/linuxcnc/Makefile.inc
+

--- a/debian/machinekit-xenomai.install
+++ b/debian/machinekit-xenomai.install
@@ -1,3 +1,0 @@
-usr/lib/linuxcnc/xenomai/*
-usr/lib/linuxcnc/ulapi-xenomai.so
-usr/libexec/linuxcnc/rtapi_app_xenomai

--- a/debian/machinekit-xenomai.install.in
+++ b/debian/machinekit-xenomai.install.in
@@ -1,0 +1,10 @@
+usr/lib/linuxcnc/xenomai/*
+usr/lib/linuxcnc/ulapi-xenomai.so
+usr/libexec/linuxcnc/rtapi_app_xenomai
+usr/include/linuxcnc/*.hh
+usr/include/linuxcnc/*.h
+usr/lib/*.a
+usr/lib/*.so
+usr/bin/comp
+usr/share/linuxcnc/Makefile.modinc
+usr/share/linuxcnc/Makefile.inc

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -134,8 +134,6 @@ ifneq ($(wildcard src/configure src/Makefile.inc),)
 	    share/applications/linuxcnc.desktop \
 	    share/desktop-directories/cnc.directory \
 	    share/menus/CNC.menu \
-	    src/Makefile.inc \
-	    src/Makefile.modinc \
 	    src/aclocal.m4 \
 	    src/config.h \
 	    src/config.h.in \
@@ -145,6 +143,10 @@ ifneq ($(wildcard src/configure src/Makefile.inc),)
 	    src/machinekitcfg.py-tmp \
 	    tcl/linuxcnc.tcl
 	rm -rf src/autom4te.cache etc
+##	    src/Makefile.inc \
+##	    src/Makefile.modinc \
+
+
 endif
 
 #	# Remove package artifacts
@@ -182,11 +184,14 @@ endif
 	cp src/rtapi/shmdrv/limits.d-machinekit.conf \
 	    debian/tmp/etc/security/limits.d/machinekit.conf
 
+	cp debian/machinekit-posix.install.in debian/machinekit-posix.install
+	cp debian/machinekit-rt-preempt.install.in debian/machinekit-rt-preempt.install
+	cp debian/machinekit-xenomai.install.in debian/machinekit-xenomai.install
+
 	if (grep ^USERMODE_PCI=yes src/Makefile.inc -q); then \
-	    cp debian/machinekit-dev.install.in debian/machinekit-dev.install; \
-	else \
-	    grep -v userpci debian/machinekit-dev.install.in \
-		> debian/machinekit-dev.install; \
+	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-posix.install; \
+	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-rt-preempt.install; \
+	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-xenomai.install; \
 	fi
 
 	dh_install --sourcedir=debian/tmp --fail-missing -Xusr/bin/pasm
@@ -213,13 +218,16 @@ binary-arch: build install
 	dh_installdeb
 
 #	# delete files that should be in machinekit-dev package
-	rm -f debian/machinekit/usr/bin/comp
-	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.modinc
-	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.inc
+#	rm -f debian/machinekit/usr/bin/comp
+#	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.modinc
+#	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.inc
 
 	cat debian/machinekit/DEBIAN/shlibs debian/shlibs.pre > \
 	    debian/shlibs.local
-	dh_shlibdeps -l debian/machinekit/usr/lib
+	## ignore missing deps / symbols info for locally built libs
+	## necessary for Stretch builds until packaged libs can be used for czmq and zeromq
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info -l debian/machinekit/usr/lib
+	#dh_shlibdeps -l debian/machinekit/usr/lib
 	dh_gencontrol
 	dh_md5sums
 	dh_builddeb


### PR DESCRIPTION
Out Of Tree builds have been broken for a long time on armhf packages.
Issue #1060 and others refer

The bottom of the problem is that the package machinekit-dev is built
with just posix flavour enabled, so as to avoid time constraints on
builds which otherwise would cause failure.

An unrealised consequence of this is that the file Makefile.inc,
which is pulled in by comp and instcomp, has flavours just set to
posix and the produced component targets posix, even if produced
on a rt-preempt or xenomai kernel.

machinekit-dev is largely an anachronism from linuxcnc days, when
in an effort to make the install as light as possible, all dev
stuff was in a seperate package.

This commit moves the -dev package files into the machinekit-\<flavour\>
package.  This ensures that the Makefile.inc contains settings which
match the targeted flavour.

Currently Debian Stretch will only build Machinekit, with local library
versions of czmq and zeromq, due to backward incompatibility of the new
versions.
This has a knock on in package building on Stretch, which fail dh_shlibdeps
tests unless a switch to ignore missing info is added.
Should be able to be removed once ported to new libs or our own ones produced.

Signed-off-by: Mick <arceye@mgware.co.uk>