### PR TITLE
configure.ac allowed an argument of --disable-webtalk to activate it.

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -983,9 +983,10 @@ PKG_CHECK_MODULES([LWS], libwebsockets,
    ],)
 
 AC_MSG_CHECKING(whether to build webtalk)
-AC_ARG_ENABLE(webtalk,
-    [  --enable-webtalk    build Webtalk],
-    [
+AC_ARG_ENABLE([webtalk],
+    AS_HELP_STRING([--enable-webtalk="ARG"], [build Webtalk [ARG=yes] ]))
+
+    AS_IF([test "x$enable_webtalk" = "xyes"], [
 	if test "$USE_LWS" != "yes"; then
 	    AC_MSG_ERROR([Please install libwebsockets before building Webtalk.])
 	fi


### PR DESCRIPTION
Logic changed so that --enable-webtalk or --enable-webtalk=yes
will enable webtalk build

--enable-webtalk=no or --disable-webtalk or no switch at all,
will disable the build of webtalk

Fixes issue @
https://github.com/machinekit/machinekit/issues/1152#issuecomment-336050599

Signed-off-by: Mick <arceye@mgware.co.uk>