### PR TITLE
Fix symlink flavour dir creation disrupted by 45b4c7d

### DIFF
--- a/debian/posix-postinst-arm.add
+++ b/debian/posix-postinst-arm.add
@@ -1,4 +1,7 @@
 
+# make symlink to modules dir
+ln -sf /usr/lib/linuxcnc/modules /usr/lib/linuxcnc/posix
+
 # ensure the links do not pre-exist, from previous installs.
 # or user work-arounds,  which will produce error messages
 rm -f /usr/lib/linuxcnc/posix/pru_generic.bin

--- a/debian/rt-preempt-postinst-arm.add
+++ b/debian/rt-preempt-postinst-arm.add
@@ -1,4 +1,7 @@
 
+# make symlink to modules dir
+ln -sf /usr/lib/linuxcnc/modules /usr/lib/linuxcnc/rt-preempt
+
 # ensure the links do not pre-exist, from previous installs 
 # or user work-arounds,  which will produce error messages
 rm -f /usr/lib/linuxcnc/rt-preempt/pru_generic.bin

--- a/debian/xenomai-postinst-arm.add
+++ b/debian/xenomai-postinst-arm.add
@@ -1,4 +1,7 @@
 
+# make symlink to modules dir
+ln -sf /usr/lib/linuxcnc/modules /usr/lib/linuxcnc/xenomai
+
 # ensure the links do not pre-exist, from previous installs.
 # or user work-arounds,  which will produce error messages
 rm -f /usr/lib/linuxcnc/xenomai/pru_generic.bin

--- a/src/Makefile
+++ b/src/Makefile
@@ -140,10 +140,10 @@ ifeq ($(RUN_IN_PLACE)+$(BUILD_DRIVERS),yes+yes)
 			-ne 0 -o ! -u ../libexec/rtapi_app_$$f \) \
 		&& need_setuid=1; \
 	done; \
-	ln -sf $(EMC2_HOME)/rtlib/prubin/pru_generic.bin ../rtlib/modules/pru_generic.bin; \
-	ln -sf $(EMC2_HOME)/rtlib/prubin/pru_generic.dbg ../rtlib/modules/pru_generic.dbg; \
-	ln -sf $(EMC2_HOME)/rtlib/prubin/pru_decamux.bin ../rtlib/modules/pru_decamux.bin; \
-	ln -sf $(EMC2_HOME)/rtlib/prubin/pru_decamux.dbg ../rtlib/modules/pru_decamux.dbg; \
+	ln -sf $(EMC2_HOME)/rtlib/prubin/pru_generic.bin ../rtlib/modules/pru_generic.bin 2>/dev/null | true; \
+	ln -sf $(EMC2_HOME)/rtlib/prubin/pru_generic.dbg ../rtlib/modules/pru_generic.dbg 2>/dev/null | true; \
+	ln -sf $(EMC2_HOME)/rtlib/prubin/pru_decamux.bin ../rtlib/modules/pru_decamux.bin 2>/dev/null | true; \
+	ln -sf $(EMC2_HOME)/rtlib/prubin/pru_decamux.dbg ../rtlib/modules/pru_decamux.dbg 2>/dev/null | true; \
 	test "$$need_setuid" = 1 && \
 	    $(VECHO) -n "You now need to run 'sudo make setuid' " && \
 	    $(VECHO) "in order to run in place." || true


### PR DESCRIPTION
In moving flavour symlink creation inside a conditional test, left package arm postinst installs without the base flavour dir to link to.

Signed-off-by: Mick <arceye@mgware.co.uk>