### PR TITLE
posemath: Adapt upstream changes - import from linuxcnc #5724d8f59.

### DIFF
--- a/src/libnml/posemath/_posemath.c
+++ b/src/libnml/posemath/_posemath.c
@@ -523,14 +523,14 @@ int pmMatZyxConvert(PmRotationMatrix const * const m, PmEulerZyx * const zyx)
 {
     zyx->y = rtapi_atan2(-m->x.z, pmSqrt(pmSq(m->x.x) + pmSq(m->x.y)));
 
-    if (rtapi_fabs(zyx->y - (2 * PM_PI)) < ZYX_Y_FUZZ) {
+    if (fabs(zyx->y - PM_PI_2) < ZYX_Y_FUZZ) {
 	zyx->z = 0.0;
-	zyx->y = (2 * PM_PI);	/* force it */
-	zyx->x = rtapi_atan2(m->y.x, m->y.y);
-    } else if (rtapi_fabs(zyx->y + (2 * PM_PI)) < ZYX_Y_FUZZ) {
+	zyx->y = PM_PI_2;	/* force it */
+	zyx->x = atan2(m->y.x, m->y.y);
+    } else if (fabs(zyx->y + PM_PI_2) < ZYX_Y_FUZZ) {
 	zyx->z = 0.0;
-	zyx->y = -(2 * PM_PI);	/* force it */
-	zyx->x = -rtapi_atan2(m->y.z, m->y.y);
+	zyx->y = -PM_PI_2;	/* force it */
+	zyx->x = -atan2(m->y.z, m->y.y);
     } else {
 	zyx->z = rtapi_atan2(m->x.y, m->x.x);
 	zyx->x = rtapi_atan2(m->y.z, m->z.z);
@@ -543,13 +543,13 @@ int pmMatRpyConvert(PmRotationMatrix const * const m, PmRpy * const rpy)
 {
     rpy->p = rtapi_atan2(-m->x.z, pmSqrt(pmSq(m->x.x) + pmSq(m->x.y)));
 
-    if (rtapi_fabs(rpy->p - (2 * PM_PI)) < RPY_P_FUZZ) {
-	rpy->r = rtapi_atan2(m->y.x, m->y.y);
-	rpy->p = (2 * PM_PI);	/* force it */
+    if (fabs(rpy->p - PM_PI_2) < RPY_P_FUZZ) {
+	rpy->r = atan2(m->y.x, m->y.y);
+	rpy->p = PM_PI_2;	/* force it */
 	rpy->y = 0.0;
-    } else if (rtapi_fabs(rpy->p + (2 * PM_PI)) < RPY_P_FUZZ) {
-	rpy->r = -rtapi_atan2(m->y.z, m->y.y);
-	rpy->p = -(2 * PM_PI);	/* force it */
+    } else if (fabs(rpy->p + PM_PI_2) < RPY_P_FUZZ) {
+	rpy->r = -atan2(m->y.x, m->y.y);
+	rpy->p = -PM_PI_2;	/* force it */
 	rpy->y = 0.0;
     } else {
 	rpy->r = rtapi_atan2(m->y.z, m->z.z);


### PR DESCRIPTION
This is based on inspection of rcslib-2014.04.29 but is not a direct
copy as the API was changed from taking pointers to taking copies
when it comes to inputs that are not changed.
One of the atan2 calls is also changed.

Author: Jepler@unpythonic.net

Closes #1350

Signed-off-by: Mick <arceye@mgware.co.uk>