### PR TITLE
De0 nano soc cramps

### DIFF
--- a/configs/hm2-soc-stepper/5i25-soc-cramps.ini
+++ b/configs/hm2-soc-stepper/5i25-soc-cramps.ini
@@ -8,8 +8,9 @@
 [HOSTMOT2]
 DRIVER=hm2_soc_ol
 BOARD=5i25
-CONFIG="firmware=socfpga/dtbo/hm2reg_uio.dtbo num_encoders=2 num_pwmgens=2 num_stepgens=10"
-DEVNAME=hm2-socfpg0
+CONFIG="firmware=socfpga/dtbo/DE0_Nano_SoC_Cramps.dtbo num_pwmgens=6 num_stepgens=8"
+#CONFIG="firmware=socfpga/dtbo/DE0_Nano_SoC_Cramps.Cramps_3x24_dpll_irq_adc_cap_spi.dtbo num_pwmgens=2 num_stepgens=8"
+DEVNAME=hm2-socfpga0
 
 
 
@@ -24,8 +25,8 @@ MACHINE =               HM2-Soc-OL-Stepper
 
 # Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
 #DEBUG =                0x00000003
-#DEBUG =                0x00000007
-DEBUG = 0
+DEBUG =                0x00000007
+#DEBUG = 0
 
 
 

--- a/configs/hm2-soc-stepper/hm2-soc-stepper-5i25-cramps.hal
+++ b/configs/hm2-soc-stepper/hm2-soc-stepper-5i25-cramps.hal
@@ -38,7 +38,7 @@ loadrt tp
 loadrt hostmot2
 
 # load low-level driver
-newinst [HOSTMOT2](DRIVER) [HOSTMOT2]DEVNAME -- config=[HOSTMOT2](CONFIG)
+newinst [HOSTMOT2](DRIVER) [HOSTMOT2]DEVNAME -- config=[HOSTMOT2](CONFIG)  debug=1
 
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES  #tp=tp kins=trivkins
 
@@ -77,14 +77,15 @@ sets emcmot.00.enable FALSE
 net emcmot.00.enable <= axis.0.amp-enable-out
 net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.00.enable
 
-# added some signals to control a led (pin 39 or 40 on gpio0 port)
-# and control power on a cramps-cape (pin 1 or 2 on gpio0 port)
-setp hm2_[HOSTMOT2](BOARD).0.gpio.000.is_output TRUE
-setp hm2_[HOSTMOT2](BOARD).0.gpio.000.invert_output TRUE
+### added some signals to control a led (pin 39 or 40 on gpio0 port)
+# and control power on a cramps-cape (pin 31 and 32 on gpio0 port)
+setp hm2_[HOSTMOT2](BOARD).0.gpio.031.is_output TRUE
+setp hm2_[HOSTMOT2](BOARD).0.gpio.032.is_output TRUE
+setp hm2_[HOSTMOT2](BOARD).0.gpio.032.invert_output TRUE
 
-net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.gpio.000.out
+net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.gpio.031.out
 
-net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.led.CR01
+net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.gpio.032.out
 
 # position command and feedback
 net emcmot.00.pos-cmd <= axis.0.motor-pos-cmd
@@ -215,4 +216,3 @@ net estop-loop iocontrol.0.user-enable-out => iocontrol.0.emc-enable-in
 # create signals for tool loading loopback
 net tool-prep-loop iocontrol.0.tool-prepare => iocontrol.0.tool-prepared
 net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -1484,6 +1484,7 @@ hostmot2-objs +=			  \
     hal/drivers/mesa-hostmot2/fwid.o	  \
     hal/drivers/mesa-hostmot2/tram.o	  \
     hal/drivers/mesa-hostmot2/raw.o	  \
+    hal/drivers/mesa-hostmot2/nano_soc_adc.o \
     hal/drivers/mesa-hostmot2/bitfile.o   \
     $(MATHSTUB)
 hm2_7i90-objs :=			  \

--- a/src/Makefile
+++ b/src/Makefile
@@ -1059,6 +1059,7 @@ install-python: install-dirs
 	$(EXE) ../bin/hal_storage $(DESTDIR)$(bindir)
 	$(EXE) ../bin/hal_temp_ads7828 $(DESTDIR)$(bindir)
 	$(EXE) ../bin/hal_temp_bbb $(DESTDIR)$(bindir)
+	$(EXE) ../bin/hal_temp_atlas $(DESTDIR)$(bindir)
 	$(EXE) ../bin/pyvcp $(DESTDIR)$(bindir)
 	$(EXE) ../bin/gladevcp $(DESTDIR)$(bindir)
 	$(EXE) ../bin/axis $(DESTDIR)$(bindir)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1486,6 +1486,7 @@ hostmot2-objs +=			  \
     hal/drivers/mesa-hostmot2/tram.o	  \
     hal/drivers/mesa-hostmot2/raw.o	  \
     hal/drivers/mesa-hostmot2/nano_soc_adc.o \
+    hal/drivers/mesa-hostmot2/capsense.o \
     hal/drivers/mesa-hostmot2/bitfile.o   \
     $(MATHSTUB)
 hm2_7i90-objs :=			  \

--- a/src/hal/drivers/mesa-hostmot2/capsense.c
+++ b/src/hal/drivers/mesa-hostmot2/capsense.c
@@ -1,0 +1,226 @@
+
+//
+//    Copyright (C) 2007-2008 Sebastian Kuzminsky
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#include "config_module.h"
+#include RTAPI_INC_SLAB_H
+
+#include "rtapi.h"
+#include "rtapi_string.h"
+#include "rtapi_math.h"
+
+#include "hal.h"
+
+#include "hal/drivers/mesa-hostmot2/hostmot2.h"
+
+int hm2_capsense_parse_md(hostmot2_t *hm2, int md_index) {
+    hm2_module_descriptor_t *md = &hm2->md[md_index];
+    int r;
+
+
+    if (hm2->capsense.num_instances != 0) {
+        HM2_ERR(
+            "found duplicate Module Descriptor for %s (inconsistent firmware), not loading driver\n",
+            hm2_get_general_function_name(md->gtag)
+        );
+        return -EINVAL;
+    }
+
+    // allocate the module-global HAL shared memory
+    hm2->capsense.hal = (hm2_capsense_module_global_t *)hal_malloc(sizeof(hm2_capsense_module_global_t));
+    if (hm2->capsense.hal == NULL) {
+        HM2_ERR("out of memory!\n");
+        r = -ENOMEM;
+        goto fail0;
+    }
+
+    if (hm2->config.num_capsensors > md->instances) {
+        HM2_ERR(
+            "config.num_capsensors=%d, but only %d are available, not loading driver\n",
+            hm2->config.num_capsensors,
+            md->instances
+        );
+        return -EINVAL;
+    }
+
+    if (hm2->config.num_capsensors == 0) {
+        return 0;
+    }
+
+    // 
+    // looks good, start initializing
+    // 
+
+
+    if (hm2->config.num_capsensors == -1) {
+        hm2->capsense.num_instances = md->instances;
+    } else {
+        hm2->capsense.num_instances = hm2->config.num_capsensors;
+    }
+
+
+    hm2->capsense.instance = (hm2_capsense_instance_t *)hal_malloc(hm2->capsense.num_instances * sizeof(hm2_capsense_instance_t));
+    if (hm2->capsense.instance == NULL) {
+        HM2_ERR("out of memory!\n");
+        r = -ENOMEM;
+        goto fail0;
+    }
+
+    hm2->capsense.capsense_data_addr = md->base_address + (0 * md->register_stride);
+    hm2->capsense.capsense_hysteresis_addr = md->base_address + (1 * md->register_stride);
+
+//    r = hm2_register_tram_read_region(hm2, hm2->capsense.capsense_data_addr, (hm2->capsense.num_instances * sizeof(u32)), &hm2->capsense.capsense_data_reg);
+    r = hm2_register_tram_read_region(hm2, hm2->capsense.capsense_data_addr, (1 * sizeof(u32)), &hm2->capsense.capsense_data_reg);
+    if (r < 0) {
+        HM2_ERR("error registering tram read region for CAPSENSE Data register (%d)\n", r);
+        goto fail0;
+    }
+
+//    hm2->capsense.capsense_data_reg = (u32 *)kmalloc(hm2->capsense.num_instances * sizeof(u32), GFP_KERNEL);
+    hm2->capsense.capsense_data_reg = (u32 *)kmalloc(1 * sizeof(u32), GFP_KERNEL);
+    if (hm2->capsense.capsense_data_reg == NULL) {
+        HM2_ERR("out of memory!\n");
+        r = -ENOMEM;
+        goto fail0;
+    }
+
+    // export to HAL
+    // FIXME: r hides the r in enclosing function, and it returns the wrong thing
+    {
+        int i;
+        int r;
+        char name[HAL_NAME_LEN + 1];
+
+        // parameters
+/*
+        // these hal parameters affect all capsense instances
+        r = hal_param_u32_newf(
+            HAL_RW,
+            &(hm2->capsense.hal->param.capsense_hysteresis),
+            hm2->llio->comp_id,
+            "%s.capsense.capsense_hysteresis",
+            hm2->llio->name
+        );
+        if (r < 0) {
+            HM2_ERR("error adding capsense.capsense_hysteresis param, aborting\n");
+            goto fail1;
+        }
+        hm2->capsense.hal->param.capsense_hysteresis = 0x33333333;
+//        hm2->capsense.written_capsense_hysteresis_reg = 0;
+*/
+
+        rtapi_snprintf(name, sizeof(name), "%s.capsense.%02d.hysteresis", hm2->llio->name, 0);
+        r = hal_pin_u32_new(name, HAL_IN, &(hm2->capsense.hal->param.capsense_hysteresis), hm2->llio->comp_id);
+        if (r < 0) {
+            HM2_ERR("error adding capsense.hysteresis pin, aborting\n");
+            goto fail1;
+        }
+
+        *hm2->capsense.hal->param.capsense_hysteresis = 0x33333333;
+ 
+       for (i = 0; i < hm2->capsense.num_instances; i ++) {
+            // pins
+            rtapi_snprintf(name, sizeof(name), "%s.capsense.%02d.trigged", hm2->llio->name, i);
+            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->capsense.instance[i].hal.pin.sensepad), hm2->llio->comp_id);
+            if (r < 0) {
+                HM2_ERR("error adding pin '%s', aborting\n", name);
+                goto fail1;
+            }
+            // init hal objects
+/*
+            for(i=0;i<hm2->capsense.num_instances;i++){
+                *(hm2->capsense.instance[i].hal.pin.sensepad) = 0;
+            }
+*/
+        }
+    }
+
+
+    return hm2->capsense.num_instances;
+
+fail1:
+    kfree(hm2->capsense.capsense_data_reg);
+
+fail0:
+    hm2->capsense.num_instances = 0;
+    return r;
+}
+
+
+/*
+int hm2_capsense_setup(hostmot2_t *hm2) {
+    int r,i;
+    char name[HAL_NAME_LEN + 1];
+
+
+    if (hm2->config.enable_capsense == 0) {
+        return 0;
+    }
+    
+    hm2->capsense = (capsense_t *)hal_malloc(sizeof(capsense_t));
+    if (hm2->capsense == NULL) {
+        HM2_ERR("out of memory!\n");
+        hm2->config.enable_capsense = 0;
+        return -ENOMEM;
+    }
+
+    for(i=0;i<NUM_capsense_SENSORS;i=i+1){
+        rtapi_snprintf(name, sizeof(name), "%s.capsense.sensepad.%d.out", hm2->llio->name, i);
+        r = hal_pin_bit_new(name, HAL_OUT, &(hm2->capsense->hal.pin.sensepad[i]), hm2->llio->comp_id);
+        if (r < 0) {
+            HM2_ERR("error adding pin '%s', aborting\n", name);
+            return -EINVAL;
+        }
+    }
+
+*/
+    // init hal objects
+/*
+    for(i=0;i<NUM_capsense_SENSORS;i++){
+        *(hm2->capsense->hal.pin.sensepad[i]) = 0;
+    }
+
+	 hm2_set_pin_direction(hm2, 36, HM2_PIN_DIR_IS_OUTPUT);	
+    
+    return 0;
+}
+*/
+
+void hm2_capsense_read(hostmot2_t *hm2) {
+    int i;
+    u32 val;
+    hal_bit_t bit;
+
+     if (hm2->capsense.num_instances == 0) return;
+	 
+    hm2->llio->read(
+        hm2->llio,
+        hm2->capsense.capsense_data_addr,
+        &val,
+        sizeof(u32)
+    );
+
+    for(i=0;i<hm2->capsense.num_instances; i ++){
+        bit = (val >> i) & 0x1;
+        *hm2->capsense.instance[i].hal.pin.sensepad = bit;
+    }
+}
+
+//void hm2_capsense_allocate_pins(hostmot2_t *hm2) {
+//    hm2_set_pin_direction(hm2, 36, HM2_PIN_DIR_IS_OUTPUT);
+//}

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.c
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.c
@@ -99,6 +99,7 @@ static int hm2_read(void *void_hm2, const hal_funct_args_t *fa) {
     hm2_dpll_process_tram_read(hm2, period);
     hm2_raw_read(hm2);
     de0_nano_soc_adc_read(hm2);
+    hm2_capsense_read(hm2);
     return 0;
 }
 
@@ -285,6 +286,8 @@ const char *hm2_get_general_function_name(int gtag) {
         case HM2_GTAG_PKTUART_RX:      return "PktUART Receive Channel";
         case HM2_GTAG_PKTUART_TX:      return "PktUART Transmit Channel";
         case HM2_GTAG_HM2DPLL:         return "Hostmot2 DPLL";
+        case HM2_GTAG_NANOADC:    return "NANOADC";
+        case HM2_GTAG_CAPSENSE:    return "CapSense";
         case HM2_GTAG_FWID:            return "Firmware ID";
         default: {
             static char unknown[100];
@@ -361,6 +364,7 @@ static int hm2_parse_config_string(hostmot2_t *hm2, char *config_string) {
     hm2->config.num_leds = -1;
     hm2->config.enable_raw = 0;
     hm2->config.enable_adc = 0;
+    hm2->config.num_capsensors = -1;
     hm2->config.firmware = NULL;
 
     if (config_string == NULL) return 0;
@@ -474,6 +478,10 @@ static int hm2_parse_config_string(hostmot2_t *hm2, char *config_string) {
         } else if (strncmp(token, "enable_adc", 10) == 0) {
             hm2->config.enable_adc = 1;
 
+        } else if (strncmp(token, "num_capsensors=", 14) == 0) {
+            token += 14;
+            hm2->config.num_capsensors = simple_strtol(token, NULL, 0);
+
 	} else if (strncmp(token, "nofwid", 6) == 0) {
             hm2->config.skip_fwid = 1;
 
@@ -513,6 +521,7 @@ static int hm2_parse_config_string(hostmot2_t *hm2, char *config_string) {
     HM2_DBG("    num_leds=%d\n",    hm2->config.num_leds);
     HM2_DBG("    enable_raw=%d\n",   hm2->config.enable_raw);
     HM2_DBG("    enable_adc=%d\n",   hm2->config.enable_adc);
+    HM2_DBG("    num_capsensors=%d\n",   hm2->config.num_capsensors);
     HM2_DBG("    firmware=%s\n",   hm2->config.firmware ? hm2->config.firmware : "(NULL)");
 
     argv_free(argv);
@@ -983,6 +992,10 @@ static int hm2_parse_module_descriptors(hostmot2_t *hm2) {
 
             case HM2_GTAG_LED:
                 md_accepted = hm2_led_parse_md(hm2, md_index);
+                break;
+
+            case HM2_GTAG_CAPSENSE:
+                md_accepted = hm2_capsense_parse_md(hm2, md_index);
                 break;
 
 	    case HM2_GTAG_FWID:
@@ -1507,7 +1520,6 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
         goto fail1;
     }
 
-
     //
     // the "raw" interface lets you peek and poke the HostMot2 registers from HAL
     //
@@ -1516,6 +1528,7 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
     if (r != 0) {
         goto fail1;
     }
+
 
     //
     // the "adc" interface lets you read the de0 nano soc builtin adc from HAL
@@ -1526,6 +1539,16 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
         goto fail1;
     }
 
+/*
+    //
+    // the "capsense" interface lets you drive and read simple capsensesensors from HAL
+    //
+
+    r = hm2_capsense_setup(hm2);
+    if (r != 0) {
+        goto fail1;
+    }
+*/
 
     //
     // At this point, all non-TRAM register buffers have been initialized

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.c
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.c
@@ -98,6 +98,7 @@ static int hm2_read(void *void_hm2, const hal_funct_args_t *fa) {
     hm2_tp_pwmgen_read(hm2); // check the status of the fault bit
     hm2_dpll_process_tram_read(hm2, period);
     hm2_raw_read(hm2);
+    de0_nano_soc_adc_read(hm2);
     return 0;
 }
 
@@ -359,6 +360,7 @@ static int hm2_parse_config_string(hostmot2_t *hm2, char *config_string) {
     hm2->config.num_dplls = -1;
     hm2->config.num_leds = -1;
     hm2->config.enable_raw = 0;
+    hm2->config.enable_adc = 0;
     hm2->config.firmware = NULL;
 
     if (config_string == NULL) return 0;
@@ -469,6 +471,9 @@ static int hm2_parse_config_string(hostmot2_t *hm2, char *config_string) {
         } else if (strncmp(token, "enable_raw", 10) == 0) {
             hm2->config.enable_raw = 1;
 
+        } else if (strncmp(token, "enable_adc", 10) == 0) {
+            hm2->config.enable_adc = 1;
+
 	} else if (strncmp(token, "nofwid", 6) == 0) {
             hm2->config.skip_fwid = 1;
 
@@ -507,6 +512,7 @@ static int hm2_parse_config_string(hostmot2_t *hm2, char *config_string) {
     HM2_DBG("    num_dplls=%d\n",    hm2->config.num_dplls);
     HM2_DBG("    num_leds=%d\n",    hm2->config.num_leds);
     HM2_DBG("    enable_raw=%d\n",   hm2->config.enable_raw);
+    HM2_DBG("    enable_adc=%d\n",   hm2->config.enable_adc);
     HM2_DBG("    firmware=%s\n",   hm2->config.firmware ? hm2->config.firmware : "(NULL)");
 
     argv_free(argv);
@@ -1507,6 +1513,15 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
     //
 
     r = hm2_raw_setup(hm2);
+    if (r != 0) {
+        goto fail1;
+    }
+
+    //
+    // the "adc" interface lets you read the de0 nano soc builtin adc from HAL
+    //
+
+    r = hm2_adc_setup(hm2);
     if (r != 0) {
         goto fail1;
     }

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -76,6 +76,10 @@ char **argv_split(gfp_t gfp, const char *str, int *argcp);
 // idrom addresses & constants
 //
 
+#define DE0_NANO_SOC_ADC_BASE 0x0200
+#define DE0_NANO_SOC_ADC_DATA 0x0204
+#define NUM_ADC_SAMPLES 8
+
 #define HM2_ADDR_IOCOOKIE  (0x0100)
 #define HM2_IOCOOKIE       (0x55AACAFE)
 
@@ -1067,6 +1071,20 @@ typedef struct {
 } hm2_raw_t;
 
 
+//
+// nano adc access
+//
+
+typedef struct {
+    struct {
+        struct {
+            hal_u32_t *status_set_reg;
+            hal_u32_t *num_samples_reg;
+            hal_u32_t *sample[NUM_ADC_SAMPLES];
+        } pin;
+    } hal;
+} de0_nano_soc_adc_t;
+
 
 
 //
@@ -1108,6 +1126,7 @@ typedef struct {
         int num_dplls;
         char sserial_modes[4][8];
         int enable_raw;
+        int enable_adc;
         char *firmware;
 	int skip_fwid;  // skip applying the fwid proto message if set
     } config;
@@ -1157,6 +1176,7 @@ typedef struct {
     hm2_led_t led;
     hm2_fwid_t fwid;
     hm2_raw_t *raw;
+    de0_nano_soc_adc_t *nano_soc_adc;
 
     struct list_head list;
 } hostmot2_t;
@@ -1165,6 +1185,9 @@ typedef struct {
 //
 // misc little helper functions
 //
+
+void de0_nano_soc_adc_read(hostmot2_t *hm2);
+void de0_nano_soc_adc_write(hostmot2_t *hm2);
 
 // this one just returns TRUE if the MD is good, FALSE if not
 int hm2_md_is_consistent(
@@ -1461,6 +1484,13 @@ int hm2_raw_setup(hostmot2_t *hm2);
 void hm2_raw_read(hostmot2_t *hm2);
 void hm2_raw_write(hostmot2_t *hm2);
 
+
+//
+// adc functions
+//
+
+int hm2_adc_setup(hostmot2_t *hm2);
+void de0_nano_soc_adc_read(hostmot2_t *hm2);
 
 
 

--- a/src/hal/drivers/mesa-hostmot2/nano_soc_adc.c
+++ b/src/hal/drivers/mesa-hostmot2/nano_soc_adc.c
@@ -1,0 +1,123 @@
+
+//
+//    Copyright (C) 2007-2008 Sebastian Kuzminsky
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#include "config_module.h"
+#include RTAPI_INC_SLAB_H
+
+#include "rtapi.h"
+#include "rtapi_string.h"
+#include "rtapi_math.h"
+
+#include "hal.h"
+
+#include "hal/drivers/mesa-hostmot2/hostmot2.h"
+
+
+
+int hm2_adc_setup(hostmot2_t *hm2) {
+    int r,i;
+    char name[HAL_NAME_LEN + 1];
+
+
+    if (hm2->config.enable_adc == 0) {
+        return 0;
+    }
+    
+    hm2->nano_soc_adc = (de0_nano_soc_adc_t *)hal_malloc(sizeof(de0_nano_soc_adc_t));
+    if (hm2->nano_soc_adc == NULL) {
+        HM2_ERR("out of memory!\n");
+        hm2->config.enable_adc = 0;
+        return -ENOMEM;
+    }
+
+    for(i=0;i<NUM_ADC_SAMPLES;i=i+1){
+        rtapi_snprintf(name, sizeof(name), "%s.nano_soc_adc.ch.%d.out", hm2->llio->name, i);
+        r = hal_pin_u32_new(name, HAL_OUT, &(hm2->nano_soc_adc->hal.pin.sample[i]), hm2->llio->comp_id);
+        if (r < 0) {
+            HM2_ERR("error adding pin '%s', aborting\n", name);
+            return -EINVAL;
+        }
+    }
+
+
+    // init hal objects
+
+    for(i=0;i<NUM_ADC_SAMPLES;i++){
+        *(hm2->nano_soc_adc->hal.pin.sample[i]) = 0;
+    }
+
+    return 0;
+}
+
+
+void de0_nano_soc_adc_read(hostmot2_t *hm2) {
+    int i;
+    u32 val;
+    u32 num_samples=NUM_ADC_SAMPLES;
+    u32 reset_reg = 0x0100;
+    u32 start_reg = 0x0101;
+
+	 if (hm2->config.enable_adc == 0) return;
+	 
+    hm2->llio->read(
+        hm2->llio,
+        DE0_NANO_SOC_ADC_BASE,
+        &val,
+        sizeof(u32)
+    );
+    if (val & 1){ 
+    /* insert dummy read of first sample */
+//        hm2->llio->read(
+//            hm2->llio,
+//            DE0_NANO_SOC_ADC_DATA,
+//            (void *)hm2->nano_soc_adc->hal.pin.sample[0],
+//            sizeof(u32)
+//        );
+	 
+	    for(i=0;i<NUM_ADC_SAMPLES;i=i+1){
+                hm2->llio->read(
+                hm2->llio,
+                DE0_NANO_SOC_ADC_DATA,
+                (void *)hm2->nano_soc_adc->hal.pin.sample[i],
+                sizeof(u32)
+            );
+        }
+
+        hm2->llio->write(
+            hm2->llio,
+            DE0_NANO_SOC_ADC_DATA,
+            &num_samples,
+            sizeof(u32)
+        );
+
+        hm2->llio->write(
+            hm2->llio,
+            DE0_NANO_SOC_ADC_BASE,
+            &reset_reg,
+            sizeof(u32)
+        );
+
+        hm2->llio->write(
+            hm2->llio,
+            DE0_NANO_SOC_ADC_BASE,
+            &start_reg,
+            sizeof(u32)
+        );
+    }
+}

--- a/src/hal/drivers/mesa-hostmot2/pins.c
+++ b/src/hal/drivers/mesa-hostmot2/pins.c
@@ -290,6 +290,16 @@ static const char* hm2_get_pin_secondary_name(hm2_pin_t *pin) {
                 case 0x6: return "Timer 4 Pin";
             }
             break;
+            
+        case HM2_GTAG_CAPSENSE:
+            switch (sec_pin) {
+                case 1: return "Charge Out Pin";
+                case 2: return "Sense 0 Pin";
+                case 3: return "Sense 1 Pin";
+                case 4: return "Sense 2 Pin";
+                case 5: return "Sense 3 Pin";
+            }
+            break;
 
         case HM2_GTAG_TWIDDLER: // Not Supported Currently
              if (sec_pin < 0x20){
@@ -612,6 +622,5 @@ void hm2_configure_pins(hostmot2_t *hm2) {
     // and about half as many I/Os as you'd expect
     hm2_pins_allocate_all(hm2, HM2_GTAG_MUXED_ENCODER, (hm2->muxed_encoder.num_instances+1)/2);
     hm2_pins_allocate_all(hm2, HM2_GTAG_HM2DPLL, hm2->dpll.num_instances);
+    hm2_pins_allocate_all(hm2, HM2_GTAG_CAPSENSE, 1);
 }
-
-

--- a/src/hal/user_comps/Submakefile
+++ b/src/hal/user_comps/Submakefile
@@ -5,6 +5,7 @@ USER_COMP_PY = \
 	hal_storage \
 	hal_temp_ads7828 \
 	hal_temp_bbb \
+	hal_temp_atlas \
 	hal_gy86 \
 	gladevcp
 

--- a/src/hal/user_comps/hal_temp_atlas.py
+++ b/src/hal/user_comps/hal_temp_atlas.py
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+# encoding: utf-8
+"""
+Temperature.py
+
+Created by Alexander Rössler on 2014-03-24.
+"""
+
+from fdm.r2temp import R2Temp
+
+import argparse
+import time
+import sys
+
+import hal
+
+# The CRAMPS board thermistor input has one side grounded and the other side
+# pulled high through a 1.00K resistor to 1.8V.  Following this is a 4.7K
+# resistor, some protection diodes, and filtering capacitors.  The ADC voltage
+# read is the filtered voltage across the thermistor.
+def adc2r_cramps(pin,ref):
+#    V_adc = pin.rawValue * 1.8 / 4096.0
+#    V_adc = pin.rawValue * 3.3 / 3315.0
+    V_adc = pin.rawValue * 3.3 / ref
+    V_T  = 0.0  # Voltage across the thermistor
+    R_PU = 2000.0 #Pull-up resistence 
+    I_PU = 0.0  # Current flowing through the pull-up resistor
+    R_T  = 0.0  # Resistance of the thermistor
+
+    V_T = V_adc
+
+    # No dividing by zero or negative voltages despite what the ADC says!
+    # Clip to a small positive value
+    I_PU = max((3.3 - V_T ) / R_PU, 0.000001) 
+#    I_PU = max((5.0 - V_T ) / R_PU, 0.000001) 
+
+    R_T = V_T / I_PU
+
+    return R_T
+
+class Pin:
+    def __init__(self):
+        self.pin = 0
+        self.r2temp = None
+        self.halValuePin = 0
+        self.halRawPin = 0
+        self.filterSamples = []
+        self.filterSize = 10
+        self.rawValue = 0.0
+        self.filterSamples = []
+        self.rawValue = 0.0
+
+    def addSample(self, value):
+        self.filterSamples.append(value)
+        if (len(self.filterSamples) > self.filterSize):
+            self.filterSamples.pop(0)
+        sampleSum = 0.0
+        for sample in self.filterSamples:
+            sampleSum += sample
+        # No dividing by zero or negative voltages despite what the ADC says!
+        # Clip to a small positive value
+        self.rawValue  = max(sampleSum / len(self.filterSamples), 0.000001) 
+
+
+def getHalName(pin):
+    return "ch-" + '{0:02d}'.format(pin.pin)
+
+
+def adc2Temp(pin,ref):
+#    R1 = 4700.0
+#    R2 = R1 / max(4095.0 / pin.rawValue - 1.0, 0.000001)
+#    return round(pin.r2temp.r2t(R2) * 10.0) / 10.0
+
+    R = adc2r_cramps(pin,ref)
+    return round(pin.r2temp.r2t(R) * 10.0) / 10.0
+
+
+parser = argparse.ArgumentParser(description='HAL component to read Temperature values over I2C')
+parser.add_argument('-n', '--name', help='HAL component name', required=True)
+parser.add_argument('-i', '--interval', help='I2C update interval', default=0.05)
+parser.add_argument('-r', '--ref', help='Calibrate Thermistor ref voltage via ref ch', default="n")
+parser.add_argument('-c', '--channels', help='Komma separated list of channels and thermistors to use e.g. 01:semitec_103GT_2,02:epcos_B57560G1104', required=True)
+parser.add_argument('-f', '--filter_size', help='Size of the low pass filter to use', default=10)
+parser.add_argument('-d', '--delay', help='Delay before the i2c should be updated', default=0.0)
+
+args = parser.parse_args()
+
+updateInterval = float(args.interval)
+delayInterval = float(args.delay)
+filterSize = int(args.filter_size)
+error = True
+watchdog = True
+
+# Create pins
+pins = []
+
+if (args.channels != ""):
+    channelsRaw = args.channels.split(',')
+    for channel in channelsRaw:
+        pinRaw = channel.split(':')
+        if (len(pinRaw) != 2):
+            print(("wrong input"))
+            sys.exit(1)
+        pin = Pin()
+        pin.pin = int(pinRaw[0])
+        if ((pin.pin > 7) or (pin.pin < 0)):
+            print(("Pin not available"))
+            sys.exit(1)
+        if (pinRaw[1] != "none"):
+            pin.r2temp = R2Temp(pinRaw[1])
+        pin.filterSize = filterSize
+        pins.append(pin)
+
+# Initialize HAL
+h = hal.component(args.name)
+for pin in pins:
+    pin.halRawPin = h.newpin(getHalName(pin) + ".raw", hal.HAL_FLOAT, hal.HAL_OUT)
+    if (pin.r2temp is not None):
+        pin.halInputPin = h.newpin(getHalName(pin) + ".input", hal.HAL_U32, hal.HAL_IN)
+        pin.halValuePin = h.newpin(getHalName(pin) + ".value", hal.HAL_FLOAT, hal.HAL_OUT)
+if (args.ref == 'y'):
+    halRefPin = h.newpin("voltage-ref", hal.HAL_U32, hal.HAL_IN)
+halErrorPin = h.newpin("error", hal.HAL_BIT, hal.HAL_OUT)
+halNoErrorPin = h.newpin("no-error", hal.HAL_BIT, hal.HAL_OUT)
+halWatchdogPin = h.newpin("watchdog", hal.HAL_BIT, hal.HAL_OUT)
+h.ready()
+
+halErrorPin.value = error
+halNoErrorPin.value = not error
+halWatchdogPin.value = watchdog
+
+try:
+    time.sleep(delayInterval)
+    while (True):
+        try:
+            if (args.ref == 'y'):
+                ref = (halRefPin.value & 0x00000FFF)
+                if (ref == 0):
+                    ref = 3300
+            else:
+                ref = 3300
+            for pin in pins:
+                value = float(pin.halInputPin.value & 0x00000FFF)
+                pin.addSample(value)
+                pin.halRawPin.value = pin.rawValue
+                if (pin.r2temp is not None):
+                    pin.halValuePin.value = adc2Temp(pin,ref)
+            error = False
+        except IOError as e:
+            error = True
+
+        halErrorPin.value = error
+        halNoErrorPin.value = not error
+        watchdog = not watchdog
+        halWatchdogPin.value = watchdog
+        time.sleep(updateInterval)
+except:
+    print(("exiting HAL component " + args.name))
+    h.exit()


### PR DESCRIPTION
This commit adds (tested to work):
hostmot2 support for socfpga ADC (tested on DE0_Nano_SoC) (same ADC as on DE10-Nano)

A hal_temp_atlas user component for 3d-print temperature conversion derived from hal_temp_bbb.
(with an optional reference voltage input on adc ch 8)

Support for a simple high precision capasitive touch sensor that can be used for
tool probing or a contact-less limit switch, etc.
Kicad schematic and board-layout here:
https://github.com/the-snowwhite/socfpga-kicad/tree/work/Touch-sense2

The complementary fpga project is the original DE0_Nano_Soc_GHRD project morphed and reduced to be only fully CRAMPS compatible atm currently residing here:
https://github.com/the-snowwhite/mksocfpga/tree/DE0_Nano_SoC_Cramps
(I expect to get the last workaroun for the capsense core in place and committ that later today also)
Schematic for the 1 GPIO -> CRAMPS interface is here:
https://github.com/the-snowwhite/socfpga-kicad/tree/work/Cramps2nano-soc
