### PR TITLE
add support for soc boards with pre-programmed fpga

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.h
@@ -56,5 +56,6 @@ typedef struct {
     int no_init_llio;
     int num;
     int debug;
+    int already_programmed;
 } hm2_soc_t;
 


### PR DESCRIPTION
this patch is allowing to use HM2 based soc boards pre-programmed fpga, good example is terrasic de10nano

successfully tested under fedora arm 27 + kernel 4.14.3 + rt5 + u-boot preloaded fpga on DE10-NANO

hal driver initialisation example:

newinst [HOSTMOT2](DRIVER) [HOSTMOT2]DEVNAME already_programmed=1 -- config=[HOSTMOT2](CONFIG)
