### PR TITLE
Fix runtests for Stretch and Buster

### DIFF
--- a/tests/linuxcncrsh/skip
+++ b/tests/linuxcncrsh/skip
@@ -1,0 +1,15 @@
+#!/bin/bash
+#                                                       -*-shell-script-*-
+
+# Skip the linuxcncrsh test if neither of the netcat binaries it uses are installed
+# this typically happens on Stretch and above, then screws up all the subsequent tests
+
+if [ -x /usr/bin/tcping ]; then
+    exit 0
+else
+    if [ -x /usr/bin/nc ]; then
+	exit 0
+    else
+        exit 1
+    fi
+fi

--- a/tests/mdi-queue/oword-queue-buster/skip
+++ b/tests/mdi-queue/oword-queue-buster/skip
@@ -1,0 +1,15 @@
+#!/bin/bash
+#                                                       -*-shell-script-*-
+
+# Skip the linuxcncrsh test if neither of the netcat binaries it uses are installed
+# this typically happens on Stretch and above, then screws up all the subsequent tests
+
+if [ -x /usr/bin/tcping ]; then
+    exit 0
+else
+    if [ -x /usr/bin/nc ]; then
+	exit 0
+    else
+        exit 1
+    fi
+fi

--- a/tests/mdi-queue/simple-queue-buster/skip
+++ b/tests/mdi-queue/simple-queue-buster/skip
@@ -1,0 +1,15 @@
+#!/bin/bash
+#                                                       -*-shell-script-*-
+
+# Skip the linuxcncrsh test if neither of the netcat binaries it uses are installed
+# this typically happens on Stretch and above, then screws up all the subsequent tests
+
+if [ -x /usr/bin/tcping ]; then
+    exit 0
+else
+    if [ -x /usr/bin/nc ]; then
+	exit 0
+    else
+        exit 1
+    fi
+fi

--- a/tests/t0/nonrandom/skip
+++ b/tests/t0/nonrandom/skip
@@ -1,0 +1,15 @@
+#!/bin/bash
+#                                                       -*-shell-script-*-
+
+# Skip the linuxcncrsh test if neither of the netcat binaries it uses are installed
+# this typically happens on Stretch and above, then screws up all the subsequent tests
+
+if [ -x /usr/bin/tcping ]; then
+    exit 0
+else
+    if [ -x /usr/bin/nc ]; then
+	exit 0
+    else
+        exit 1
+    fi
+fi

--- a/tests/t0/random-with-t0/skip
+++ b/tests/t0/random-with-t0/skip
@@ -1,0 +1,15 @@
+#!/bin/bash
+#                                                       -*-shell-script-*-
+
+# Skip the linuxcncrsh test if neither of the netcat binaries it uses are installed
+# this typically happens on Stretch and above, then screws up all the subsequent tests
+
+if [ -x /usr/bin/tcping ]; then
+    exit 0
+else
+    if [ -x /usr/bin/nc ]; then
+	exit 0
+    else
+        exit 1
+    fi
+fi

--- a/tests/t0/random-without-t0/skip
+++ b/tests/t0/random-without-t0/skip
@@ -1,0 +1,15 @@
+#!/bin/bash
+#                                                       -*-shell-script-*-
+
+# Skip the linuxcncrsh test if neither of the netcat binaries it uses are installed
+# this typically happens on Stretch and above, then screws up all the subsequent tests
+
+if [ -x /usr/bin/tcping ]; then
+    exit 0
+else
+    if [ -x /usr/bin/nc ]; then
+	exit 0
+    else
+        exit 1
+    fi
+fi

--- a/tests/toolchanger/toolno-pocket-differ/nonrandom/skip
+++ b/tests/toolchanger/toolno-pocket-differ/nonrandom/skip
@@ -1,0 +1,15 @@
+#!/bin/bash
+#                                                       -*-shell-script-*-
+
+# Skip the linuxcncrsh test if neither of the netcat binaries it uses are installed
+# this typically happens on Stretch and above, then screws up all the subsequent tests
+
+if [ -x /usr/bin/tcping ]; then
+    exit 0
+else
+    if [ -x /usr/bin/nc ]; then
+	exit 0
+    else
+        exit 1
+    fi
+fi

--- a/tests/toolchanger/toolno-pocket-differ/random/skip
+++ b/tests/toolchanger/toolno-pocket-differ/random/skip
@@ -1,0 +1,15 @@
+#!/bin/bash
+#                                                       -*-shell-script-*-
+
+# Skip the linuxcncrsh test if neither of the netcat binaries it uses are installed
+# this typically happens on Stretch and above, then screws up all the subsequent tests
+
+if [ -x /usr/bin/tcping ]; then
+    exit 0
+else
+    if [ -x /usr/bin/nc ]; then
+	exit 0
+    else
+        exit 1
+    fi
+fi


### PR DESCRIPTION
Quite a few runtests rely upon linuxcncrsh used in conjunction with
`tcping` or `nc`

The netcat package containing these binaries has been deprecated,
starting at Stretch, along with a lot of the old net-utils.
(Even ifconfig is not available unless specifically installed,
from the package net-tools)

Add a `skip` script to those tests which require deprecated binaries
to test for presence and skip if not found.

Not doing so will cause the failure of that and every subsequent
test because the linuxcnc/halcmd processes are left running.

Signed-off-by: Mick <arceye@mgware.co.uk>