### PR TITLE
return back hm2 setsserial module

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1464,7 +1464,7 @@ endif
 endif
 
 ifeq ($(BUILD_HOSTMOT2),yes)
-obj-$(CONFIG_HOSTMOT2) += hostmot2.o hm2_7i43.o hm2_7i90.o hm2_pci.o hm2_test.o
+obj-$(CONFIG_HOSTMOT2) += hostmot2.o hm2_7i43.o hm2_7i90.o hm2_pci.o hm2_test.o setsserial.o
 ifeq ($(BUILD_SYS),user-dso)
 obj-$(CONFIG_HOSTMOT2) += hm2_eth.o
 hm2_eth-objs  :=			  \
@@ -1514,7 +1514,7 @@ hm2_test-objs :=			  \
     hal/drivers/mesa-hostmot2/hm2_test.o  \
     hal/drivers/mesa-hostmot2/bitfile.o   \
     $(MATHSTUB)
-setsserial-objs :=			  \
+setsserial-objs +=			  \
     hal/drivers/mesa-hostmot2/setsserial.o  \
     $(MATHSTUB)
 endif
@@ -1829,6 +1829,7 @@ $(RTLIBDIR)/hostmot2$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hostmot2-objs))
 $(RTLIBDIR)/hm2_7i43$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hm2_7i43-objs))
 $(RTLIBDIR)/hm2_7i90$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hm2_7i90-objs))
 $(RTLIBDIR)/hm2_pci$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hm2_pci-objs))
+$(RTLIBDIR)/setsserial$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(setsserial-objs))
 ifeq ($(BUILD_SYS),user-dso)
 $(RTLIBDIR)/hm2_eth$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hm2_eth-objs))
 endif

--- a/src/hal/drivers/mesa-hostmot2/setsserial.c
+++ b/src/hal/drivers/mesa-hostmot2/setsserial.c
@@ -18,7 +18,11 @@
 //
 //    The code in this file is based on UFLBP.PAS by Peter C. Wallace.  
 
-#include <linux/firmware.h>
+#include "config_module.h"
+#include RTAPI_INC_SLAB_H
+#include RTAPI_INC_CTYPE_H
+#include RTAPI_INC_STRING_H
+
 #include "rtapi.h"
 #include "rtapi_app.h"
 #include "hal.h"
@@ -34,8 +38,6 @@ MODULE_LICENSE("GPL");
 
 static char *cmd;
 RTAPI_MP_STRING(cmd, "smart-serial setting commands");
-
-char **cmd_list;
 
 hostmot2_t *hm2;
 hm2_sserial_remote_t *remote;
@@ -421,6 +423,7 @@ fail0:
 int rtapi_app_main(void)
 {
     int cnt;
+    char **cmd_list;
     
     comp_id = hal_init("setsserial");
     hal_ready(comp_id);

--- a/src/rtapi/userpci/Submakefile
+++ b/src/rtapi/userpci/Submakefile
@@ -21,8 +21,12 @@ hostmot2-objs +=			  \
     rtapi/userpci/device.o		  \
     rtapi/userpci/firmware.o		  \
     rtapi/userpci/string.o
-endif
 
+setsserial-objs +=			  \
+    rtapi/userpci/device.o		  \
+    rtapi/userpci/firmware.o		  \
+    rtapi/userpci/string.o
+endif
 
 clean: userpci-clean
 userpci-clean:


### PR DESCRIPTION
this patch returns setsserial module (a utility for setting Smart Serial NVRAM parameters)

tested it today with de10nano (hm2_soc_ol) + 7i76 in setup mode

Jun 16 11:43:08 de10cnc rtapi:0[14537]: 4:rtapi_app:14537:user setsserial.so default iparms: ''
Jun 16 11:43:08 de10cnc rtapi:0[14537]: 4:rtapi_app:14537:user halg_xinitfv:90 HAL: initializing component 'setsserial' type=1 arg1=0 arg2=0/0x0
Jun 16 11:43:08 de10cnc rtapi:0[14537]: 1:rtapi_app:14537:user Firmware Flash Success
Jun 16 11:43:08 de10cnc rtapi:0[14537]: 4:rtapi_app:14537:user setsserial: loaded from setsserial.so

test script (for hm2_soc_ol):
loadrt hostmot2 sserial_baudrate=115200 debug_idrom=1 debug_module_descriptors=1 debug_pin_descriptors=1 debug_modules=1
newinst hm2_soc_ol hm2-socfpga0 already_programmed=1 -- config=""
loadrt setsserial cmd="flash hm2_de10.0.7i76.0.0 7I76R14.BIN"
exit
