### PR TITLE
Makefile.modinc:  add EXTRA_RTFLAGS to EXTRA_CFLAGS

### DIFF
--- a/src/Makefile.modinc.in
+++ b/src/Makefile.modinc.in
@@ -73,7 +73,7 @@ else
 include @EMC2_HOME@/share/linuxcnc/Makefile.inc
 endif
 
-EXTRA_CFLAGS := $(RTFLAGS) \
+EXTRA_CFLAGS := $(RTFLAGS) $(EXTRA_RTFLAGS) \
 	-D__MODULE__ \
 	$(call cc-option,-mieee-fp) \
 	$(KERNEL_MATH_CFLAGS)


### PR DESCRIPTION
Out-of-tree build system needs a way of adding CFLAGS to RT compile
commands, such as Sascha Ittner's EtherCAT RT comp, which must include
the EtherLab header files.