### PR TITLE
configs/ARM: BeagleBone: use generic iio sysfs path for adc

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/ReadTemp.py
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/ReadTemp.py
@@ -255,7 +255,7 @@ if len(args.adc) != num_chan :
 if len(args.therm) != num_chan :
     raise UserWarning('Incorrect number of thermistors specified!  Expected:' + args.num_chan)
 
-syspath = '/sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/'
+syspath = '/sys/bus/iio/devices/iio:device0/'
 
 FileName = []
 

--- a/configs/ARM/BeagleBone/BeBoPr++/Pepper/setup.bridge.sh
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pepper/setup.bridge.sh
@@ -95,8 +95,8 @@ if [ -z "${ACTIVE}" ] ; then
 
 fi
 
-if [ ! -r /sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/in_voltage5_raw ] ; then
-	echo "Analog input files not found in /sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/" >&2
+if [ ! -r /sys/bus/iio/devices/iio:device0/in_voltage5_raw ] ; then
+	echo "Analog input files not found in /sys/bus/iio/devices/iio:device0/" >&2
 	exit 1;
 fi
 

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/ReadTemp.py
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/ReadTemp.py
@@ -255,7 +255,7 @@ if len(args.adc) != num_chan :
 if len(args.therm) != num_chan :
     raise UserWarning('Incorrect number of thermistors specified!  Expected:' + args.num_chan)
 
-syspath = '/sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/'
+syspath = '/sys/bus/iio/devices/iio:device0/'
 
 FileName = []
 

--- a/configs/ARM/BeagleBone/BeBoPr++/Pololu/setup.bridge.sh
+++ b/configs/ARM/BeagleBone/BeBoPr++/Pololu/setup.bridge.sh
@@ -95,8 +95,8 @@ if [ -z "${ACTIVE}" ] ; then
 
 fi
 
-if [ ! -r /sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/in_voltage5_raw ] ; then
-	echo "Analog input files not found in /sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/" >&2
+if [ ! -r /sys/bus/iio/devices/iio:device0/in_voltage5_raw ] ; then
+	echo "Analog input files not found in /sys/bus/iio/devices/iio:device0/" >&2
 	exit 1;
 fi
 

--- a/configs/ARM/BeagleBone/BeBoPr++/ReadTemp.py
+++ b/configs/ARM/BeagleBone/BeBoPr++/ReadTemp.py
@@ -255,7 +255,7 @@ if len(args.adc) != num_chan :
 if len(args.therm) != num_chan :
     raise UserWarning('Incorrect number of thermistors specified!  Expected:' + args.num_chan)
 
-syspath = '/sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/'
+syspath = '/sys/bus/iio/devices/iio:device0/'
 
 FileName = []
 

--- a/configs/ARM/BeagleBone/BeBoPr++/setup.bridge.sh
+++ b/configs/ARM/BeagleBone/BeBoPr++/setup.bridge.sh
@@ -95,8 +95,8 @@ if [ -z "${ACTIVE}" ] ; then
 
 fi
 
-if [ ! -r /sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/in_voltage5_raw ] ; then
-	echo "Analog input files not found in /sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/" >&2
+if [ ! -r /sys/bus/iio/devices/iio:device0/in_voltage5_raw ] ; then
+	echo "Analog input files not found in /sys/bus/iio/devices/iio:device0/" >&2
 	exit 1;
 fi
 

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/ReadTemp.py
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/ReadTemp.py
@@ -255,7 +255,7 @@ if len(args.adc) != num_chan :
 if len(args.therm) != num_chan :
     raise UserWarning('Incorrect number of thermistors specified!  Expected:' + args.num_chan)
 
-syspath = '/sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/'
+syspath = '/sys/bus/iio/devices/iio:device0/'
 
 FileName = []
 

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/setup.bridge.sh
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/setup.bridge.sh
@@ -87,8 +87,8 @@ else
 	load_cape $DTBO $REV
 fi
 
-if [ ! -r /sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/in_voltage5_raw ] ; then
-	echo "Analog input files not found in /sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/" >&2
+if [ ! -r /sys/bus/iio/devices/iio:device0/in_voltage5_raw ] ; then
+	echo "Analog input files not found in /sys/bus/iio/devices/iio:device0/" >&2
 	exit 1;
 fi
 

--- a/configs/ARM/BeagleBone/BeBoPr/ReadTemp.py
+++ b/configs/ARM/BeagleBone/BeBoPr/ReadTemp.py
@@ -255,7 +255,7 @@ if len(args.adc) != num_chan :
 if len(args.therm) != num_chan :
     raise UserWarning('Incorrect number of thermistors specified!  Expected:' + args.num_chan)
 
-syspath = '/sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/'
+syspath = '/sys/bus/iio/devices/iio:device0/'
 
 FileName = []
 

--- a/configs/ARM/BeagleBone/PocketNC/ReadTemp.py
+++ b/configs/ARM/BeagleBone/PocketNC/ReadTemp.py
@@ -255,7 +255,7 @@ if len(args.adc) != num_chan :
 if len(args.therm) != num_chan :
     raise UserWarning('Incorrect number of thermistors specified!  Expected:' + args.num_chan)
 
-syspath = '/sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/'
+syspath = '/sys/bus/iio/devices/iio:device0/'
 
 FileName = []
 

--- a/configs/ARM/BeagleBone/Replicape/hal_temp_bbb
+++ b/configs/ARM/BeagleBone/Replicape/hal_temp_bbb
@@ -171,7 +171,7 @@ def getHalName(pin):
 
 
 def checkAdcInput(pin):
-    syspath = '/sys/devices/ocp.*/44e0d000.tscadc/tiadc/iio:device0/'
+    syspath = '/sys/bus/iio/devices/iio:device0/'
     tempName = glob.glob(syspath + 'in_voltage' + str(pin.pin) + '_raw')
     pin.filename = tempName[0]
     try:


### PR DESCRIPTION
Daren Schwenke tested with 3.8.x and 4.4.x

https://groups.google.com/d/msg/machinekit/RrNLUo4ASP4/Ye6sNvyYBgAJ

Signed-off-by: Robert Nelson <robertcnelson@gmail.com>
CC: Daren Schwenke <darenschwenke@gmail.com>
CC: Charles Steinkuehler <charles@steinkuehler.net>