### PR TITLE
Dependency changes for Stretch packaging

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -271,8 +271,16 @@ HAVE_KTHREADS_FLAVOR=false
 rm -f machinekit-{rtai,xenomai}-kernel-*.install
 
 # copy base templates into place
-cp control.in control
-echo "debian/control:  copied base template" >&2
+# stretch uses some different packages
+if [[ $DISTRO_CODENAME == "stretch" ]] ; then
+	cp control-stretch.in control
+	echo "debian/control:  copied Stretch base template" >&2
+    else
+	cp control.in control
+	echo "debian/control:  copied base template" >&2
+    fi
+    
+
 cp rules.in rules; chmod +x rules
 echo "debian/rules:  copied base template" >&2
 cp machinekit.install.in machinekit.install

--- a/debian/control-stretch.in
+++ b/debian/control-stretch.in
@@ -1,0 +1,60 @@
+Source: machinekit
+Section: misc
+Priority: extra
+Maintainer: John Morris <john@dovetail-automata.com>
+Build-Depends: debhelper (>= 6),
+    autoconf (>= 2.63), automake, libboost-python-dev, libgl1-mesa-dev,
+    libglu1-mesa-dev, libgtk2.0-dev, libmodbus-dev (>= 3.0), libudev-dev,
+    libncurses-dev, libreadline-dev, libusb-1.0-0-dev, libxmu-dev,
+    libxmu-headers, python (>= 2.6.6-3~), python-dev (>= 2.6.6-3~),
+    cython (>= 0.19), dh-python,
+    pkg-config, psmisc, python-tk, libxaw7-dev, libboost-serialization-dev,
+    zeromq, czmq, libjansson-dev (>= 2.5),
+    libwebsockets-dev (>= 1.2.2), procps,
+    liburiparser-dev, libssl-dev, python-setuptools,
+    uuid-dev, uuid-runtime, libavahi-client-dev,
+    libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
+    python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
+    python-simplejson, libtk-img, libboost-thread-dev,
+    python-pyftpdlib, @BUILD_DEPS@ @TCL_TK_BUILD_DEPS@
+Standards-Version: 2.1.0
+
+#########################################################################
+## not built any more, components of it are in flavour packages
+##
+#Package: machinekit-dev
+#Architecture: any
+#Depends: make, g++, @TCL_TK_BUILD_DEPS@,
+#    ${shlibs:Depends}, ${misc:Depends},
+#    machinekit (= ${binary:Version}),
+#    yapps2-runtime
+#Section: libs
+#Description: PC based motion controller for real-time Linux
+# Machinekit is the next-generation Enhanced Machine Controller which
+# provides motion control for CNC machine tools and robotic
+# applications (milling, cutting, routing, etc.).
+# .
+# This package includes files needed to build new realtime components and
+# alternate front-ends for machinekit
+#########################################################################
+
+Package: machinekit
+Breaks: linuxcnc
+Replaces: linuxcnc
+Architecture: any
+Depends: ${shlibs:Depends}, machinekit-rt-threads, @TCL_TK_DEPS@,
+    @DEPS@ bwidget (>= 1.7), libtk-img (>=1.13),
+    ${python:Depends}, ${misc:Depends},
+    python-tk, python-imaging, python-imaging-tk,
+    python-gnome2, python-glade2,
+    python-numpy, python-gtksourceview2,
+    python-vte, python-xlib, python-gtkglext1, python-configobj,
+    python-protobuf (>= 2.4.1), python-gst-1.0,
+    python-avahi, python-simplejson, python-pyftpdlib,
+    python-pydot, xdot, zeromq, czmq,
+    tclreadline, bc, procps, psmisc,
+    gstreamer1.0-plugins-base
+Description: PC based motion controller for real-time Linux
+ Machinekit is the next-generation Enhanced Machine Controller which
+ provides motion control for CNC machine tools and robotic
+ applications (milling, cutting, routing, etc.).

--- a/debian/extras/etc/ld.so.conf.d/czmq-zeromq.conf
+++ b/debian/extras/etc/ld.so.conf.d/czmq-zeromq.conf
@@ -1,0 +1,2 @@
+# Ensure temp czmq and zeromq libs are found
+/usr/local/lib

--- a/debian/machinekit.install.in
+++ b/debian/machinekit.install.in
@@ -39,3 +39,4 @@ usr/share/applications/*
 usr/share/desktop-directories/cnc.directory
 etc/modprobe.d/linuxcnc.conf
 etc/xdg/menus/applications-merged/cnc.menu
+etc/ld.so.conf.d/czmq-zeromq.conf


### PR DESCRIPTION
Two depended packages have substantially changed their numbering
ie. python-gst0.1 becomes python-gst-1.0
    gstreamer0.1-plugins-base becomes gstreamer1.0-plugins-base

python-zmq depends upon later versions of zmq (libzmq5) so cannot be a dep.

Specify czmq and zeromq to bring in the libs built which use the
previous API.
Add an /etc/ld.so.conf.d/ entry to ensure it caches /usr/local/lib

configure detects distro codename and makes substitutions if
Stretch detected - so will not affect existing builds

Now tested with a from scratch install on amd64 and works

Signed-off-by: Mick <arceye@mgware.co.uk>