### PR TITLE
Fix  overflow into Machinekit package

### DIFF
--- a/debian/control.posix.in
+++ b/debian/control.posix.in
@@ -3,6 +3,7 @@ Package: machinekit-posix
 Architecture: any
 Depends: machinekit (= ${binary:Version}), ${shlibs:Depends}, 
 Provides:  machinekit-rt-threads
+Breaks: machinekit-dev
 Enhances: machinekit
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/debian/control.rt-preempt.in
+++ b/debian/control.rt-preempt.in
@@ -8,6 +8,7 @@ Depends: machinekit (= ${binary:Version}), ${shlibs:Depends},
  linux-image-4.1.19-rt22mah [i386], linux-image-4.1.19-rt22mah [amd64]
 Provides:  machinekit-rt-threads
 Suggests: hostmot2-firmware-all [!armhf]
+Breaks: machinekit-dev
 Enhances: machinekit
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/debian/control.xenomai.in
+++ b/debian/control.xenomai.in
@@ -5,6 +5,7 @@ Depends: machinekit (= ${binary:Version}), ${shlibs:Depends},
 	xenomai-runtime
 Provides:  machinekit-rt-threads
 Recommends: hostmot2-firmware-all [!armhf]
+Breaks: machinekit-dev
 Enhances: machinekit
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -141,11 +141,10 @@ ifneq ($(wildcard src/configure src/Makefile.inc),)
 	    src/config.status \
 	    src/configure \
 	    src/machinekitcfg.py-tmp \
+	    src/Makefile.inc \
+	    src/Makefile.modinc \
 	    tcl/linuxcnc.tcl
 	rm -rf src/autom4te.cache etc
-##	    src/Makefile.inc \
-##	    src/Makefile.modinc \
-
 
 endif
 
@@ -217,10 +216,10 @@ binary-arch: build install
 	dh_makeshlibs
 	dh_installdeb
 
-#	# delete files that should be in machinekit-dev package
-#	rm -f debian/machinekit/usr/bin/comp
-#	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.modinc
-#	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.inc
+#	# delete files that should be in machinekit-<flavor> package
+	rm -f debian/machinekit/usr/bin/comp
+	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.modinc
+	rm -f debian/machinekit/usr/share/linuxcnc/Makefile.inc
 
 	cat debian/machinekit/DEBIAN/shlibs debian/shlibs.pre > \
 	    debian/shlibs.local


### PR DESCRIPTION
Reverse testing commenting out of Makefile.inc Makefile.modinc and comp, to ensure files are deleted before creation of main machinekit package.

Add `Breaks: machinekit-dev` property to all machinekit-{flavour}
packages debian/control files, to prompt upgraders to remove that old package, which conflicts.

Signed-off-by: Mick <arceye@mgware.co.uk>