### PR TITLE
Fixup 080f48d7, "Fix out-of-tree module loading"

### DIFF
--- a/src/hal/cython/machinekit/rtapi.pyx
+++ b/src/hal/cython/machinekit/rtapi.pyx
@@ -218,7 +218,7 @@ class RTAPIcommand:
         if r:
             raise RuntimeError("rtapi_loadrt '%s' failed: %s" % (args,strerror(-r)))
 
-        return hal.components[name]
+        return hal.components[name.split('/')[-1]]
 
     def unloadrt(self,char *name, int instance=0):
         if name == NULL:


### PR DESCRIPTION
Commit 080f48d7 failed to address this case, calling `loadrt` from the
python rtapi module.

See PR #1367.