### PR TITLE
Makefile: machinetalk protobuf jplan and interpolator linking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1611,10 +1611,10 @@ motmod-objs += libnml/posemath/sincos.o $(MATHSTUB)
 # vtexport-objs += hal/vtable-example/vcode.o
 
 obj-m += jplan.o
-jplan-objs := hal/jplanner/jplan.o
+jplan-objs := hal/jplanner/jplan.o machinetalk/build/machinetalk/protobuf/jplan.npb.o
 
 obj-m += interpolate.o
-interpolate-objs := hal/interpolator/interpolate.o
+interpolate-objs := hal/interpolator/interpolate.o machinetalk/build/machinetalk/protobuf/ros.npb.o
 
 obj-m += icomp.o
 icomp-objs := hal/icomp-example/icomp.o


### PR DESCRIPTION
see also:
https://github.com/machinekit/Machinekit-HAL/pull/27/commits/369d82ac6b86aece36ef2b86d78de54b29948c3b

jplan and interpolator were not properly linked