### PR TITLE
Restore yapps dependency to machinekit-flavour packages.

### DIFF
--- a/debian/control.posix.in
+++ b/debian/control.posix.in
@@ -1,7 +1,7 @@
 
 Package: machinekit-posix
 Architecture: any
-Depends: machinekit (= ${binary:Version}), ${shlibs:Depends}, 
+Depends: machinekit (= ${binary:Version}), ${shlibs:Depends}, yapps2-runtime
 Provides:  machinekit-rt-threads
 Breaks: machinekit-dev
 Enhances: machinekit

--- a/debian/control.rt-preempt-stretch.in
+++ b/debian/control.rt-preempt-stretch.in
@@ -1,7 +1,7 @@
 
 Package: machinekit-rt-preempt
 Architecture: any
-Depends: machinekit (= ${binary:Version}), ${shlibs:Depends},
+Depends: machinekit (= ${binary:Version}), ${shlibs:Depends}, yapps2-runtime,
 # These Debian-style RT_PREEMPT package names are restricted by
 # architecture; ARM arch SOCs are all incompatible, so this can't be
 # easily done for ARM.

--- a/debian/control.rt-preempt.in
+++ b/debian/control.rt-preempt.in
@@ -1,7 +1,7 @@
 
 Package: machinekit-rt-preempt
 Architecture: any
-Depends: machinekit (= ${binary:Version}), ${shlibs:Depends},
+Depends: machinekit (= ${binary:Version}), ${shlibs:Depends}, yapps2-runtime,
 # These Debian-style RT_PREEMPT package names are restricted by
 # architecture; ARM arch SOCs are all incompatible, so this can't be
 # easily done for ARM.

--- a/debian/control.xenomai.in
+++ b/debian/control.xenomai.in
@@ -1,7 +1,7 @@
 
 Package: machinekit-xenomai
 Architecture: any
-Depends: machinekit (= ${binary:Version}), ${shlibs:Depends},
+Depends: machinekit (= ${binary:Version}), ${shlibs:Depends}, yapps2-runtime,
 	xenomai-runtime
 Provides:  machinekit-rt-threads
 Recommends: hostmot2-firmware-all [!armhf]


### PR DESCRIPTION
Left out when comp etc. moved and machinekit-dev deprecated

Fixes #1246

Signed-off-by: Mick <arceye@mgware.co.uk>