### PR TITLE
update videoserver for new mjpg-streamer

### DIFF
--- a/src/machinetalk/videoserver/videoserver.py
+++ b/src/machinetalk/videoserver/videoserver.py
@@ -14,6 +14,9 @@ from machinekit import service
 from machinekit import config
 
 
+MJPG_STREAMER_PLUGIN_PATH = '/usr/local/lib/mjpg-streamer/'
+
+
 class VideoDevice:
     process = None
     service = None
@@ -90,7 +93,7 @@ class VideoServer(threading.Thread):
                 "dsname = ", videoDevice.dsname,
                 "port =", videoDevice.port))
 
-        libpath = '/usr/local/lib/'
+        libpath = MJPG_STREAMER_PLUGIN_PATH
         os.environ['LD_LIBRARY_PATH'] = libpath
 
         arguments = ""


### PR DESCRIPTION
This patch updates videoserver for the new [mjpg-streamer](https://github.com/machinekoder/mjpg-streamer) rather than the mjpeg-streamer used before.