### PR TITLE
Allow RT threads to specify nowait

### DIFF
--- a/src/hal/lib/hal_thread.c
+++ b/src/hal/lib/hal_thread.c
@@ -117,7 +117,10 @@ static void thread_task(void *arg)
 	    // support actual period measurement (get the starting value right)
 	    fa.last_start_time = rtapi_get_time();
 
-	    rtapi_wait(thread->flags);
+            // If a nowait thread is idle, this becomes a tight loop that
+            // effectively spinlocks a single core processor. Allow the thread
+            // to sleep and give other threads some cpu time.
+	    rtapi_wait(thread->flags & ~TF_NOWAIT);
 	    continue;
 	}
 

--- a/src/rtapi/rtapi_task.c
+++ b/src/rtapi/rtapi_task.c
@@ -165,12 +165,14 @@ int _rtapi_task_new(const rtapi_task_args_t *args) {
 	return -EINVAL;
     }
 
+    /* Allow RT threads to use nowait. Required for external timing.
     if ((args->flags & (TF_NOWAIT|TF_NONRT)) == TF_NOWAIT) {
 	rtapi_print_msg(RTAPI_MSG_ERR,"task '%s' : nowait flag invalid for RT thread\n",
 			args->name);
 	rtapi_mutex_give(&(rtapi_data->mutex));
 	return -EINVAL;
     }
+    */
 
     // task slot found; reserve it and release lock
     rtapi_print_msg(RTAPI_MSG_DBG,


### PR DESCRIPTION
This addresses #1306. The original #941 changes seem to be adding in the missing multicore pieces to the mainline, and these are the only required modifications after the multicore merge.