### PR TITLE
remove test for DTOV_STAT_APPLIED (device tree overlay applied)

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
@@ -318,11 +318,11 @@ static int hm2_soc_mmap(hm2_soc_t *brd) {
     hm2_lowlevel_io_t *this = &brd->llio;
 
     // we can mmap this device safely only if programmed so cop out
-    if (brd->fpga_state != DTOV_STAT_APPLIED) {
-        LL_ERR("invalid fpga state %d, unsafe to mmap %s",
-            brd->fpga_state, brd->uio_dev);
-        return -EIO;
-    }
+//    if (brd->fpga_state != DTOV_STAT_APPLIED) {
+//        LL_ERR("invalid fpga state %d, unsafe to mmap %s",
+//            brd->fpga_state, brd->uio_dev);
+//        return -EIO;
+//    }
 
     // Fix race from overlay framework
     // spin to give uio device time to appear with proper permissions
@@ -333,7 +333,7 @@ static int hm2_soc_mmap(hm2_soc_t *brd) {
 	if (ret == 0)
 	    break;
         retries--;
-        usleep(200000);
+        usleep(300000);
     }
     if (ret || (brd->uio_dev == NULL)) {
 	LL_ERR("failed to map %s to /dev/uioX\n", brd->name);


### PR DESCRIPTION
and increase delay of waiting for fpga configure end.

Signed-off-by: Michael Brown <producer@holotronic.dk>

This works great for me on both the DE10 and DE0 Nano SoC's

However please on a different  setup (ie. with Roberts image) before merging.