### PR TITLE
Add BCM2835 hardware to recognised processor types for RPi3

### DIFF
--- a/src/hal/drivers/cpuinfo.c
+++ b/src/hal/drivers/cpuinfo.c
@@ -41,6 +41,8 @@ char *get_cpuinfo_revision(char *revision)
          rpi_found = 1;
       else if (strcmp(hardware, "BCM2709") == 0)
          rpi_found = 1;
+      else if (strcmp(hardware, "BCM2835") == 0)
+         rpi_found = 1;
       sscanf(buffer, "Revision	: %s", revision);
    }
    fclose(fp);


### PR DESCRIPTION
Fixes #1223

Signed-off-by: Mick <arceye@mgware.co.uk>