### PR TITLE
Add ARCH_CFLAGS for platform_pc builds

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -541,9 +541,15 @@ AC_ARG_WITH(platform-pc,
     ],
     [
         case $host_cpu in
-	    (i?86 | x86_64)
-	        TARGET_PLATFORM_PC=unk
+	    (x86_64)
+	        ARCH_CFLAGS="-m64"
+		TARGET_PLATFORM_PC=unk
 		;;
+	    (i?86)
+	        ARCH_CFLAGS="-m32"
+		TARGET_PLATFORM_PC=unk
+		;;
+
 	    (*)
 	        TARGET_PLATFORM_PC=false
 		platform_pc_reason="$arch_disab_msg"


### PR DESCRIPTION
Add specific arch flag (-m=32|-m=64) for platform_pc builds
Ensures proper linkage upon multi-arch system
or within a multi-arch docker container.

These flags already exist in Machinekit-HAL and have zero impact on
a single arch system, as they just repeat what the linker would expect.

Signed-off-by: Mick <arceye@mgware.co.uk>