### PR TITLE
src/rtapi/userpci/list.h: fixes for compiling C++

### DIFF
--- a/src/rtapi/userpci/list.h
+++ b/src/rtapi/userpci/list.h
@@ -57,14 +57,14 @@ struct list_head {
  * This is only for internal list manipulation where we know
  * the prev/next entries already!
  */
-static inline void __list_add(struct list_head *new,
+static inline void __list_add(struct list_head *nw,
 			      struct list_head *prev,
 			      struct list_head *next)
 {
-	next->prev = new;
-	new->next = next;
-	new->prev = prev;
-	prev->next = new;
+	next->prev = nw;
+	nw->next = next;
+	nw->prev = prev;
+	prev->next = nw;
 }
 
 /**
@@ -75,9 +75,9 @@ static inline void __list_add(struct list_head *new,
  * Insert a new entry after the specified head.
  * This is good for implementing stacks.
  */
-static inline void list_add(struct list_head *new, struct list_head *head)
+static inline void list_add(struct list_head *nw, struct list_head *head)
 {
-	__list_add(new, head, head->next);
+	__list_add(nw, head, head->next);
 }
 
 /**
@@ -88,9 +88,9 @@ static inline void list_add(struct list_head *new, struct list_head *head)
  * Insert a new entry before the specified head.
  * This is useful for implementing queues.
  */
-static inline void list_add_tail(struct list_head *new, struct list_head *head)
+static inline void list_add_tail(struct list_head *nw, struct list_head *head)
 {
-	__list_add(new, head->prev, head);
+	__list_add(nw, head->prev, head);
 }
 
 /*
@@ -114,8 +114,8 @@ static inline void __list_del(struct list_head *prev, struct list_head *next)
 static inline void list_del(struct list_head *entry)
 {
 	__list_del(entry->prev, entry->next);
-	entry->next = (void *) 0;
-	entry->prev = (void *) 0;
+	entry->next = (struct list_head *) 0;
+	entry->prev = (struct list_head *) 0;
 }
 
 /**


### PR DESCRIPTION
@ArcEye @cdsteinkuehler @zultron
are these changes acceptable? Please advise if otherwise

C++ chockes on variables named "new"
/home/bas/projects/machinekit/include/userpci/list.h:60:49: error: expected ‘,’ or ‘...’ before ‘new’
 static inline void __list_add(struct list_head *new,

invalid conversion error of void pointer:
/machinekit/include/userpci/list.h:118:25: error: invalid conversion from ‘void*’ to ‘list_head*’ [-fpermissive]
  entry->prev = (void *) 0;