### PR TITLE
Tidy up and remove some dangling references to machinekit-hal

### DIFF
--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Build/cross-build Machinekit-HAL in Docker
+# Build/cross-build Machinekit in Docker
 #
 # This script can be run manually or in Travis CI.  Sample manual
 # usage, `$PWD` is the `src/` directory:

--- a/scripts/build_source_package
+++ b/scripts/build_source_package
@@ -30,7 +30,7 @@ MAJOR_MINOR_VERSION="${MAJOR_MINOR_VERSION:-0.1}"
 TRAVIS_REPO=${TRAVIS_REPO_SLUG:+travis.${TRAVIS_REPO_SLUG/\//.}}
 PKGSOURCE="${PKGSOURCE:-${TRAVIS_REPO:-$(hostname)}}"
 DEBIAN_SUITE="${DEBIAN_SUITE:-experimental}"
-REPO_URL="${REPO_URL:-https://github.com/arceye/Machinekit-hal}"
+REPO_URL="${REPO_URL:-https://github.com/machinekit/machinekit}"
 
 # Compute version
 if ${IS_PR}; then
@@ -83,7 +83,7 @@ cd ${SOURCE_DIR}
 
 mv debian/changelog debian/changelog.orig
 cat > debian/changelog <<EOF
-machinekit-hal (${VERSION}-${RELEASE}) ${DEBIAN_SUITE}; urgency=low
+machinekit (${VERSION}-${RELEASE}) ${DEBIAN_SUITE}; urgency=low
 
   * Travis CI rebuild
     - TAG ${TAG}
@@ -103,7 +103,7 @@ if test "$BUILD_SOURCE" = true; then
 
     # create .orig tarball
     git archive HEAD | \
-	bzip2 -z | tee ../machinekit-hal_${VERSION}.orig.tar.bz2 >/dev/null
+	bzip2 -z | tee ../machinekit_${VERSION}.orig.tar.bz2 >/dev/null
 
     # build source package
     dpkg-source -b .


### PR DESCRIPTION
Now has been tested to build all Jessie packages using the mk-cross-builder