### PR TITLE
Changes to Configs to run on Stretch

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.bbio
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.bbio
@@ -1,0 +1,43 @@
+# File generated with BB pin configurator
+# title: Xylotex
+overlay cape-universal
+overlay cape-bone-iio
+#overlay cape-univ-emmc
+ P8_03 low #gpio1.06 Enable
+ P8_05 high #gpio1.02 Enable_n
+ P8_07 high #gpio2.02 Enable_n (ECO location)
+ P8_08 high #gpio2.03 
+ P8_09 in #gpio2.05 
+ P8_10 in #gpio2.04 
+ P8_13 low #gpio0.23 J2.PWM0-Heater
+ P8_14 in #gpio0.26 
+ P8_17 in #gpio0.27 
+ P8_18 in #gpio2.01 
+ P8_19 low #gpio0.22 J3.PWM1-Heater
+ P8_20 out #gpio1.31 E_ENA
+ P8_21 out #gpio1.30 E_DIR
+ P8_25 out #gpio1.00 STATUS_LED
+ P8_27 out #gpio2.22 Z_Step
+ P8_28 out #gpio2.24 Z_Ena
+ P8_29 out #gpio2.23 Z_Dir
+ P8_29 out #gpio2.23 Z_Dir
+ P8_30 out #gpio0.10 E_Step
+ P8_31 in #gpio0.10 X_Min
+ P8_32 in #gpio0.11 X_Max
+ P8_33 in #gpio0.09 Y_Max
+ P8_35 in #gpio0.08 Y_Min
+ P8_36 out #gpio2.16 J4.PWM
+ P8_37 in #gpio2.14 Z_Max
+ P8_38 in #gpio2.15 Z_Min
+ P8_39 out #gpio2.12 Z_Min
+ P8_40 out #gpio2.13 Y_Ena
+ P8_41 out #gpio2.10 X_Ena
+ P8_42 out #gpio2.11 Y_Step
+ P8_43 out #gpio2.08 X_Step
+ P8_44 out #gpio2.09 X_Dir
+ P8_45 low #gpio2.06 PWM1
+ P8_46 low #gpio2.07 PWM0
+ P9_14 low #gpio1.18 J4.PWM2-Heater
+# P9_36 in #THRM2
+# P9_38 in #THRM1
+# P9_40 in #THRM0

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
@@ -287,7 +287,7 @@ setp limit1.0.min 0
 net bed.temp.meas    <= Therm.temp1
 net bed.temp.meas    => pid.1.feedback
 
-sets bed.temp.set  0
+sets bed.temp.set    0
 net bed.temp.set     => pid.1.command
 
 net bed.heater  <= pid.1.output

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
@@ -8,23 +8,25 @@
 
 # Launch the setup script to make sure hardware setup looks good
 loadusr -w ./setup.bridge.sh
+#loadusr -w config-pin -f ./BeBoPr-Bridge.bbio
 
 
 # ###################################
 # Core EMC/HAL Loads
 # ###################################
-
 # kinematics
 loadrt trivkins
 
-# motion controller, get name and thread periods from ini file
 # trajectory planner
 loadrt tp
+
+# motion controller, get name and thread periods from ini file
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 
 # load low-level drivers
-loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
+#loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
+loadrt hal_bb_gpio output_pins=807,826,917,918,924,926 input_pins=808,809,810,814,817,818
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid count=2
 loadrt limit1 count=2
@@ -38,7 +40,7 @@ loadusr -Wn Therm ./ReadTemp.py -n Therm --num_chan 2 -t 1 1 -a 4 5
 # ################################################
 # THREADS
 # ################################################
-
+# hpg = [PRUCONF](DRIVER)
 addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
@@ -54,12 +56,9 @@ addf bb_gpio.write                        servo-thread
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
 # ######################################################
-
-
 # ################
 # X [0] Axis
 # ################
-
 # axis enable chain
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
@@ -90,9 +89,9 @@ setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.00.step_type       0
 # P8.43 PRU1.out2
-setp hpg.stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         843
 # P8.44 PRU1.out4
-setp hpg.stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          844
 
 
 # ################
@@ -129,9 +128,9 @@ setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.01.step_type       0
 # P8.42 PRU1.out5
-setp hpg.stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         842
 # P8.39 PRU1.out6
-setp hpg.stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          839
 
 
 # ################
@@ -168,9 +167,9 @@ setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.02.step_type       0
 # P8.27 PRU1.out8
-setp hpg.stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         827
 # P8.29 PRU1.out9
-setp hpg.stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          829
 
 
 # ################
@@ -207,9 +206,9 @@ setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.03.step_type       0
 # P8.30 GPIO2.25
-setp hpg.stepgen.03.steppin         0x22
+setp hpg.stepgen.03.steppin         830
 # P8.21 GPIO1.30
-setp hpg.stepgen.03.dirpin          0x23
+setp hpg.stepgen.03.dirpin          821
 
 
 # ##################################################
@@ -254,17 +253,17 @@ newsig bed.temp.meas float
 setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.pin       813
 setp hpg.pwmgen.00.out.00.enable    1
 setp hpg.pwmgen.00.out.00.value     0.0
 
 # J3 E1 Heater PRU1.out0
-setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.pin       819
 setp hpg.pwmgen.00.out.01.enable    1
 setp hpg.pwmgen.00.out.01.value     0.0
 
 # J4 Bed Heater GPIO2.16
-setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.pin       914
 setp hpg.pwmgen.00.out.02.enable    1
 setp hpg.pwmgen.00.out.02.value     0.0
 

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.ini
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.ini
@@ -47,6 +47,8 @@ MAX_FEED_OVERRIDE =     1.5
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../../nc_files/
+#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files/
+#PROGRAM_PREFIX = ~/machinekit/nc_files/
 
 # Introductory graphic
 INTRO_GRAPHIC =         machinekit.gif

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.ini
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.ini
@@ -1,28 +1,31 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=1 num_stepgens=4 num_pwmgens=3
-PRUBIN=xenomai/pru_generic.bin
+#PRUBIN=xenomai/pru_generic.bin
+PRUBIN=rt-preempt/pru_generic.bin
 
-
+###############################################################################
+# Hardware Abstraction Layer section
+###############################################################################
 [EMC]
 
 # Name of machine, for use with display, etc.
 MACHINE =               BeBoPr
 
 # Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+DEBUG = 0
 #DEBUG =                0x00000003
 #DEBUG =                0x00000007
-DEBUG = 0
 
 
-
-
+###############################################################################
+# Sections for display options 
+###############################################################################
 [DISPLAY]
-
 # Name of display program, e.g., tkemc
+DISPLAY = axis
 #DISPLAY = tkemc
 #DISPLAY = gscreen
-DISPLAY = axis
 
 # Touchy currently won't work without some hardware buttons/jog-wheel
 #DISPLAY = touchy
@@ -64,6 +67,9 @@ jpg = image-to-gcode
 py = python
 
 
+###############################################################################
+# Task controller section 
+###############################################################################
 [TASK]
 
 # Name of task controller program, e.g., milltask
@@ -73,16 +79,17 @@ TASK =                  milltask
 CYCLE_TIME =            0.010
 
 
-
-
+###############################################################################
+# Part program interpreter section 
+###############################################################################
 [RS274NGC]
 
 # File containing interpreter variables
 PARAMETER_FILE =        pru-stepper.var
 
-
-
-
+###############################################################################
+# Motion control section 
+###############################################################################
 [EMCMOT]
 
 EMCMOT =                motmod
@@ -97,8 +104,9 @@ COMM_WAIT =             0.010
 SERVO_PERIOD =          1000000
 
 
-
-
+###############################################################################
+# Hardware Abstraction Layer section
+###############################################################################
 [HAL]
 
 # The run script first uses halcmd to execute any HALFILE
@@ -116,6 +124,9 @@ HALFILE =		BeBoPr-Bridge.hal
 POSTGUI_HALFILE =       BeBoPr.postgui.hal
 
 
+###############################################################################
+# Trajectory planner section
+###############################################################################
 [TRAJ]
 
 AXES =                  4
@@ -132,6 +143,9 @@ MAX_LINEAR_VELOCITY = 200.00
 
 
 
+###############################################################################
+# Axes sections
+###############################################################################
 [AXIS_0]
 
 # 
@@ -182,6 +196,7 @@ STEPSPACE  =              1000
 
 
 
+################################################################
 [AXIS_1]
 
 TYPE =              LINEAR
@@ -203,11 +218,15 @@ MIN_FERROR = 0.25
 
 HOME =                  0.000
 HOME_OFFSET =           0.00
-HOME_SEARCH_VEL =       0.0
-HOME_LATCH_VEL =        0.0
 HOME_USE_INDEX =        NO
 HOME_IGNORE_LIMITS =    YES
 HOME_SEQUENCE =         0
+
+# Set to zero if you don't have physical home/limit switches
+# Set to the desired homing and latch velocity if you have switches
+# See: https://github.com/machinekit/machinekit-docs
+HOME_SEARCH_VEL =       0.0
+HOME_LATCH_VEL =        0.0
 
 # these are in nanoseconds
 DIRSETUP   =              200
@@ -218,6 +237,7 @@ STEPSPACE  =              1000
 
 
 
+################################################################
 [AXIS_2]
 
 TYPE =              LINEAR
@@ -239,11 +259,15 @@ MIN_FERROR = 0.25
 
 HOME =                  0.000
 HOME_OFFSET =           0.00
+HOME_IGNORE_LIMITS =    YES
+HOME_USE_INDEX =        NO
+HOME_SEQUENCE =         0
+
+# Set to zero if you don't have physical home/limit switches
+# Set to the desired homing and latch velocity if you have switches
+# See: https://github.com/machinekit/machinekit-docs
 HOME_SEARCH_VEL =       0.0
 HOME_LATCH_VEL =        0.0
-HOME_USE_INDEX =        NO
-HOME_IGNORE_LIMITS =    YES
-HOME_SEQUENCE =         0
 
 # these are in nanoseconds
 DIRSETUP   =              200
@@ -254,6 +278,7 @@ STEPSPACE  =              1000
 
 
 
+################################################################
 [AXIS_3]
 
 TYPE = ANGULAR
@@ -274,13 +299,17 @@ MAX_LIMIT = 999999999.0
 FERROR = 1.0
 MIN_FERROR = .25
 
-HOME = 0.0
-HOME_OFFSET = 0.0
+HOME =                  0.000
+HOME_OFFSET =           0.00
+HOME_IGNORE_LIMITS =    YES
+HOME_USE_INDEX =        NO
+HOME_SEQUENCE =         0
+
+# Set to zero if you don't have physical home/limit switches
+# Set to the desired homing and latch velocity if you have switches
+# See: https://github.com/machinekit/machinekit-docs
 HOME_SEARCH_VEL =       0.0
 HOME_LATCH_VEL =        0.0
-HOME_USE_INDEX =        NO
-HOME_IGNORE_LIMITS =    YES
-HOME_SEQUENCE =         0
 
 # these are in nanoseconds
 DIRSETUP   =              200

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
@@ -28,7 +28,8 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=lineardeltakins
 
 # load low-level drivers
-loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
+#loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
+loadrt hal_bb_gpio output_pins=807,826,917,918,924,926 input_pins=808,809,810,814,817,818
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid count=2
 loadrt limit1 count=2
@@ -103,9 +104,9 @@ setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.00.step_type       0
 # P8.43 PRU1.out2
-setp hpg.stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         843
 # P8.44 PRU1.out4
-setp hpg.stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          844
 
 # because column C is connected to the X-axis output
 # the bebopr-bridge signal needs to be X-max means P8.9
@@ -146,9 +147,9 @@ setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.01.step_type       0
 # P8.42 PRU1.out5
-setp hpg.stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         842
 # P8.39 PRU1.out6
-setp hpg.stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          839
 
 
 # because column A is connected to the Y-axis output
@@ -190,9 +191,9 @@ setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.02.step_type       0
 # P8.27 PRU1.out8
-setp hpg.stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         827
 # P8.29 PRU1.out9
-setp hpg.stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          829
 
 # because column B is connected to the Z-axis output
 # the bebopr-bridge signal needs to be Z-max means P8.18
@@ -233,9 +234,9 @@ setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.03.step_type       0
 # P8.30 GPIO2.25
-setp hpg.stepgen.03.steppin         0x22
+setp hpg.stepgen.03.steppin         830
 # P8.21 GPIO1.30
-setp hpg.stepgen.03.dirpin          0x23
+setp hpg.stepgen.03.dirpin          821
 
 
 # ##################################################
@@ -280,7 +281,7 @@ newsig fan.speed.set float
 setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.pin       813
 setp hpg.pwmgen.00.out.00.enable    1
 setp hpg.pwmgen.00.out.00.value     0.0
 
@@ -314,7 +315,7 @@ net e0_temp_within_range wcomp.0.out => motion.digital-in-00
 # no longer J3 E1 Heater PRU1.out0
 # instead used for FAN control
 # we use scale 255 for compatibility with slicing software
-setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.pin       819
 setp hpg.pwmgen.00.out.01.enable    1
 setp hpg.pwmgen.00.out.01.value     0.0
 setp hpg.pwmgen.00.out.01.scale     255
@@ -325,7 +326,7 @@ net fan.speed.set => hpg.pwmgen.00.out.01.value
 
 
 # J4 Bed Heater GPIO2.16
-setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.pin       914
 setp hpg.pwmgen.00.out.02.enable    1
 setp hpg.pwmgen.00.out.02.value     0.0
 

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.ini
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.ini
@@ -66,6 +66,8 @@ MAX_FEED_OVERRIDE =     1.5
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../../nc_files/
+#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files/
+#PROGRAM_PREFIX = ~/machinekit/nc_files/
 
 # Introductory graphic
 INTRO_GRAPHIC =         machinekit.gif

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.ini
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.ini
@@ -1,10 +1,8 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=1 num_stepgens=4 num_pwmgens=3
-PRUBIN=xenomai/pru_generic.bin
-
-
-
+#PRUBIN=xenomai/pru_generic.bin
+PRUBIN=rt-preempt/pru_generic.bin
 
 [EMC]
 
@@ -12,9 +10,9 @@ PRUBIN=xenomai/pru_generic.bin
 MACHINE =              LinearDelta
 
 # Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+DEBUG = 0
 #DEBUG =                0x00000003
 #DEBUG =                0x00000007
-DEBUG = 0
 
 
 
@@ -79,9 +77,6 @@ INCREMENTS = 10 1 0.1 0.01
 
 PYVCP = BeBoPr.panel.xml
 
-
-
-
 [FILTER]
 PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
 PROGRAM_EXTENSION = .py Python Script
@@ -89,8 +84,6 @@ png = image-to-gcode
 gif = image-to-gcode
 jpg = image-to-gcode
 py = python
-
-
 
 
 [TASK]
@@ -371,7 +364,4 @@ EMCIO =                 io
 CYCLE_TIME =            0.100
 
 # tool table file
-TOOL_TABLE =            tool.tbl
-
-
-
+TOOL_TABLE = tool.tbl

--- a/configs/ARM/BeagleBone/CRAMPS/CRAMPS.ini
+++ b/configs/ARM/BeagleBone/CRAMPS/CRAMPS.ini
@@ -47,6 +47,8 @@ MAX_FEED_OVERRIDE =     1.5
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../../nc_files/
+#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files/
+#PROGRAM_PREFIX = ~/machinekit/nc_files/
 
 # Introductory graphic
 INTRO_GRAPHIC =         machinekit.gif

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.ini
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.ini
@@ -55,8 +55,9 @@ MAX_SPINDLE_OVERRIDE =  1.0
 MIN_SPINDLE_OVERRIDE =  0.25
 
 # Prefix to be used
-#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files
-PROGRAM_PREFIX = ~/machinekit/nc_files/
+PROGRAM_PREFIX = ../../../nc_files/
+#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files/
+#PROGRAM_PREFIX = ~/machinekit/nc_files/
 
 # Introductory graphic
 INTRO_GRAPHIC =         linuxcnc.gif


### PR DESCRIPTION
Fixed configs for BeBoPr-Bridge to run on Stretch.
Changed ini files to have consistent "PROGRAM_PREFIX"
not sure yet which is best, but my inclination is "PROGRAM_PREFIX = ~/machinekit/nc_files".
https://github.com/machinekit/machinekit/commit/2d8a5da5bee062a1c0953ef23c2f2c993a0f20f
https://github.com/machinekit/machinekit/commit/c6bf459c80958b55ef44e1348457078e9c19b80d0