### PR TITLE
Launcher and haltalk updates

### DIFF
--- a/lib/python/machinekit/launcher.py
+++ b/lib/python/machinekit/launcher.py
@@ -251,6 +251,7 @@ def _exitHandler(signum, frame):
 
     if not _exiting:
         _exiting = True  # prevent double execution
+        sys.stdout.write("Caught interrupt; exiting\n")
         end_session()
         sys.exit(0)
 
@@ -266,10 +267,11 @@ def set_machinekit_ini(ini):
 
 
 # ensure mklauncher is running
-def ensure_mklauncher():
+def ensure_mklauncher(debug=False):
     try:
         subprocess.check_output(['pgrep', 'mklauncher'])
         return
     except subprocess.CalledProcessError:
         pass
-    start_process('exec mklauncher .')
+    start_process('exec mklauncher %s .' % (
+        '-d' if debug else ''))

--- a/lib/python/machinekit/launcher.py
+++ b/lib/python/machinekit/launcher.py
@@ -272,4 +272,4 @@ def ensure_mklauncher():
         return
     except subprocess.CalledProcessError:
         pass
-    start_process('mklauncher .')
+    start_process('exec mklauncher .')

--- a/src/machinetalk/haltalk/haltalk_main.cc
+++ b/src/machinetalk/haltalk/haltalk_main.cc
@@ -435,23 +435,35 @@ int main (int argc, char *argv[])
     // generic binding & announcement parameters
     // from $MACHINEKIT_INI
     self.netopts.rundir = RUNDIR;
-    if (mk_getnetopts(&self.netopts))
+    if (mk_getnetopts(&self.netopts)) {
+	fprintf(stderr, "Error:  mk_getnetopts() failed\n");
 	exit(1);
+    }
 
-    if (read_config(&self))
+    if (read_config(&self)) {
+	fprintf(stderr, "Error:  read_config() failed\n");
 	exit(1);
+    }
 
     // webtalk-specific port number from $MACHINEKIT_INI
-    if (read_machinekit_ini(&self))
+    if (read_machinekit_ini(&self)) {
+	fprintf(stderr, "Error:  read_machinekit_ini() failed\n");
 	exit(1);
+    }
 
     print_container = self.cfg->debug & 1; // log sent protobuf messages to stderr if debug & 1
 
     retval = hal_setup(&self);
-    if (retval) exit(retval);
+    if (retval) {
+	fprintf(stderr, "Error:  hal_setup() failed\n");
+	exit(retval);
+    }
 
     retval = zmq_init(&self);
-    if (retval) exit(retval);
+    if (retval) {
+	fprintf(stderr, "Error:  zmq_init() failed\n");
+	exit(retval);
+    }
 
 #ifdef NOTYET
     retval = bridge_init(&self);


### PR DESCRIPTION
- `launcher.py`:  flatten process hierarchy for mklauncher
  - Plumb debug option through to `mklauncher`
  - Print info message when exiting
- `haltalk`:  print exit error message instead of failing silently

