### PR TITLE
hal: fix race conditions with loadusr

### DIFF
--- a/src/hal/cython/machinekit/hal_loadusr.pyx
+++ b/src/hal/cython/machinekit/hal_loadusr.pyx
@@ -37,7 +37,7 @@ def loadusr(command, wait=False, wait_name=None, wait_timeout=5.0, shell=False, 
         if ret is not None:
             raise RuntimeError(command + ' exited with return code ' + str(ret))
         # check if component exists
-        if (wait_name is not None) and (wait_name in components):
+        if (wait_name is not None) and (wait_name in components) and (components[wait_name].state == COMP_READY):
             return components[wait_name]
         # check for timeout
         if timeout >= wait_timeout:


### PR DESCRIPTION
If we don't wait for HAL components to become ready we may run into race conditions.