### PR TITLE
mkwrapper: fix new style class problems

### DIFF
--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -45,7 +45,8 @@ def getFreePort():
     return port
 
 
-class CustomFTPHandler(object, FTPHandler):
+# noinspection PyClassicStyleClass
+class CustomFTPHandler(FTPHandler):
 
     def on_file_received(self, file):
         # do something when a file has been received


### PR DESCRIPTION
FTP was not working after the last update. Turns out `pyftplib` does not support new-style classes.