### PR TITLE
Remove python-gst deps for Stretch package builds

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -130,7 +130,12 @@ BUILD_DEPS=  # List of Build-Depends
 HAVE_FLAVOR=false
 
 # copy base templates into place
-cp control.in control
+## need python-gst0.10 for Jessie, none for Stretch
+if [ "$DISTRO_CODENAME" == "stretch" ]; then
+    cp control.stretch.in control
+else
+    cp control.in control
+fi
 echo "debian/control:  copied base template" >&2
 cp rules.in rules; chmod +x rules
 echo "debian/rules:  copied base template" >&2

--- a/debian/control.stretch.in
+++ b/debian/control.stretch.in
@@ -53,8 +53,7 @@ Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
     python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, python-simplejson, python-pyftpdlib,
     python-pydot, xdot,
-    tclreadline, bc, procps, psmisc,
-    python-gst0.10
+    tclreadline, bc, procps, psmisc
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which
  provides motion control for CNC machine tools and robotic

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -96,9 +96,16 @@ BASE = os.path.abspath( os.path.join( os.path.dirname( sys.argv[0] ), ".." ) )
 LIBDIR = os.path.join( BASE, "lib", "python" )
 sys.path.insert( 0, LIBDIR )
 
+global debver
+with open("/etc/debian_version") as f:
+        debver = f.read()[0]
+print debver
+
 # as now we know the libdir path we can import our own modules
 from gmoccapy import widgets       # a class to handle the widgets
-from gmoccapy import player        # a class to handle sounds
+# Stretch does not have a gst module available
+if debver < 9:
+    from gmoccapy import player        # a class to handle sounds
 from gmoccapy import notification  # this is the module we use for our error handling
 from gmoccapy import preferences   # this handles the preferences
 from gmoccapy import getiniinfo    # this handles the INI File reading so checking is done in that module
@@ -238,7 +245,10 @@ class gmoccapy( object ):
         self._init_dynamic_tabs()
         self._init_tooleditor()
         self._init_themes()
-        self._init_audio()
+	# Stretch does not have a gst module available
+	global debver
+	if debver < 9:
+	    self._init_audio()
         self._init_gremlin()
         self._init_hide_cursor()
         self._init_keyboard()

--- a/src/emc/usr_intf/gscreen/gscreen.py
+++ b/src/emc/usr_intf/gscreen/gscreen.py
@@ -60,16 +60,27 @@ try:
 except:
     print "**** GSCREEN INFO: You don't seem to have pynotify installed"
 
+global debver
+with open("/etc/debian_version") as f:
+        debver = f.read()[0]
+#print debver
+
 # try to add ability for audio feedback to user.
-try:
+
+# Stretch does not have a gst module available
+if debver < 9:
+    try:
+	_AUDIO_AVAILABLE = False
+        import pygst
+	pygst.require("0.10")
+        import gst
+	_AUDIO_AVAILABLE = True
+        print "**** GSCREEN INFO: audio available!"
+    except:
+	print "**** GSCREEN INFO: no audio alerts available - PYGST libray not installed?"
+else:
     _AUDIO_AVAILABLE = False
-    import pygst
-    pygst.require("0.10")
-    import gst
-    _AUDIO_AVAILABLE = True
-    print "**** GSCREEN INFO: audio available!"
-except:
-    print "**** GSCREEN INFO: no audio alerts available - PYGST libray not installed?"
+
 
 # BASE is the absolute path to linuxcnc base
 # libdir is the path to Gscreen python files


### PR DESCRIPTION
Debian have removed the python module `gst` from the python-gst-1.0 package available for Stretch.
This breaks gmoccapy GUI and means no sounds in gscreen.

The python-gst-1.0 package was backported by Debian to Jessie, which then created the same errors in Jessie packages too.

This reverts Jessie packages to `python-gst0.10` which does have `gst` module, removes python-gst deps from Stretch packages and adds distro based conditional tests to gmoccapy and gscreen, as to whether they should create an audio player, which is dependent upon module `gst` being available.

Fixes Issue at https://github.com/machinekit/machinekit/issues/1228#issuecomment-345339637
until author does more permanent revision

