### PR TITLE
Work

### DIFF
--- a/configs/hm2-soc-stepper/5i25-soc-cramps.ini
+++ b/configs/hm2-soc-stepper/5i25-soc-cramps.ini
@@ -9,7 +9,6 @@
 DRIVER=hm2_soc_ol
 BOARD=5i25
 CONFIG="firmware=socfpga/dtbo/DE0_Nano_SoC_Cramps.3x24.dtbo num_pwmgens=6 num_stepgens=8"
-#CONFIG="firmware=socfpga/dtbo/DE0_Nano_SoC_Cramps.Cramps_3x24_dpll_irq_adc_cap_spi.dtbo num_pwmgens=2 num_stepgens=8"
 DEVNAME=hm2-socfpga0
 
 
@@ -175,10 +174,8 @@ SCALE =           320
 MIN_LIMIT =             -100.0
 MAX_LIMIT =             100.0
 
-#FERROR =     0.050
-#MIN_FERROR = 0.005
-FERROR =			2.0
-MIN_FERROR = 	0.20
+FERROR =        800
+MIN_FERROR =    200
 
 HOME =                  0.000
 HOME_OFFSET =           0.10
@@ -192,8 +189,6 @@ DIRSETUP =			650
 DIRHOLD =			650
 STEPLEN =			1900
 STEPSPACE =			1900
-
-
 
 
 [AXIS_1]
@@ -216,11 +211,8 @@ SCALE = 640
 MIN_LIMIT =             -1000.0
 MAX_LIMIT =             1000.0
 
-#FERROR =     0.050
-#MIN_FERROR = 0.005
-
-FERROR =			2.0
-MIN_FERROR =   0.20
+FERROR =        800
+MIN_FERROR =    200
 
 
 HOME =                  0.000
@@ -231,15 +223,10 @@ HOME_USE_INDEX =                NO
 HOME_IGNORE_LIMITS =            NO
 
 # these are in nanoseconds
-#DIRSETUP   =              200
-#DIRHOLD    =              200
-#STEPLEN    =              40000
-#STEPSPACE  =              40000
-
-DIRSETUP =			30
-DIRHOLD =			30
-STEPLEN =			30
-STEPSPACE =			30
+DIRSETUP =			650
+DIRHOLD =			650
+STEPLEN =			1900
+STEPSPACE =			1900
 
 
 
@@ -259,8 +246,8 @@ SCALE = -1000
 MIN_LIMIT =             -100.0
 MAX_LIMIT =             100.0
 
-FERROR =     12.6
-MIN_FERROR = 1.26
+FERROR =        800
+MIN_FERROR =    200
 
 HOME =                  0.0
 HOME_OFFSET =           0.0
@@ -270,16 +257,10 @@ HOME_USE_INDEX =                 NO
 HOME_IGNORE_LIMITS =             NO
 
 # these are in nanoseconds
-#DIRSETUP   =              200
-#DIRHOLD    =              200
-#STEPLEN    =              40000
-#STEPSPACE  =              40000
-
 DIRSETUP =			650
 DIRHOLD =			650
 STEPLEN =			1900
 STEPSPACE =			1900
-
 
 
 [EMCIO]

--- a/configs/hm2-soc-stepper/5i25-soc-cramps_no-fw-load.ini
+++ b/configs/hm2-soc-stepper/5i25-soc-cramps_no-fw-load.ini
@@ -1,0 +1,277 @@
+
+#The hm2 sample stepper config should be pretty close. Copy an existing say
+#5I20.ini file to 5i25-probx.ini or some such, replace the BOARD with 5i25,
+#delete the firmware string on the loadrt hm2 line and you should be pretty
+#close. The hm2-soc-stepper file may need some changes as well for any GPIO may not
+#make sense with the 5i25 config
+
+[HOSTMOT2]
+DRIVER=hm2_soc_ol
+BOARD=5i25
+CONFIG="num_pwmgens=6 num_stepgens=8"
+#CONFIG="firmware=socfpga/dtbo/DE0_Nano_SoC_Cramps.3x24.dtbo num_pwmgens=6 num_stepgens=8"
+DEVNAME=hm2-socfpga0 already_programmed=1
+
+
+
+
+[EMC]
+
+#- Version of this INI file
+VERSION =               $Revision$
+
+# Name of machine, for use with display, etc.
+MACHINE =               HM2-Soc-OL-Stepper
+
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+#DEBUG =                0x00000003
+DEBUG =                0x00000007
+#DEBUG = 0
+
+
+
+
+[DISPLAY]
+
+# Name of display program, e.g., tkemc
+#DISPLAY =               tkemc
+DISPLAY =              axis
+
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.200
+
+# Path to help file
+#HELP_FILE =             tklinucnc.txt
+
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.5
+
+# Prefix to be used
+PROGRAM_PREFIX = ../../nc_files/
+
+# Introductory graphic
+INTRO_GRAPHIC =         machinekit.gif
+INTRO_TIME =            2
+
+# Increments for the JOG section
+INCREMENTS = 10 1 0.1 0.01
+
+
+#PYVCP = 3D.Temps.panel.xml
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+
+
+[TASK]
+
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.010
+
+
+
+
+[RS274NGC]
+
+# File containing interpreter variables
+PARAMETER_FILE =        hm2-soc-stepper.var
+
+
+
+
+[EMCMOT]
+
+EMCMOT =                motmod
+
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+
+# Interval between tries to emcmot, in seconds
+COMM_WAIT =             0.010
+
+#+ Base task period, in nanosecs - this is the fastest thread in the machine
+BASE_PERIOD =   200000
+
+#- Servo task period, in nanosecs - will be rounded to an int multiple of BASE_PERIOD
+SERVO_PERIOD =  2100000
+
+
+[HAL]
+
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+
+HALFILE =		hm2-soc-stepper-5i25-cramps.hal
+
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =               save neta
+
+
+[TRAJ]
+
+AXES =                  3
+COORDINATES =           X Y Z
+#HOME =                  0 0 0
+LINEAR_UNITS =          mm
+ANGULAR_UNITS =         degree
+CYCLE_TIME =            0.010
+
+DEFAULT_VELOCITY =      15
+MAX_VELOCITY =          3000
+DEFAULT_ACCELERATION =  6000
+MAX_ACCELERATION =      8000
+MAX_LINEAR_VELOCITY = 2000.00
+
+
+[AXIS_0]
+
+#
+# Step timing is 40 us steplen + 40 us stepspace
+# That gives 80 us step period = 12.5 KHz step freq
+#
+# Bah, even software stepping can handle that, hm2 doesnt buy you much with
+# such slow steppers.
+#
+# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
+#
+# This gives a maxvel of 12.5/1 = 12.5 ips
+#
+
+
+TYPE =              LINEAR
+MAX_VELOCITY =       200
+MAX_ACCELERATION =   1000
+STEPGEN_MAX_VEL =    250
+STEPGEN_MAX_ACC =    1250
+# Set Stepgen max 20% higher than the axis
+
+#STEPGEN_MAX_VEL =    12
+#STEPGEN_MAX_ACC =    24
+
+#BACKLASH =           0.000
+
+# scale is 200 steps/rev * 5 revs/inch
+#SCALE =           1000
+SCALE =           320
+
+MIN_LIMIT =             -100.0
+MAX_LIMIT =             100.0
+
+FERROR =        800
+MIN_FERROR =    200
+
+HOME =                  0.000
+HOME_OFFSET =           0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+HOME_USE_INDEX =                NO
+HOME_IGNORE_LIMITS =            NO
+
+# these are in nanoseconds
+DIRSETUP =			650
+DIRHOLD =			650
+STEPLEN =			1900
+STEPSPACE =			1900
+
+
+[AXIS_1]
+
+TYPE =              LINEAR
+MAX_VELOCITY =       20000
+MAX_ACCELERATION =   100000
+STEPGEN_MAX_VEL =    25000
+STEPGEN_MAX_ACC =    125000
+# Set Stepgen max 20% higher than the axis
+#STEPGEN_MAX_VEL =    12
+#STEPGEN_MAX_ACC =    24
+
+#BACKLASH =           0.000
+
+#SCALE = 1000
+#SCALE = 1250
+SCALE = 640
+
+MIN_LIMIT =             -1000.0
+MAX_LIMIT =             1000.0
+
+FERROR =        800
+MIN_FERROR =    200
+
+
+HOME =                  0.000
+HOME_OFFSET =           -0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+HOME_USE_INDEX =                NO
+HOME_IGNORE_LIMITS =            NO
+
+# these are in nanoseconds
+DIRSETUP =			650
+DIRHOLD =			650
+STEPLEN =			1900
+STEPSPACE =			1900
+
+
+
+[AXIS_2]
+
+TYPE =              LINEAR
+MAX_VELOCITY =      10
+#MAX_ACCELERATION =  20
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    12
+STEPGEN_MAX_ACC =    24
+
+BACKLASH =           0.000
+
+SCALE = -1000
+
+MIN_LIMIT =             -100.0
+MAX_LIMIT =             100.0
+
+FERROR =        800
+MIN_FERROR =    200
+
+HOME =                  0.0
+HOME_OFFSET =           0.0
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+HOME_USE_INDEX =                 NO
+HOME_IGNORE_LIMITS =             NO
+
+# these are in nanoseconds
+DIRSETUP =			650
+DIRHOLD =			650
+STEPLEN =			1900
+STEPSPACE =			1900
+
+
+[EMCIO]
+
+# Name of IO controller program, e.g., io
+EMCIO =                 io
+
+# cycle time, in seconds
+CYCLE_TIME =            0.100
+
+# tool table file
+TOOL_TABLE =            tool.tbl
+

--- a/configs/hm2-soc-stepper/hm2-soc-stepper-5i25-cramps.hal
+++ b/configs/hm2-soc-stepper/hm2-soc-stepper-5i25-cramps.hal
@@ -38,7 +38,7 @@ loadrt tp
 loadrt hostmot2
 
 # load low-level driver
-newinst [HOSTMOT2](DRIVER) [HOSTMOT2]DEVNAME -- config=[HOSTMOT2](CONFIG)  debug=1
+newinst [HOSTMOT2](DRIVER) [HOSTMOT2](DEVNAME) -- config=[HOSTMOT2](CONFIG)  debug=1
 
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES  #tp=tp kins=trivkins
 

--- a/src/hal/utils/Submakefile
+++ b/src/hal/utils/Submakefile
@@ -33,6 +33,17 @@ $(call TOOBJSDEPS, $(HALCMDCCSRCS)) : EXTRAFLAGS =  \
 	$(PROTOBUF_LIBS) $(CZMQ_LIBS) $(AVAHI_LIBS) -lm -lstdc++
 TARGETS += ../bin/halcmd
 
+ifdef TARGET_PLATFORM_SOCFPGA
+HM2UTILRCS := hal/utils/mksocmemio.c
+$(call TOOBJSDEPS, $(HM2UTILRCS)) : EXTRAFLAGS = -Wall -Werror -std=c99
+USERSRCS += $(HM2UTILRCS)
+../bin/mksocmemio: $(call TOOBJS, $(HM2UTILRCS))
+	$(ECHO) Linking $(notdir $@)
+	@mkdir -p $(dir $@)
+	$(Q)$(CC) $(LDFLAGS) -g -Wall -o $@ $^
+TARGETS += ../bin/mksocmemio
+endif
+
 ifdef HAVE_GTK
 HALMETERSRCS := \
     hal/utils/meter.c \

--- a/src/hal/utils/mksocmemio.c
+++ b/src/hal/utils/mksocmemio.c
@@ -1,0 +1,101 @@
+#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+
+#define HW_REGS_SPAN ( 65536 )
+
+//#define MAX_ADDR 65533 (higher creates no output error)
+#define MAX_ADDR 1020
+
+static void show_usage(void)
+{
+    printf("mksocmemio: Utility to read or write hm2socfpga memory locatons\n");
+    printf("Note: the mksocfpga uio0 driver needs to be active\n ");
+    printf("To input Hexadecimal Address and data values, preceed the number with 0x:\n");
+    printf("Usage options:\n");
+    printf(" -h For this help message.\n");
+    printf(" -r For reading an address: [-r <address>]\n");
+    printf(" -w For writing an address: [-w <address> <value>]\n");
+}
+
+
+int main ( int argc, char *argv[] )
+{
+    void *virtual_base;
+    void *h2p_lw_axi_mem_addr=NULL;
+    int fd;
+    u_int32_t index, inval;
+    
+    // Open /dev/uio0
+    if ( ( fd = open ( "/dev/uio0", ( O_RDWR | O_SYNC ) ) ) == -1 ) {
+        printf ( "    ERROR: could not open \"/dev/uio0\"...\n" );
+        return ( 1 );
+    }
+    
+    // get virtual addr that maps to physical
+    virtual_base = mmap( NULL, HW_REGS_SPAN, ( PROT_READ | PROT_WRITE ), MAP_SHARED, fd, 0);
+    
+    if ( virtual_base == MAP_FAILED ) {
+        printf ( "    ERROR: mmap() failed...\n" );
+        
+        close ( fd );
+        return ( 1 );
+    }
+    // Get the base address that maps to the device
+    //    assign pointer
+    h2p_lw_axi_mem_addr=virtual_base;
+    if (argc > 2) {
+        if(argv[2][0] == '0' && argv[2][1] == 'x') {
+            printf("Hex address value input found\n");
+            index = (u_int32_t) strtoul(argv[2], NULL, 16);
+        }
+        else {
+            printf("Assuming decimal address value input\n");
+            index = (u_int32_t) strtoul(argv[2], NULL, 10);
+        }
+        u_int32_t value = *((u_int32_t *)(h2p_lw_axi_mem_addr + index));
+    
+        switch (argv[1][1]) {
+            case 'r':
+                printf("Read: ");
+                printf("Address   0x%08X\t%u\n \tvalue = 0x%08X\t%u \n", index, index, value, value);
+                break;
+            case 'w':
+                if (argc == 4) {
+                    printf("Write: ");
+//                    printf("Address   0x%08X\t %u will be set to\nvalue   0x%08X \t %u \n", index, index, value, value);
+                    if(argv[3][0] == '0' && argv[3][1] == 'x') {
+                        inval = (u_int32_t) strtoul(argv[3], NULL, 16);
+                    }
+                    else {
+                        inval = (u_int32_t) strtoul(argv[3], NULL, 10);
+                    }
+                    *((u_int32_t *)(h2p_lw_axi_mem_addr + index)) = inval;
+                    printf("Wrote:  0x%08X\t %u\tto Address --> 0x%08X\t%u \n", inval, inval, index, index);                    
+                } else {
+                    printf("Value missing use: mksocmemio -h to show valid options and argunemts\n");
+                }
+                break;
+            default:
+                printf("Wrong option: %s\n use: mksocmemio -h to show valid options and argunemts\n", argv[1]);
+                break;
+        }
+
+    }
+    else if (argc == 2) {
+        switch (argv[1][1]){
+            case 'h':
+                show_usage();
+                break;
+            default:
+                printf("Wrong option %s\n use: mksocmemio -h to show valid options and argunemts\n", argv[1]);
+                break;
+        }
+    }
+    close ( fd );
+    return (0);
+}


### PR DESCRIPTION
I cleaned up the socfpga hostmot2 memory utility:

  mksocmemio

and this is an attempt to move it in from the mksocfpga repo so that it (only) gets compiled in MK in the socfpga flavor.

Also a fix for the joint.x error and a new (no bitfile load) config demonstrating how to use the:

      already_programmed=1

Setting (this took me a while to figure out)