### PR TITLE
Fix jog increment hot key in Axis

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1372,7 +1372,7 @@ def jogspeed_incremental(dir=1):
     if cursel == "":
         cursel = 0
     else:
-        cursel = int(cursel)
+        cursel = int(cursel[0])
     if dir == 1:
         if cursel > 0:
             # If it was "Continous" just before, then don't change last jog increment!


### PR DESCRIPTION
Pressing 'I' triggers an error because a tuple is used as an
argument to int()

Solution is simply to specify index of [0]

Can't see how this ever worked, maybe no-one used it.

Fixes #1239

Signed-off-by: Mick <arceye@mgware.co.uk>