### PR TITLE
Add note to emclcd.cc re Stretch onwards

### DIFF
--- a/src/emc/usr_intf/emclcd.cc
+++ b/src/emc/usr_intf/emclcd.cc
@@ -23,6 +23,11 @@
 *
 * Supported interfaces include Serial and USB.
 *
+* NOTE: Some of programs whose output is parsed (ifconfig and netstat)
+*	are from the package net-tools.  
+*	This ceased to be installed by default from Debian Stretch
+*	and will need installing specifically for this program to 
+*	have a chance of working.
 ********************************************************************/
 
 #include <stdio.h>
@@ -1700,6 +1705,13 @@ int main(int argc, char *argv[])
 
     initMain();
     printf("emclcd starting\n");
+
+    // net-tools not installed by default Stretch onwards, see header
+    if( (access("/bin/netstat", F_OK ) == -1) || 
+	(access("/sbin/ifconfig", F_OK ) == -1) ){
+        fprintf(stderr, "Package net-tools required to run emclcd\n");
+	exit(1);
+    }
 
     // process local arguments
     strncpy(server, DEFAULT_SERVER, strlen(DEFAULT_SERVER) + 1);


### PR DESCRIPTION
Appears not worth the effort of converting this to use `ip a` and `ip route` to replace `ifconfig` and `netstat` respectively.
The output is different and would require a re-write of something it is unlikely anyone uses.

The package net-tools is still available, so test for netstat and ifconfig
and warn users that they need to install that package if not found.