### PR TITLE
 Add support for Debian Buster package builds 

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -12,7 +12,7 @@
 if test -x /usr/bin/lsb_release; then
     DISTRO_ID=$(lsb_release -is)  # Debian or Ubuntu
     DISTRO_RELEASE=$(lsb_release -rs)   # 8.1, 14.04, etc.
-    DISTRO_CODENAME=$(lsb_release -cs) # wheezy | jessie | stretch
+    DISTRO_CODENAME=$(lsb_release -cs) # wheezy | jessie | stretch | buster
 fi
 
 # Work out of the debian/ directory
@@ -130,12 +130,15 @@ BUILD_DEPS=  # List of Build-Depends
 HAVE_FLAVOR=false
 
 # copy base templates into place
-## need python-gst0.10 for Jessie, none for Stretch
+## need python-gst0.10 for Jessie, none for Stretch, no python-gtksourceview2 for Buster
 if [ "$DISTRO_CODENAME" == "stretch" ]; then
     cp control.stretch.in control
+elif [ "$DISTRO_CODENAME" == "buster" ]; then
+    cp control.buster.in control   	
 else
     cp control.in control
 fi
+
 echo "debian/control:  copied base template" >&2
 cp rules.in rules; chmod +x rules
 echo "debian/rules:  copied base template" >&2

--- a/debian/control.buster.in
+++ b/debian/control.buster.in
@@ -1,0 +1,60 @@
+Source: machinekit
+Section: misc
+Priority: extra
+Maintainer: John Morris <john@dovetail-automata.com>
+Build-Depends: debhelper (>= 6),
+    autoconf (>= 2.63), automake, libboost-python-dev, libgl1-mesa-dev,
+    libglu1-mesa-dev, libgtk2.0-dev, libmodbus-dev (>= 3.0), libudev-dev,
+    libncurses-dev, libreadline-dev, libusb-1.0-0-dev, libxmu-dev,
+    libxmu-headers, python (>= 2.6.6), python-dev (>= 2.6.6),
+    cython (>= 0.19), dh-python,
+    pkg-config, psmisc, python-tk, libxaw7-dev, libboost-serialization-dev,
+    libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson-dev (>= 2.5),
+    libwebsockets-dev (>= 1.2.2),
+    python-zmq (>= 14.0.1), procps,
+    liburiparser-dev, libssl-dev, python-setuptools,
+    uuid-dev, uuid-runtime, libavahi-client-dev,
+    libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
+    python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
+    python-simplejson, libtk-img, libboost-thread-dev,
+    python-pyftpdlib, tcl8.6-dev, tk8.6-dev @BUILD_DEPS@
+Standards-Version: 2.1.0
+
+#########################################################################
+## not built any more, components of it are in flavour packages
+##
+#Package: machinekit-dev
+#Architecture: any
+#Depends: make, g++, tcl8.6, tk8.6,
+#    ${shlibs:Depends}, ${misc:Depends},
+#    machinekit (= ${binary:Version}),
+#    yapps2-runtime
+#Section: libs
+#Description: PC based motion controller for real-time Linux
+# Machinekit is the next-generation Enhanced Machine Controller which
+# provides motion control for CNC machine tools and robotic
+# applications (milling, cutting, routing, etc.).
+# .
+# This package includes files needed to build new realtime components and
+# alternate front-ends for machinekit
+#########################################################################
+
+Package: machinekit
+Breaks: linuxcnc
+Replaces: linuxcnc
+Architecture: any
+Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
+    bwidget (>= 1.7), libtk-img (>=1.13),
+    ${python:Depends}, ${misc:Depends},
+    python-tk, python-imaging, python-imaging-tk,
+    python-gnome2, python-glade2,
+    python-numpy,
+    python-vte, python-xlib, python-gtkglext1, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1),
+    python-avahi, python-simplejson, python-pyftpdlib,
+    python-pydot, xdot,
+    tclreadline, bc, procps, psmisc
+Description: PC based motion controller for real-time Linux
+ Machinekit is the next-generation Enhanced Machine Controller which
+ provides motion control for CNC machine tools and robotic
+ applications (milling, cutting, routing, etc.).

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -26,8 +26,8 @@ endif
 THREADS_POSIX = --without-posix
 THREADS_RT_PREEMPT = --without-rt-preempt
 THREADS_XENOMAI = --without-xenomai
-THREADS_XENOMAI_KERNEL = --without-xenomai-kernel
-THREADS_RTAI_KERNEL = --without-rtai-kernel
+#THREADS_XENOMAI_KERNEL = --without-xenomai-kernel
+#THREADS_RTAI_KERNEL = --without-rtai-kernel
 
 # Kernel threads need a list of configured header source directories
 # for each architecture
@@ -81,10 +81,6 @@ build-stamp: debian/control
 	    $(THREADS_POSIX) \
 	    $(THREADS_RT_PREEMPT) \
 	    $(THREADS_XENOMAI) \
-	    $(THREADS_XENOMAI_KERNEL) \
-	    $(THREADS_RTAI_KERNEL) \
-	    $(HEADERS_XENOMAI_KERNEL_$(DEB_HOST_ARCH)) \
-	    $(HEADERS_RTAI_KERNEL_$(DEB_HOST_ARCH)) \
 	    --sysconfdir=/etc \
 	    --mandir=/usr/share/man \
 	    --enable-emcweb
@@ -107,10 +103,6 @@ ifneq ($(wildcard src/configure src/Makefile.inc),)
 	    $(THREADS_POSIX) \
 	    $(THREADS_RT_PREEMPT) \
 	    $(THREADS_XENOMAI) \
-	    $(THREADS_XENOMAI_KERNEL) \
-	    $(THREADS_RTAI_KERNEL) \
-	    $(HEADERS_XENOMAI_KERNEL_$(DEB_HOST_ARCH)) \
-	    $(HEADERS_RTAI_KERNEL_$(DEB_HOST_ARCH)) \
 	    --sysconfdir=/etc \
 	    --mandir=/usr/share/man \
 	    --enable-emcweb

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -238,7 +238,8 @@ binary-arch: build install
 
 	cat debian/machinekit/DEBIAN/shlibs debian/shlibs.pre > \
 	    debian/shlibs.local
-	dh_shlibdeps -l debian/machinekit/usr/lib
+	#enable buster builds to work with problematic shlib deps in current packages
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info -l debian/machinekit/usr/lib
 	dh_gencontrol
 	
 	dh_md5sums

--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -3,6 +3,9 @@
 # Build/cross-build packages and test Machinekit in Docker
 #
 # This script can be run manually or in Travis CI
+#
+# NB. for Buster builds, IMAGE needs to be set to 'arceye/mk-cross-builder'
+# and tag to amd64_10, armhf_10 or i386_10
 
 ###########################################################
 # Configuration from environment, CL args and defaults

--- a/scripts/build_source_package
+++ b/scripts/build_source_package
@@ -20,6 +20,7 @@ test ${TRAVIS_PULL_REQUEST:-false} = false && IS_PR=false || IS_PR=true
 case $TAG in
     *_8) DISTRO=jessie ;;
     *_9) DISTRO=stretch ;;
+    *_10) DISTRO=buster ;;
 esac
 
 COMMIT_TIMESTAMP="$(git log -1 --pretty=format:%at)"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2333,26 +2333,26 @@ then
     AC_MSG_ERROR([awk not found])
 fi
 
-if test -n "${rtai_kernels}${xenomai_kernels}${shmdrv_kernels}"; then
+#if test -n "${rtai_kernels}${xenomai_kernels}${shmdrv_kernels}"; then
     # Kernel module tools only needed for kthreads
-    AC_PATH_PROG(INSMOD, insmod, "none", $SPATH)
-    if test $INSMOD = "none"
-    then
-	AC_MSG_ERROR([insmod not found])
-    fi
+#    AC_PATH_PROG(INSMOD, insmod, "none", $SPATH)
+#    if test $INSMOD = "none"
+#    then
+#	AC_MSG_ERROR([insmod not found])
+#    fi
 
-    AC_PATH_PROG(RMMOD, rmmod, "none", $SPATH)
-    if test $RMMOD = "none"
-    then
-	AC_MSG_ERROR([rmmod not found])
-    fi
+#    AC_PATH_PROG(RMMOD, rmmod, "none", $SPATH)
+#    if test $RMMOD = "none"
+#    then
+#	AC_MSG_ERROR([rmmod not found])
+#    fi
 
-    AC_PATH_PROG(LSMOD, lsmod, "none", $SPATH)
-    if test $LSMOD = "none"
-    then
-	AC_MSG_ERROR([lsmod not found])
-    fi
-fi
+#    AC_PATH_PROG(LSMOD, lsmod, "none", $SPATH)
+#    if test $LSMOD = "none"
+#    then
+#	AC_MSG_ERROR([lsmod not found])
+#    fi
+#fi
 
 AC_PATH_PROG(PIDOF, pidof, "none", $SPATH)
 if test $PIDOF = "none"


### PR DESCRIPTION
Remove dependency on python-gtksourceview2 deprecated in Buster

Amend packaging to support Buster package builds

arceye/mk-cross-builder:amd64|armhf|i386 needs specifically selecting
but otherwise build process is identical and no custom packages reqd.

Remove defunct kernel threads options in rules.in and configure.ac 

Signed-off-by: Mick <arceye@mgware.co.uk>
