### PR TITLE
mklauncher: read stdout in chunks and not in lines

### DIFF
--- a/src/machinetalk/mklauncher/mklauncher.py
+++ b/src/machinetalk/mklauncher/mklauncher.py
@@ -320,7 +320,7 @@ class Mklauncher(object):
                     stdout_index = len(launcher.output)
                     while True:
                         try:
-                            line = process.stdout.readline()
+                            line = process.stdout.read()
                             stdoutLine = StdoutLine()
                             stdoutLine.index = stdout_index
                             stdoutLine.line = line


### PR DESCRIPTION
A Very simple patch to fix the behavior of reading the stdout of processes when the output does not contain a newline character.

E.g.
```
(write)Loading blabla...(flush) done\n
```