### PR TITLE
hal_bb_gpio: fix invert pin direction

### DIFF
--- a/src/hal/drivers/hal_bb_gpio/hal_bb_gpio.c
+++ b/src/hal/drivers/hal_bb_gpio/hal_bb_gpio.c
@@ -323,7 +323,7 @@ int rtapi_app_main(void) {
 
 	    // Add HAL pin
 	    retval = hal_pin_bit_newf(
-		HAL_OUT,
+		HAL_IN,
 		&(port_data->input_inv[pin + header*PINS_PER_HEADER]),
 		comp_id, "bb_gpio.p%d.in-%02d.invert", PIN_HEADER, pin);
 


### PR DESCRIPTION
Fix for problem introduced by: https://github.com/machinekit/machinekit/commit/41a5deff2ab9463ae53213aa3d3195f6b34d7a27#diff-33d49c1dd2784aad48ad40ab6a13069c

invert pins should be input pins as they invert the pin signal