### PR TITLE
Add the cross-builder specific scripts for future use.

### DIFF
--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -1,0 +1,163 @@
+#!/bin/bash -e
+#
+# Build/cross-build Machinekit-HAL in Docker
+#
+# This script can be run manually or in Travis CI.  Sample manual
+# usage, `$PWD` is the `src/` directory:
+#
+# .travis/docker_build.sh
+
+###########################################################
+# Configuration from environment, CL args and defaults
+CMD=${CMD:-shell}
+IMAGE=${IMAGE:-dovetailautomata/mk-cross-builder}
+TAG=${TAG:-amd64}
+JOBS=${JOBS:-2}
+BUILD_SOURCE=${BUILD_SOURCE:-true}  # update Changelog & source pkg
+
+# CL arguments
+while getopts c:i:t:j:nh? opt; do
+    case "$opt" in
+	c) CMD=$OPTARG ;;
+	i) IMAGE=$OPTARG ;;
+	t) TAG=$OPTARG ;;
+	j) JOBS=$OPTARG ;;
+	n) BUILD_SOURCE=false ;;
+	?|h|*) echo "Usage:  $0 [ -i DOCKER-IMAGE ] [ -t DOCKER-TAG ]" \
+	    "[ -c ( deb [ -n ] | test | [ shell ] [ COMMAND ARG ... ] ) ]" >&2
+	    exit 1 ;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+###########################################################
+# Set build parameters
+
+case ${TAG} in
+    amd64)
+	BUILD_OPTS='-b'                  # Build all binary packages
+	RUN_TESTS='runtests tests'       # Run tests on build arch
+	;;
+    i386)                                # Machine arch: i386
+	BUILD_OPTS="-a i386"             # - Set machine arch
+	;;&
+    armhf|raspbian)                      # Machine arch: armhf
+	BUILD_OPTS="-a armhf"            # - Set machine arch
+	;;&
+    i386|armhf|raspbian)                 # Cross-compile/foreign arch
+	BUILD_OPTS+=" -B"                # - Only build arch binary packages
+	BUILD_OPTS+=" -d"                # - Root fs missing build deps; force
+	RUN_TESTS='true'                 # - Don't run tests
+	BUILD_SOURCE=false               # - Don't build source package
+	;;
+    *) echo "Warning:  unknown tag '${TAG}'" >&2 ;;
+esac
+
+# DH_VERBOSE turn on verbose package debuilds
+! ${MK_PACKAGE_VERBOSE:-false} || export DH_VERBOSE=1
+
+# Parallel jobs in `make`
+export DEB_BUILD_OPTIONS="parallel=${JOBS}"
+
+# UID/GID to carry into Docker
+DUID=`id -u`; DGID=`id -g`
+
+# Bind source directory:  parent of $PWD for packages
+BIND_SOURCE_DIR="$(readlink -f $PWD/..)"
+
+# Directory containing this script
+SCRIPT_DIR="$(dirname $0)"
+
+# Make TAG accessible to called programs
+export TAG
+
+###########################################################
+# Generate command line
+
+declare -a BUILD_CL DOCKER_EXTRA_OPTS
+case $CMD in
+    "shell"|"") # Interactive shell (default)
+	DOCKER_EXTRA_OPTS=( --privileged )
+	if test -z "$*"; then
+	    BUILD_CL=( bash -i )
+	else
+	    BUILD_CL=( "$@" )
+	fi
+	;;
+    "deb") # Build Debian packages
+	DOCKER_EXTRA_OPTS=(
+	    # Used in dpkg-buildpackage
+	    -e DEB_BUILD_OPTIONS=$DEB_BUILD_OPTIONS
+	    -e DH_VERBOSE=$DH_VERBOSE
+	    # Used in scripts/build_source_package
+	    -e DEBIAN_SUITE=$DEBIAN_SUITE
+	    -e MAJOR_MINOR_VERSION=$MAJOR_MINOR_VERSION
+	    -e PKGSOURCE=$PKGSOURCE
+	    -e REPO_URL=$REPO_URL
+	    -e TRAVIS_BRANCH=$TRAVIS_BRANCH
+	    -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST
+	    -e TRAVIS_REPO=$TRAVIS_REPO
+	    -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG
+	)
+	BUILD_CL=( bash -xec "
+            # configure source package
+            debian/configure -prxt 8.6;
+
+            # update Changelog and build source package
+            $SCRIPT_DIR/build_source_package $BUILD_SOURCE
+
+            # build binary packages
+            dpkg-buildpackage -uc -us ${BUILD_OPTS} -j$JOBS
+            "
+	)
+	;;
+    "test") # RIP build and regression tests
+	BUILD_CL=( bash -xec "
+            # Set up build:  \`autoconf\` and \`make\`
+	    cd src;
+	    ./autogen.sh;
+	    ./configure --host=\$HOST_MULTIARCH;
+
+            # Build
+	    make -j${JOBS};
+
+            # Set up runtime:  setuid, environment, ini
+	    sudo make setuid >& /dev/null || true;
+	    cd ..;
+	    . scripts/rip-environment;
+	    echo -e 'ANNOUNCE_IPV4=0\nANNOUNCE_IPV6=0' >> \
+		etc/linuxcnc/machinekit.ini;
+	    tail etc/linuxcnc/machinekit.ini;
+
+            # Run regression tests
+	    ${RUN_TESTS}"
+	)
+	;;
+    *)   echo "Unkown command '$CMD'" >&2; exit 1 ;;
+esac
+
+###########################################################
+# Run build
+
+set -x  # Show user the command
+
+# Run the Docker container as follows:
+# - Remove container after exit
+# - Run interactively with terminal
+# - Add any `DOCKER_EXTRA_OPTS` from above
+# - As Travis CI user/group
+# - Bind-mount home and source directories; start in source directory
+# - Pass environment variable `TAG`
+# - Set hostname to $IMAGE:$TAG (replace `/` and `:` with `-`)
+# - Run build command as set above
+# hide --it
+docker run \
+    --rm \
+    "${DOCKER_EXTRA_OPTS[@]}" \
+    -u $DUID:$DGID -e USER=${USER} \
+    -v ${HOME}:${HOME} -e HOME=${HOME} \
+    -v ${BIND_SOURCE_DIR}:${BIND_SOURCE_DIR} -w ${PWD} \
+    -e TAG=${TAG} \
+    -h ${IMAGE//[\/:]/-}-${TAG} \
+    ${IMAGE}:${TAG} \
+    "${BUILD_CL[@]}"

--- a/scripts/build_packagecloud_upload
+++ b/scripts/build_packagecloud_upload
@@ -1,0 +1,65 @@
+#!/bin/bash -e
+#
+# Upload packages to packagecloud.io
+#
+# In Travis CI, set the following environment variables:
+# - PACKAGECLOUD_USER:  Travis CI user name
+# - PACKAGECLOUD_TOKEN:  ** HIDDEN **  User's Travis CI token
+# - PACKAGECLOUD_REPO:  Same as the GitHub repo
+# - DEPLOY_BRANCH:  Only push build results for this branch
+#
+# The following environment variables should be set in .travis.yml:
+# - CMD:  (Also may be first arg to script) Exit if not 'deb'
+# - TAG:  One of amd64/i386/armhf/raspbian
+#
+# The following environment variables should be set by Travis CI:
+# - TRAVIS_TEST_RESULT:  Exit if not '0'
+# - TRAVIS_PULL_REQUEST:  Exit if not 'false'
+# - TRAVIS_BRANCH:  Exit unless matches DEPLOY_BRANCH
+#
+# The `package_cloud` ruby gem should be installed
+
+TAG=${1:-$TAG}
+
+################################################
+# Checks
+
+exit_nice () { echo "No packagecloud upload:  $*" >&2; exit 0; }
+error () { echo "Error:  $*" >&2; exit 1; }
+
+test -n "PACKAGECLOUD_USER" || \
+    exit_nice "PACKAGECLOUD_USER not set"
+test "$CMD" = "deb" || \
+    exit_nice "CMD '$CMD' != 'deb'"
+test "$TRAVIS_TEST_RESULT" -eq 0 || \
+    exit_nice "TRAVIS_TEST_RESULT '$TRAVIS_TEST_RESULT' != '0'"
+test "$TRAVIS_PULL_REQUEST" = false || \
+    exit_nice "TRAVIS_PULL_REQUEST '$TRAVIS_PULL_REQUEST' != 'false'"
+test "$TRAVIS_BRANCH" = "${DEPLOY_BRANCH:-master}" || \
+    exit_nice "TRAVIS_BRANCH '$TRAVIS_BRANCH' != '${DEPLOY_BRANCH:-master}'"
+test -n "$TAG" || error "TAG not set"
+
+
+################################################
+# Set up
+
+case $TAG in
+    raspbian)  DISTRO=raspbian; exit_nice "FIXME:  not pushing Raspbian packages" ;;
+    amd64|i386|armhf) DISTRO=jessie ;;
+    *) error "Unknown tag '$TAG'" ;;
+esac
+
+PACKAGECLOUD_REPO=${PACKAGECLOUD_REPO:-machinekit}
+PACKAGECLOUD_ARCHIVE=${PACKAGECLOUD_USER}/${PACKAGECLOUD_REPO}/debian/${DISTRO}
+
+
+################################################
+# Deploy
+
+if [ "${TAG}" = "amd64" ]; then
+    set -x  # Show user
+#    package_cloud push ${PACKAGECLOUD_ARCHIVE} ../*.dsc
+else
+    set -x  # Show user
+fi
+#package_cloud push ${PACKAGECLOUD_ARCHIVE} ../*_$TAG.deb

--- a/scripts/build_source_package
+++ b/scripts/build_source_package
@@ -1,0 +1,110 @@
+#!/bin/bash -e
+#
+# Update the Changelog file to create packages with version/release
+# that continuously increments (to ensure `apt-get upgrade` works) and
+# that contains identifying information about the package's source (to
+# indicate who built the package, how, and from what revision).
+
+
+# Whether to actually build the source
+BUILD_SOURCE=$1
+
+# Computed variables
+SOURCE_DIR=$(readlink -f $(dirname ${0})/..)
+test ${TRAVIS_PULL_REQUEST:-false} = false && IS_PR=false || IS_PR=true
+
+case $TAG in
+    amd64|i386|armhf) DISTRO=jessie ;;
+    raspbian) DISTRO=raspbian ;;
+esac
+
+COMMIT_TIMESTAMP="$(git log -1 --pretty=format:%at)"
+SHA1SHORT="$(git log -1 --pretty=format:%h)"
+COMMITTER_NAME="$(git log -1 --pretty=format:%an)"
+COMMITTER_EMAIL="$(git log -1 --pretty=format:%ae)"
+BRANCH_NAME="$(git rev-parse --symbolic-full-name HEAD)"
+BRANCH_NAME="${BRANCH_NAME//*\//}"  # convert / to -
+
+# Supplied variables for package configuration
+MAJOR_MINOR_VERSION="${MAJOR_MINOR_VERSION:-0.1}"
+TRAVIS_REPO=${TRAVIS_REPO_SLUG:+travis.${TRAVIS_REPO_SLUG/\//.}}
+PKGSOURCE="${PKGSOURCE:-${TRAVIS_REPO:-$(hostname)}}"
+DEBIAN_SUITE="${DEBIAN_SUITE:-experimental}"
+REPO_URL="${REPO_URL:-https://github.com/arceye/Machinekit-hal}"
+
+# Compute version
+if ${IS_PR}; then
+    # Use build timestamp (now) as pkg version patchlevel
+    TIMESTAMP="$(date +%s)"
+    PR_OR_BRANCH="pr${TRAVIS_PULL_REQUEST}"
+    COMMIT_URL="${REPO_URL}/pull/${TRAVIS_PULL_REQUEST}"
+else
+    # Use merge commit timestamp as pkg version patchlevel
+    TIMESTAMP="$COMMIT_TIMESTAMP"
+    PR_OR_BRANCH="${TRAVIS_BRANCH:-${BRANCH_NAME:-unk.branch}}"
+    COMMIT_URL="${REPO_URL}/commit/${SHA1SHORT}"
+fi
+
+# sanitize upstream identifier
+UPSTREAM_ID=${PKGSOURCE//[-_]/}.${PR_OR_BRANCH//[-_]/}
+
+# Final version
+VERSION="${MAJOR_MINOR_VERSION}.${TIMESTAMP}.git${SHA1SHORT}"
+
+# Final release
+RELEASE="1${UPSTREAM_ID}~1${DISTRO}"
+
+###########################################################
+# Debug output
+echo "COMMIT_TIMESTAMP=$COMMIT_TIMESTAMP"
+echo "SHA1SHORT=$SHA1SHORT"
+echo "COMMITTER_NAME=$COMMITTER_NAME"
+echo "COMMITTER_EMAIL=$COMMITTER_EMAIL"
+echo "BRANCH_NAME=$BRANCH_NAME"
+echo "MAJOR_MINOR_VERSION=$MAJOR_MINOR_VERSION"
+echo "TRAVIS_REPO=$TRAVIS_REPO"
+echo "PKGSOURCE=$PKGSOURCE"
+echo "DEBIAN_SUITE=$DEBIAN_SUITE"
+echo "REPO_URL=$REPO_URL"
+echo "TIMESTAMP=$TIMESTAMP"
+echo "PR_OR_BRANCH=$PR_OR_BRANCH"
+echo "COMMIT_URL=$COMMIT_URL"
+echo "UPSTREAM_ID=$UPSTREAM_ID"
+echo "VERSION=$VERSION"
+echo "RELEASE=$RELEASE"
+
+
+###########################################################
+# Generate debian/changelog entry
+#
+# https://www.debian.org/doc/debian-policy/ch-source.html#s-dpkgchangelog
+
+cd ${SOURCE_DIR}
+
+mv debian/changelog debian/changelog.orig
+cat > debian/changelog <<EOF
+machinekit-hal (${VERSION}-${RELEASE}) ${DEBIAN_SUITE}; urgency=low
+
+  * Travis CI rebuild
+    - TAG ${TAG}
+    - PR/branch ${PR_OR_BRANCH}
+    - Commit ${SHA1SHORT}
+    - ${COMMIT_URL}
+
+ -- ${COMMITTER_NAME} <${COMMITTER_EMAIL}>  $(date -R)
+
+EOF
+echo "New changelog entry:"
+cat debian/changelog # debug output
+cat debian/changelog.orig >> debian/changelog
+
+if test "$BUILD_SOURCE" = true; then
+    set -x # Let user see
+
+    # create .orig tarball
+    git archive HEAD | \
+	bzip2 -z | tee ../machinekit-hal_${VERSION}.orig.tar.bz2 >/dev/null
+
+    # build source package
+    dpkg-source -b .
+fi


### PR DESCRIPTION
Will have no effect on current builds in Travis, which use others.

Once Wheezy support is dropped, these will be required for faster
builds of Jessie through a Jenkins job as per Machinekit-HAL.

Signed-off-by: Mick <arceye@mgware.co.uk>