### PR TITLE
debian/postinstall: make sure to create directory before symlinks

### DIFF
--- a/debian/posix-postinst.add
+++ b/debian/posix-postinst.add
@@ -7,6 +7,7 @@ rm -f /usr/lib/linuxcnc/posix/pru_decamux.bin
 rm -f /usr/lib/linuxcnc/posix/pru_decamux.dbg
 
 # make symlinks to BBB pru_*.*
+mkdir -p /usr/lib/linuxcnc/posix/
 ln -sf /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/posix/pru_generic.bin
 ln -sf /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/posix/pru_generic.dbg
 ln -sf /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/posix/pru_decamux.bin

--- a/debian/rt-preempt-postinst.add
+++ b/debian/rt-preempt-postinst.add
@@ -1,5 +1,5 @@
 
-# ensure the links do not pre-exist, from previous installs 
+# ensure the links do not pre-exist, from previous installs.
 # or user work-arounds,  which will produce error messages
 rm -f /usr/lib/linuxcnc/rt-preempt/pru_generic.bin
 rm -f /usr/lib/linuxcnc/rt-preempt/pru_generic.dbg
@@ -7,6 +7,7 @@ rm -f /usr/lib/linuxcnc/rt-preempt/pru_decamux.bin
 rm -f /usr/lib/linuxcnc/rt-preempt/pru_decamux.dbg
 
 # make symlinks to BBB pru_*.*
+mkdir -p /usr/lib/linuxcnc/rt-preempt/
 ln -sf /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/rt-preempt/pru_generic.bin
 ln -sf /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/rt-preempt/pru_generic.dbg
 ln -sf /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/rt-preempt/pru_decamux.bin

--- a/debian/xenomai-postinst.add
+++ b/debian/xenomai-postinst.add
@@ -7,6 +7,7 @@ rm -f /usr/lib/linuxcnc/xenomai/pru_decamux.bin
 rm -f /usr/lib/linuxcnc/xenomai/pru_decamux.dbg
 
 # make symlinks to BBB pru_*.*
+mkdir -p /usr/lib/linuxcnc/xenomai/
 ln -sf /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/xenomai/pru_generic.bin
 ln -sf /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/xenomai/pru_generic.dbg
 ln -sf /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/xenomai/pru_decamux.bin


### PR DESCRIPTION
Package updates still fail with:

```
ln: failed to create symbolic link '/usr/lib/linuxcnc/rt-preempt/pru_generic.bin': No such file or directory
ln: failed to create symbolic link '/usr/lib/linuxcnc/rt-preempt/pru_generic.dbg': No such file or directory
ln: failed to create symbolic link '/usr/lib/linuxcnc/rt-preempt/pru_decamux.bin': No such file or directory
ln: failed to create symbolic link '/usr/lib/linuxcnc/rt-preempt/pru_decamux.dbg': No such file or directory
```

I hope this helps to fix the problem.