### PR TITLE
Fix dh_python2 multi-arch renames of libraries.

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -212,7 +212,7 @@ binary-arch: build install
 	dh_compress -X.pdf -X.txt -X.hal -X.ini -X.clp -X.var -X.nml \
 	    -X.tbl -X.xml -Xsample-configs
 	dh_fixperms -X/linuxcnc_module_helper -X/rtapi_app_
-	dh_python2 --ignore-shebangs --no-guessing-versions
+	dh_python2 --ignore-shebangs --no-guessing-versions --no-ext-rename
 	dh_makeshlibs
 	dh_installdeb
 


### PR DESCRIPTION
If machinekit packages are built upon a multi-arch enabled Debian system,
dh_python2 renames the python libraries to {libname}.{arch}.so

As machinekit libraries are not intended to be multiarch, just one arch
and flavour installed at a time, this is both unnecessary and breaks
packages because the default library name is not able to be found.

Signed-off-by: Mick <arceye@mgware.co.uk>