### PR TITLE
Set slow (servo) thread to floating point

### DIFF
--- a/src/hal/drivers/hal_gpio_demo.hal
+++ b/src/hal/drivers/hal_gpio_demo.hal
@@ -2,7 +2,7 @@
 
 loadrt hal_gpio
 newthread fast 100000
-newthread slow 1000000
+newthread slow 1000000 fp
 
 loadrt stepgen step_type=5 ctrl_type=v 
 


### PR DESCRIPTION
This changed back to being a requirement with the multicore merge.  
Will default to no floating point.