### PR TITLE
Make PASM created pru_generic* binaries flavour independent.

### DIFF
--- a/debian/armhf.postrm.in
+++ b/debian/armhf.postrm.in
@@ -1,0 +1,5 @@
+
+# remove the whole dir and contents, uninstall will have left it
+# because the symlinks still exist
+
+rm -r -d -f /usr/lib/linuxcnc

--- a/debian/configure
+++ b/debian/configure
@@ -119,9 +119,16 @@ do_rt-preempt() {
 }
 
 do_xenomai() {
+    if [[ $DISTRO_CODENAME == "stretch" ]] ; then
+	cat control.xenomai-stretch.in >> control
+	echo "debian/control:  added xenomai threads package for Stretch" >&2
+    else
+	cat control.xenomai.in >> control
+	echo "debian/control:  added xenomai threads package for Wheezy/Jessie" >&2
+    fi
+
     # Be sure the -dev files only appear once
     BUILD_DEPS="${BUILD_DEPS/libxenomai-dev, /}libxenomai-dev, "
-    cat control.xenomai.in >> control
     echo "debian/control:  added Xenomai (userland) threads package" \
 	"with Build-Depends:" >&2
     echo "    libxenomai-dev" >&2

--- a/debian/configure
+++ b/debian/configure
@@ -93,8 +93,13 @@ rules_set_kthreads_headers() {
 }
 
 do_posix() {
-    cat control.posix.in >> control
-    echo "debian/control:  added POSIX threads package" >&2
+    if [[ $DISTRO_CODENAME == "stretch" ]] ; then
+	cat control.posix-stretch.in >> control
+	echo "debian/control:  added POSIX threads package for stretch" >&2
+    else
+	cat control.posix.in >> control
+        echo "debian/control:  added POSIX threads package" >&2
+    fi
     rules_enable_threads posix
     HAVE_FLAVOR=true
 }

--- a/debian/control.posix-stretch.in
+++ b/debian/control.posix-stretch.in
@@ -1,0 +1,14 @@
+
+Package: machinekit-posix
+Architecture: any
+Depends: machinekit (= ${binary:Version}), ${shlibs:Depends}, yapps2-runtime, czmq, zeromq
+Provides:  machinekit-rt-threads
+Breaks: machinekit-dev
+Enhances: machinekit
+Description: PC based motion controller for real-time Linux
+ Machinekit is the next-generation Enhanced Machine Controller which
+ provides motion control for CNC machine tools and robotic
+ applications (milling, cutting, routing, etc.).
+ .
+ This package provides components and drivers that run on a non-realtime
+ (Posix) system.

--- a/debian/control.xenomai-stretch.in
+++ b/debian/control.xenomai-stretch.in
@@ -1,17 +1,16 @@
 
-Package: machinekit-rt-preempt
+Package: machinekit-xenomai
 Architecture: any
 Depends: machinekit (= ${binary:Version}), ${shlibs:Depends}, yapps2-runtime, czmq, zeromq,
-# These Debian-style RT_PREEMPT package names are restricted by
-# architecture; ARM arch SOCs are all incompatible, so this can't be
-# easily done for ARM.
- linux-image-rt-686-pae [i386], linux-image-rt-amd64 [amd64]
+	xenomai-runtime
 Provides:  machinekit-rt-threads
-Suggests: hostmot2-firmware-all [!armhf]
+Recommends: hostmot2-firmware-all [!armhf]
+Breaks: machinekit-dev
 Enhances: machinekit
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which
  provides motion control for CNC machine tools and robotic
  applications (milling, cutting, routing, etc.).
  .
- This package provides components and drivers that run on an RT-Preempt system.
+ This package provides components and drivers that run on a Xenomai
+ realtime system, with userspace threads.

--- a/debian/machinekit-rt-preempt.install.in
+++ b/debian/machinekit-rt-preempt.install.in
@@ -8,4 +8,3 @@ usr/lib/*.so
 usr/bin/comp
 usr/share/linuxcnc/Makefile.modinc
 usr/share/linuxcnc/Makefile.inc
-

--- a/debian/posix-postinst.add
+++ b/debian/posix-postinst.add
@@ -1,4 +1,10 @@
-# !/bin/sh
+
+# ensure the links do not pre-exist, from previous installs.
+# or user work-arounds,  which will produce error messages
+rm -f /usr/lib/linuxcnc/posix/pru_generic.bin
+rm -f /usr/lib/linuxcnc/posix/pru_generic.dbg
+rm -f /usr/lib/linuxcnc/posix/pru_decamux.bin
+rm -f /usr/lib/linuxcnc/posix/pru_decamux.dbg
 
 # make symlinks to BBB pru_*.*
 ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/posix/pru_generic.bin

--- a/debian/pru-postinst.in
+++ b/debian/pru-postinst.in
@@ -1,0 +1,7 @@
+# !/bin/sh
+
+# make symlinks to BBB pru_*.*
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/posix/pru_generic.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/posix/pru_generic.dbg
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/posix/pru_decamux.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/posix/pru_decamux.dbg

--- a/debian/rt-preempt-postinst.add
+++ b/debian/rt-preempt-postinst.add
@@ -1,0 +1,13 @@
+
+# ensure the links do not pre-exist, from previous installs 
+# or user work-arounds,  which will produce error messages
+rm -f /usr/lib/linuxcnc/rt-preempt/pru_generic.bin
+rm -f /usr/lib/linuxcnc/rt-preempt/pru_generic.dbg
+rm -f /usr/lib/linuxcnc/rt-preempt/pru_decamux.bin
+rm -f /usr/lib/linuxcnc/rt-preempt/pru_decamux.dbg
+
+# make symlinks to BBB pru_*.*
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/rt-preempt/pru_generic.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/rt-preempt/pru_generic.dbg
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/rt-preempt/pru_decamux.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/rt-preempt/pru_decamux.dbg

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -197,14 +197,17 @@ endif
 	if [ -f debian/platform_pc ] ; then \
 	    rm -f debian/platform_pc; \
 	else \
+	    mkdir -p debian/tmp/usr/lib/linuxcnc/prubin; \
+	    cp rtlib/prubin/* debian/tmp/usr/lib/linuxcnc/prubin; \
+	    cat debian/posix-postinst.add >> debian/machinekit-posix.postinst; \
+	    cat debian/rt-preempt-postinst.add >> debian/machinekit-rt-preempt.postinst; \
+	    cat debian/xenomai-postinst.add >> debian/machinekit-xenomai.postinst; \
+	    cat debian/armhf.postrm.in >> debian/machinekit-posix.postrm; \
+	    cat debian/armhf.postrm.in >> debian/machinekit-rt-preempt.postrm; \
+	    cat debian/armhf.postrm.in >> debian/machinekit-xenomai.postrm; \
 	    echo "usr/lib/linuxcnc/prubin/*" >> debian/machinekit-posix.install; \
 	    echo "usr/lib/linuxcnc/prubin/*" >> debian/machinekit-rt-preempt.install; \
 	    echo "usr/lib/linuxcnc/prubin/*" >> debian/machinekit-xenomai.install; \
-	    mkdir -p debian/tmp/usr/lib/linuxcnc/prubin; \
-	    cp rtlib/prubin/* debian/tmp/usr/lib/linuxcnc/prubin; \
-	    cp debian/pru-postinst.in debian/machinekit-posix.postinst; \
-	    cp debian/pru-postinst.in debian/machinekit-rt-preempt.postinst; \
-	    cp debian/pru-postinst.in debian/machinekit-xenomai.postinst; \
 	fi
 
 

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -193,6 +193,21 @@ endif
 	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-xenomai.install; \
 	fi
 
+	## only want this for armhf builds ##
+	if [ -f debian/platform_pc ] ; then \
+	    rm -f debian/platform_pc; \
+	else \
+	    echo "usr/lib/linuxcnc/prubin/*" >> debian/machinekit-posix.install; \
+	    echo "usr/lib/linuxcnc/prubin/*" >> debian/machinekit-rt-preempt.install; \
+	    echo "usr/lib/linuxcnc/prubin/*" >> debian/machinekit-xenomai.install; \
+	    mkdir -p debian/tmp/usr/lib/linuxcnc/prubin; \
+	    cp rtlib/prubin/* debian/tmp/usr/lib/linuxcnc/prubin; \
+	    cp debian/pru-postinst.in debian/machinekit-posix.postinst; \
+	    cp debian/pru-postinst.in debian/machinekit-rt-preempt.postinst; \
+	    cp debian/pru-postinst.in debian/machinekit-xenomai.postinst; \
+	fi
+
+
 	dh_install --sourcedir=debian/tmp --fail-missing -Xusr/bin/pasm
 
 # Build architecture-independent files here.

--- a/debian/xenomai-postinst.add
+++ b/debian/xenomai-postinst.add
@@ -1,0 +1,13 @@
+
+# ensure the links do not pre-exist, from previous installs.
+# or user work-arounds,  which will produce error messages
+rm -f /usr/lib/linuxcnc/xenomai/pru_generic.bin
+rm -f /usr/lib/linuxcnc/xenomai/pru_generic.dbg
+rm -f /usr/lib/linuxcnc/xenomai/pru_decamux.bin
+rm -f /usr/lib/linuxcnc/xenomai/pru_decamux.dbg
+
+# make symlinks to BBB pru_*.*
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/xenomai/pru_generic.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/xenomai/pru_generic.dbg
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/xenomai/pru_decamux.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/xenomai/pru_decamux.dbg

--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Build/cross-build Machinekit-HAL in Docker
+# Build/cross-build Machinekit in Docker
 #
 # This script can be run manually or in Travis CI.  Sample manual
 # usage, `$PWD` is the `src/` directory:

--- a/scripts/build_source_package
+++ b/scripts/build_source_package
@@ -30,7 +30,7 @@ MAJOR_MINOR_VERSION="${MAJOR_MINOR_VERSION:-0.1}"
 TRAVIS_REPO=${TRAVIS_REPO_SLUG:+travis.${TRAVIS_REPO_SLUG/\//.}}
 PKGSOURCE="${PKGSOURCE:-${TRAVIS_REPO:-$(hostname)}}"
 DEBIAN_SUITE="${DEBIAN_SUITE:-experimental}"
-REPO_URL="${REPO_URL:-https://github.com/arceye/Machinekit-hal}"
+REPO_URL="${REPO_URL:-https://github.com/machinekit/machinekit}"
 
 # Compute version
 if ${IS_PR}; then
@@ -83,7 +83,7 @@ cd ${SOURCE_DIR}
 
 mv debian/changelog debian/changelog.orig
 cat > debian/changelog <<EOF
-machinekit-hal (${VERSION}-${RELEASE}) ${DEBIAN_SUITE}; urgency=low
+machinekit (${VERSION}-${RELEASE}) ${DEBIAN_SUITE}; urgency=low
 
   * Travis CI rebuild
     - TAG ${TAG}
@@ -103,7 +103,7 @@ if test "$BUILD_SOURCE" = true; then
 
     # create .orig tarball
     git archive HEAD | \
-	bzip2 -z | tee ../machinekit-hal_${VERSION}.orig.tar.bz2 >/dev/null
+	bzip2 -z | tee ../machinekit_${VERSION}.orig.tar.bz2 >/dev/null
 
     # build source package
     dpkg-source -b .

--- a/src/Makefile
+++ b/src/Makefile
@@ -151,6 +151,10 @@ ifeq ($(RUN_IN_PLACE)+$(BUILD_DRIVERS),yes+yes)
 		    \( 0`stat -c %u ../libexec/rtapi_app_$$f 2>/dev/null` \
 			-ne 0 -o ! -u ../libexec/rtapi_app_$$f \) \
 		&& need_setuid=1; \
+	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_generic.bin ../rtlib/$$f/pru_generic.bin; \
+	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_generic.dbg ../rtlib/$$f/pru_generic.dbg; \
+	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_decamux.bin ../rtlib/$$f/pru_decamux.bin; \
+	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_decamux.dbg ../rtlib/$$f/pru_decamux.dbg; \
 	done; \
 	test "$$need_setuid" = 1 && \
 	    $(VECHO) -n "You now need to run 'sudo make setuid' " && \

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -764,6 +764,12 @@ else
     fi
 fi
 
+if test $TARGET_PLATFORM_PC = true; then
+	echo "*** TARGET_PLATFORM_PC=true ***"
+	touch ../debian/platform_pc
+fi
+
+
 # Print messages about what platforms are to be enabled or disabled
 AC_MSG_CHECKING(platform-pc)
 AC_MSG_RESULT([$platform_pc_reason])

--- a/src/hal/components/hal_pru.c
+++ b/src/hal/components/hal_pru.c
@@ -22,7 +22,7 @@
 #include <unistd.h>
 
 // load this PRU code (prefixed by EMC_RTLIB_DIR)
-#define  DEFAULT_CODE  "blinkleds.bin"
+#define  DEFAULT_CODE  "pru_generic.bin"
 
 #include "prussdrv.h"           // UIO interface to uio_pruss
 #include "pru.h"                // PRU-related defines
@@ -334,27 +334,29 @@ static int setup_pru(int pru, char *filename, int disabled)
     char pru_binpath[PATH_MAX];
 
     // default the .bin filename if not given
-    if (!strlen(filename))
+    if (!strlen(filename)){
+	rtapi_print_msg(RTAPI_MSG_ERR, 
+	    "%s: no filename given - default to %s\n",
+	    modname, DEFAULT_CODE);
 	filename = DEFAULT_CODE;
-    
+	}
     strcpy(pru_binpath, filename);
 
     struct stat statb;
 
     if (!((stat(pru_binpath, &statb) == 0) &&
 	 S_ISREG(statb.st_mode))) {
-
+	rtapi_print_msg(RTAPI_MSG_ERR, 
+	    "%s: filename %s does not exist.\n", modname, pru_binpath);
 	// filename not found, prefix fw_path & try that:
 	strcpy(pru_binpath, fw_path);
 	strcat(pru_binpath, filename);
 
 	if (!((stat(pru_binpath, &statb) == 0) &&
 	      S_ISREG(statb.st_mode))) {
-	    // nyet, complain
-	    getcwd(pru_binpath, sizeof(pru_binpath));
 	    rtapi_print_msg(RTAPI_MSG_ERR,
-			    "%s: cant find %s in %s or %s\n",
-			    modname, filename, pru_binpath, fw_path);
+		"%s: cannot find filename %s\n",
+		modname, pru_binpath);
 	    return -ENOENT;
 	}
     }

--- a/src/hal/drivers/hal_pru_generic/Submakefile
+++ b/src/hal/drivers/hal_pru_generic/Submakefile
@@ -1,5 +1,14 @@
 ifdef TARGET_PLATFORM_BEAGLEBONE
 
+# These are actually the same location but the package
+# build needs to set a path relative to the Makefile,
+# from whence it will be copied to debian/tmp
+ifeq ($(RUN_IN_PLACE),yes)
+PRUBINDIR := $(EMC2_HOME)/rtlib/prubin
+else
+PRUBINDIR := ../rtlib/prubin
+endif
+
 # support for ARM335x PRU (Programmable Realtime Unit) components and
 SUPPORT_DIR := hal/support
 PRU_SRC_DIR := hal/drivers/hal_pru_generic
@@ -10,17 +19,10 @@ PRU_MAINS   := pru_generic pru_decamux
 PRU_FILES := $(wildcard $(PRU_SRC_DIR)/*.p)
 
 # .bin file produced by PASM -b goes in rtlib
-PRU_BIN := $(patsubst %,$(RTLIBDIR)/%.bin,$(PRU_MAINS))
-PRU_DBG := $(patsubst %,$(RTLIBDIR)/%.dbg,$(PRU_MAINS))
+PRU_BIN := $(patsubst %,$(PRUBINDIR)/%.bin,$(PRU_MAINS))
+PRU_DBG := $(patsubst %,$(PRUBINDIR)/%.dbg,$(PRU_MAINS))
 
-# .bin files are targets
-# Adding to TARGETS builds the PRU code once and puts it in the RTLIBDIR for
-# the first defined RTOS flavor (typically posix)
-#TARGETS +=  $(PRU_BIN) $(PRU_DBG)
-# Only build PRU code for the Xenomai RTOS flavor
-ifeq ($(threads),xenomai) 
-modules : $(PRU_BIN) $(PRU_DBG)
-endif
+modules : $(PRU_BIN) $(PRU_DBG) 
 
 # .bin output, create listing
 PASM_BINFLAGS := -b -L -d
@@ -28,7 +30,7 @@ PASM_BINFLAGS := -b -L -d
 # conversion rule for the above
 # assemble .p  into .bin object files
 
-$(RTLIBDIR)/%.bin $(RTLIBDIR)/%.dbg: $(PASM) 
+$(PRUBINDIR)/%.bin $(PRUBINDIR)/%.dbg: $(PASM) 
 
 
 PRU_DEPS := $(patsubst %,objects/%,$(patsubst %,$(PRU_SRC_DIR)/%.d,$(PRU_MAINS)))
@@ -41,14 +43,14 @@ $(PRU_DEPS): objects/%.d : %.p
 	$(Q)cpp -x c -MM -MG -MT objects/$(patsubst %.p,%.bin,$<) -o $@ $<
 
 objects/%.bin objects/%.dbg : %.p objects/%.d $(PASM)
-	$(Q)mkdir -p $(RTLIBDIR)
+	$(Q)mkdir -p $(PRUBINDIR)
 	$(ECHO) Assembling PRU code $@ 
 	$(Q)$(PASM) $(PASM_BINFLAGS) $< $(basename $@)
 
-$(PRU_BIN): $(RTLIBDIR)/%.bin : objects/$(PRU_SRC_DIR)/%.bin
-	cp $^ $@
+$(PRU_BIN): $(PRUBINDIR)/%.bin : objects/$(PRU_SRC_DIR)/%.bin
+	cp -f $^ $@
 
-$(PRU_DBG): $(RTLIBDIR)/%.dbg : objects/$(PRU_SRC_DIR)/%.dbg
-	cp $^ $@
+$(PRU_DBG): $(PRUBINDIR)/%.dbg : objects/$(PRU_SRC_DIR)/%.dbg
+	cp -f $^ $@
 
 endif


### PR DESCRIPTION
They will now be located at $EMC2_RTLIB_BASE_DIR/prubin for binaries
and $EMC_HOME/rtlib/prubin for RIP builds
ie. in a dir immediately alongside the existing flavour dirs
then symlinked to each flavour dir so that existing configs are unchanged.

This largely mirrors the commits to Machinekit-HAL.

Fixes the underlying problem in #1199, #1182 and #1238 
Should now allow the use of later 4.x rt-preempt kernels with BBB and other arm boards