### PR TITLE
Sample config - changing from 4DOF as default to 3DOF

### DIFF
--- a/configs/ARM/BeagleBone/Rostock-4DOF-CRAMPS/README.md
+++ b/configs/ARM/BeagleBone/Rostock-4DOF-CRAMPS/README.md
@@ -7,6 +7,39 @@ enable this please take a look at the Fabrikator-Mini-CRAMPS
 configuration.
 This configuration is using python configuration of HAL, have modular design, support 4 axis for Delta,
 using new Joint Angle Offsets and radius offsets to correct hardware build issues,
-Configuration is using Velocity Extrusion mode.
+Configuration is using Velocity Extrusion mode because Axis A is considered as Rotational Axis.
 
 To calibrate Delta use Dial indicator and following resource: http://www.escher3d.com/pages/wizards/wizarddelta.php
+
+
+This config have 2 possible types of configuration
+3DOF (default) - 3 degree of freedom (almost same as in configs/ARM/BeagleBone/MendelMax-CRAMPS/ with added lineardelta configuration)
+4DOF - 4 degree of freedom (same as 3DOF + 4-th axis with required changes)
+
+To use 4DOF configuration:
+change config filename in "run.py" file from "CRAMPS.3DOF.ini" to "CRAMPS.4DOF.ini"
+
+Joint offsets are configured in "CRAMPS.OTHER.inc" file under "[MACHINE]" section
+new parameters:
+JOINT_1_ANGLE_OFFSET - Degree of displacement from ideal JOINT position (positive or negative float value)
+JOINT_1_RADIUS_OFFSET - JOINT Radius displacement from DELTA_R (positive or negative float value)
+JOINT_2_ANGLE_OFFSET - Degree of displacement from ideal JOINT position (positive or negative float value)
+JOINT_2_RADIUS_OFFSET - JOINT Radius displacement from DELTA_R (positive or negative float value)
+
+If parameter is missing in config - then it considered as "0.00"
+
+JOINT Angles are considered following way:
+if you look at XY plane of LinearDelta printer then X0-Y0 is the center of print area
+Line from center to X"DELTA_R"-Y0 points to 0 degree
+Line from center to X0-Y"DELTA_R" points to 90 degree - JOINT_0
+JOINT_1 is displaced at 120 degree from JOINT_0 - (90+120) = 210
+JOINT_2 is displaced at 120 degree from JOINT_1 - (210+120) = 330
+and closing the loop
+JOINT_0 is displaced at 120 degree from JOINT_2 - (330+120)= 450 = (360+90) = 90
+
+in 4DOF configuration we have additional JOINT_3 (Rotational Axis - A)
+it's considered as rotational axis on Y axis
+Center of rotation going from Y"+DELTA_R",X0,Z0 to Y"-DELTA_R",X0,Z0
+Physicaly it`s looking like rotational device parallel to build plate with center of rotation going from 90 degree to (90+180) = 270 degree.
+
+4DOF configuration is considered as experimental - currently no slicer exist which can support 4-th axis, but you can use imagination.

--- a/configs/ARM/BeagleBone/Rostock-4DOF-CRAMPS/rostock-3dof.py
+++ b/configs/ARM/BeagleBone/Rostock-4DOF-CRAMPS/rostock-3dof.py
@@ -40,21 +40,20 @@ base.setup_stepper(section='AXIS_0', axisIndex=0, stepgenIndex=0, thread='servo-
 base.setup_stepper(section='AXIS_1', axisIndex=1, stepgenIndex=1, thread='servo-thread')
 # Z [2] Axis
 base.setup_stepper(section='AXIS_2', axisIndex=2, stepgenIndex=2, thread='servo-thread')
-
 # Extruder, velocity controlled
 for i in range(0, numExtruders):
     base.setup_stepper(section='EXTRUDER_%i' % i, stepgenIndex=3,
-                       axisIndex=(i+3), thread='servo-thread')
+                       velocitySignal='ve-extrude-vel', thread='servo-thread')
 
 # Extruder Multiplexer
 base.setup_extruder_multiplexer(extruders=numExtruders, thread='servo-thread')
 
 # Stepper Multiplexer
-#multiplexSections = []
-#for i in range(0, numExtruders):
-#    multiplexSections.append('EXTRUDER_%i' % i)
-#base.setup_stepper_multiplexer(stepgenIndex=5, sections=multiplexSections,
-#                               selSignal='extruder-sel', thread='servo-thread')
+multiplexSections = []
+for i in range(0, numExtruders):
+    multiplexSections.append('EXTRUDER_%i' % i)
+base.setup_stepper_multiplexer(stepgenIndex=4, sections=multiplexSections,
+                               selSignal='extruder-sel', thread='servo-thread')
 
 # Fans
 for i in range(0, numFans):

--- a/configs/ARM/BeagleBone/Rostock-4DOF-CRAMPS/run.py
+++ b/configs/ARM/BeagleBone/Rostock-4DOF-CRAMPS/run.py
@@ -16,7 +16,7 @@ try:
     if os.path.exists('/dev/video0'):  # automatically start videoserver
          launcher.start_process('videoserver -i video.ini Webcam1')
     launcher.start_process("configserver -n MendelMax ~/Cetus ~/Machineface")
-    launcher.start_process('linuxcnc CRAMPS.4DOF.ini')
+    launcher.start_process('linuxcnc CRAMPS.3DOF.ini')
     while True:
         launcher.check_processes()
         time.sleep(1)


### PR DESCRIPTION
While i was working on docs and requested changes - code was merged

so created new pull request
this pull request will sync rostock-3dof.py file with configs/ARM/BeagleBone/MendelMax-CRAMPS/mendelmax.py as was described in comment: https://github.com/machinekit/machinekit/pull/1385#discussion_r206775377
Put more details in Readme
and switch default setup to 3DOF configuration (usual LinearDelta style) - as it will be more usable for community