### PR TITLE
Module loading and debugging

### DIFF
--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -180,17 +180,24 @@ Load(){
     # rtapi_msgd creates the global segment containing the error ring buffer
     # so start this first:
 
-    ${rtapi_msgd} --instance=$MK_INSTANCE $NAME_CMD \
-	--rtmsglevel=$DEBUG \
-	--usrmsglevel=$DEBUG \
-	--halsize=$HAL_SIZE $MSGD_OPTS || \
-	(echo "rtapi_msgd startup failed - aborting"; exit $?)
+    local cmd=(${rtapi_msgd} --instance=$MK_INSTANCE $NAME_CMD
+			     --rtmsglevel=$DEBUG
+			     --usrmsglevel=$DEBUG
+			     --halsize=$HAL_SIZE $MSGD_OPTS)
+    [ $DEBUG -eq 0 ] || echo "rtapi_msgd command:  ${cmd[@]}" >&2
+    "${cmd[@]}" || (
+	e=$?; echo "rtapi_msgd startup failed - aborting" >&2; exit $e)
 
     # rtapi_app_<flavor> now handles the kernel module loading
     # for kthreads as needed
+    local cmd=(${rtapi_app} --instance=$MK_INSTANCE $RTAPI_APP_OPTS)
     if [ $DEBUG -gt 0 ] ; then
-	    ${rtapi_app} --instance=$MK_INSTANCE $RTAPI_APP_OPTS  || \
-		(echo "rtapi_app startup failed - aborting"; exit $?)
+	echo "rtapi_app command:  ${cmd[@]}" >&2
+	"${cmd[@]}" || (
+	    e=$?; echo "rtapi_app startup failed; aborting" >&2; exit $e)
+    else
+	"${cmd[@]}" 2>&1 || (
+	    e=$?; echo "rtapi_app startup failed; aborting" >&2; exit $e)
     fi
     # wait until rtapi_app responds, meaning setup is complete
     # this avoids startup races
@@ -333,7 +340,8 @@ CheckUnloaded(){
 
     MSGD_PID=`$PIDOF msgd:$MK_INSTANCE`
     if [ "$MSGD_PID" != "" ] ; then
-	echo "instance $MK_INSTANCE still running - process msgd:$MK_INSTANCE present (pid $MSGD_PID) !"
+	echo "instance $MK_INSTANCE still running;" \
+	     "process msgd:$MK_INSTANCE present (pid $MSGD_PID) !" >&2
 	exit 1
     fi
 
@@ -343,8 +351,9 @@ CheckUnloaded(){
 
     RTAPI_PID=`$PIDOF rtapi:$MK_INSTANCE`
     if [ "$RTAPI_PID" != "" ] ; then
-	echo "instance $MK_INSTANCE inproperly shutdown!"
-	echo "msgd:$MK_INSTANCE gone, but rtapi:$MK_INSTANCE alive (pid $RTAPI_PID)"
+	echo "instance $MK_INSTANCE inproperly shutdown!" >&2
+	echo "msgd:$MK_INSTANCE gone," \
+	     "but rtapi:$MK_INSTANCE alive (pid $RTAPI_PID)" >&2
 	exit 1
     fi
 
@@ -359,9 +368,11 @@ CheckUnloaded(){
 
     for seg in `ls $POSIXSHM 2>/dev/null` ; do
 	if pids=`fuser $seg  2>/dev/null` ; then
-	    echo instance $MK_INSTANCE: shared memory $seg still in use by pid: $pids !
+	    echo "instance $MK_INSTANCE: " \
+		 "shared memory $seg still in use by pid: $pids !" >&2
 	else
-	    echo instance $MK_INSTANCE: leftover shared memory $seg unused, removing
+	    echo "instance $MK_INSTANCE: " \
+		 "leftover shared memory $seg unused, removing" >&2
 	    rm -f $seg
 	fi
     done
@@ -376,7 +387,7 @@ CheckUnloaded(){
     for module in $MODULES_UNLOAD ; do
 	# check to see if the module is installed
 	if $LSMOD | awk '{print $1}' | grep -x $module >/dev/null ; then
-	    echo "ERROR: Could not unload '$module'"
+	    echo "ERROR: Could not unload '$module'" >&2
 	    STATUS=error
 	fi
     done

--- a/src/hal/lib/hal_object_selectors.h
+++ b/src/hal/lib/hal_object_selectors.h
@@ -24,18 +24,6 @@
 //    these can be extended as needed.
 
 //--------------------------------------------------------------------
-// use this selector to retrieve a pointer to a HAL object descriptor
-// selected by the standard selection (type, object ID/object name):
-//
-// selector-specific arguments:
-//
-// returned HAL object descriptor or NULL if not found
-//     .user_ptr1 = NULL,  // holy water - init to zero
-// };
-int yield_match(hal_object_ptr o, foreach_args_t *args);
-
-
-//--------------------------------------------------------------------
 // use this selector to retrieve the name of a HAL object
 // selected by the standard selection (type, object ID/object name prefix):
 //

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -1518,7 +1518,7 @@ int do_unloadrt_cmd(char *name)
 	goto FATAL;
 
     args.user_arg1 = 0; // now unload those which exported vtables
-    halg_foreach(1, &args, unload_rt_cb);
+    ret = halg_foreach(1, &args, unload_rt_cb);
     if (ret < 0)
 	goto FATAL;
     return 0;

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -1215,13 +1215,19 @@ bool inst_name_exists(const int use_halmutex, char *name)
     }
 }
 
-int loadrt(const int use_halmutex, char *mod_name, char *args[])
+int loadrt(const int use_halmutex, char *mod_path, char *args[])
 {
     char *cp1;
     int n, retval;
     char arg_string[MAX_CMD_LEN+1];
 
-    retval = rtapi_loadrt(rtapi_instance, mod_name, (const char **)args);
+    // Get the basename of args->name
+    char *mod_name = mod_path; // default case:  module loaded by rpath
+    for (int i=0; mod_path[i] != 0; i++)
+      if (mod_path[i] == '/')
+        mod_name = mod_path + i + 1;
+
+    retval = rtapi_loadrt(rtapi_instance, mod_path, (const char **)args);
     if ( retval != 0 ) {
 	halcmd_error("insmod failed, returned %d:\n%s\n"
 		     "See %s for more information.\n",

--- a/tests/rtapi.0/test.sh
+++ b/tests/rtapi.0/test.sh
@@ -1,17 +1,22 @@
 #!/bin/sh
 rm -f rtapi_test
-#set -e
+set -e
 gcc -g -DULAPI \
     -I../../include \
     rtapi_test.c \
-    ../../lib/libmtalk.so ../../lib/liblinuxcnculapi.so -o rtapi_test
+    ../../lib/libmtalk.so \
+    ../../lib/liblinuxcnculapi.so \
+    ../../lib/liblinuxcnchal.so \
+    -o rtapi_test
 
 realtime stop
+set +e
 ./rtapi_test
 if [ $? -ne 1 ]; then
     echo "rtapi_test: expected 1, got " $?
     exit 1;
 fi
+set -e
 realtime start
 ./rtapi_test
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Here's a stack of patches resulting from trying to run a comp both built *and installed* out-of-tree.

This fixes an issue loading comps from a given path instead of a given filename within the rpath.

There are also a couple of trivial fixes for module handling-related things I noticed along the excursion, a patch to `realtime.in` with various minor fixes, and a fix for the `rtapi.0` test that breaks on Ubuntu (prob. due to differences in the Ubuntu linker build-time options, previously discussed).
