### PR TITLE
Fix configure.ac build environment variable `ARCH_CFLAGS`

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -699,6 +699,8 @@ AC_ARG_WITH(platform-zedboard,
 	esac
     ])
 
+AC_SUBST(ARCH_CFLAGS)
+
 if $platform_specified; then
     # Platform was explicitly specified using --with-platform-*;
     # disable anything not explicitly specified


### PR DESCRIPTION
This var was introduced to allow for architecture specific switches
required for some arm boards.

However there was no AC_SUBST() macro exporting the var and recent tests
where I used the var to pass args for cross-building, showed that it was
not being substituted in Makefile.inc.in, so having no effect.

AC_SUBST(ARCH_CFLAGS) inserted and fixes.

Signed-off-by: Mick <arceye@mgware.co.uk>