### PR TITLE
Revert flavour changes

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.bbio
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.bbio
@@ -1,0 +1,43 @@
+# File generated with BB pin configurator
+# title: Xylotex
+overlay cape-universal
+overlay cape-bone-iio
+#overlay cape-univ-emmc
+ P8_03 low #gpio1.06 Enable
+ P8_05 high #gpio1.02 Enable_n
+ P8_07 high #gpio2.02 Enable_n (ECO location)
+ P8_08 high #gpio2.03 
+ P8_09 in #gpio2.05 
+ P8_10 in #gpio2.04 
+ P8_13 low #gpio0.23 J2.PWM0-Heater
+ P8_14 in #gpio0.26 
+ P8_17 in #gpio0.27 
+ P8_18 in #gpio2.01 
+ P8_19 low #gpio0.22 J3.PWM1-Heater
+ P8_20 out #gpio1.31 E_ENA
+ P8_21 out #gpio1.30 E_DIR
+ P8_25 out #gpio1.00 STATUS_LED
+ P8_27 out #gpio2.22 Z_Step
+ P8_28 out #gpio2.24 Z_Ena
+ P8_29 out #gpio2.23 Z_Dir
+ P8_29 out #gpio2.23 Z_Dir
+ P8_30 out #gpio0.10 E_Step
+ P8_31 in #gpio0.10 X_Min
+ P8_32 in #gpio0.11 X_Max
+ P8_33 in #gpio0.09 Y_Max
+ P8_35 in #gpio0.08 Y_Min
+ P8_36 out #gpio2.16 J4.PWM
+ P8_37 in #gpio2.14 Z_Max
+ P8_38 in #gpio2.15 Z_Min
+ P8_39 out #gpio2.12 Z_Min
+ P8_40 out #gpio2.13 Y_Ena
+ P8_41 out #gpio2.10 X_Ena
+ P8_42 out #gpio2.11 Y_Step
+ P8_43 out #gpio2.08 X_Step
+ P8_44 out #gpio2.09 X_Dir
+ P8_45 low #gpio2.06 PWM1
+ P8_46 low #gpio2.07 PWM0
+ P9_14 low #gpio1.18 J4.PWM2-Heater
+# P9_36 in #THRM2
+# P9_38 in #THRM1
+# P9_40 in #THRM0

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
@@ -287,7 +287,7 @@ setp limit1.0.min 0
 net bed.temp.meas    <= Therm.temp1
 net bed.temp.meas    => pid.1.feedback
 
-sets bed.temp.set  0
+sets bed.temp.set    0
 net bed.temp.set     => pid.1.command
 
 net bed.heater  <= pid.1.output

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
@@ -8,23 +8,25 @@
 
 # Launch the setup script to make sure hardware setup looks good
 loadusr -w ./setup.bridge.sh
+#loadusr -w config-pin -f ./BeBoPr-Bridge.bbio
 
 
 # ###################################
 # Core EMC/HAL Loads
 # ###################################
-
 # kinematics
 loadrt trivkins
 
-# motion controller, get name and thread periods from ini file
 # trajectory planner
 loadrt tp
+
+# motion controller, get name and thread periods from ini file
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
 
 # load low-level drivers
-loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
+#loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
+loadrt hal_bb_gpio output_pins=807,826,917,918,924,926 input_pins=808,809,810,814,817,818
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid count=2
 loadrt limit1 count=2
@@ -38,7 +40,7 @@ loadusr -Wn Therm ./ReadTemp.py -n Therm --num_chan 2 -t 1 1 -a 4 5
 # ################################################
 # THREADS
 # ################################################
-
+# hpg = [PRUCONF](DRIVER)
 addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
@@ -54,12 +56,9 @@ addf bb_gpio.write                        servo-thread
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
 # ######################################################
-
-
 # ################
 # X [0] Axis
 # ################
-
 # axis enable chain
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
@@ -90,9 +89,9 @@ setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.00.step_type       0
 # P8.43 PRU1.out2
-setp hpg.stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         843
 # P8.44 PRU1.out4
-setp hpg.stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          844
 
 
 # ################
@@ -129,9 +128,9 @@ setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.01.step_type       0
 # P8.42 PRU1.out5
-setp hpg.stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         842
 # P8.39 PRU1.out6
-setp hpg.stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          839
 
 
 # ################
@@ -168,9 +167,9 @@ setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.02.step_type       0
 # P8.27 PRU1.out8
-setp hpg.stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         827
 # P8.29 PRU1.out9
-setp hpg.stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          829
 
 
 # ################
@@ -207,9 +206,9 @@ setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.03.step_type       0
 # P8.30 GPIO2.25
-setp hpg.stepgen.03.steppin         0x22
+setp hpg.stepgen.03.steppin         830
 # P8.21 GPIO1.30
-setp hpg.stepgen.03.dirpin          0x23
+setp hpg.stepgen.03.dirpin          821
 
 
 # ##################################################
@@ -254,17 +253,17 @@ newsig bed.temp.meas float
 setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.pin       813
 setp hpg.pwmgen.00.out.00.enable    1
 setp hpg.pwmgen.00.out.00.value     0.0
 
 # J3 E1 Heater PRU1.out0
-setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.pin       819
 setp hpg.pwmgen.00.out.01.enable    1
 setp hpg.pwmgen.00.out.01.value     0.0
 
 # J4 Bed Heater GPIO2.16
-setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.pin       914
 setp hpg.pwmgen.00.out.02.enable    1
 setp hpg.pwmgen.00.out.02.value     0.0
 

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.ini
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.ini
@@ -47,6 +47,8 @@ MAX_FEED_OVERRIDE =     1.5
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../../nc_files/
+#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files/
+#PROGRAM_PREFIX = ~/machinekit/nc_files/
 
 # Introductory graphic
 INTRO_GRAPHIC =         machinekit.gif

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.ini
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.ini
@@ -1,28 +1,31 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=1 num_stepgens=4 num_pwmgens=3
-PRUBIN=xenomai/pru_generic.bin
+#PRUBIN=xenomai/pru_generic.bin
+PRUBIN=rt-preempt/pru_generic.bin
 
-
+###############################################################################
+# Hardware Abstraction Layer section
+###############################################################################
 [EMC]
 
 # Name of machine, for use with display, etc.
 MACHINE =               BeBoPr
 
 # Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+DEBUG = 0
 #DEBUG =                0x00000003
 #DEBUG =                0x00000007
-DEBUG = 0
 
 
-
-
+###############################################################################
+# Sections for display options 
+###############################################################################
 [DISPLAY]
-
 # Name of display program, e.g., tkemc
+DISPLAY = axis
 #DISPLAY = tkemc
 #DISPLAY = gscreen
-DISPLAY = axis
 
 # Touchy currently won't work without some hardware buttons/jog-wheel
 #DISPLAY = touchy
@@ -64,6 +67,9 @@ jpg = image-to-gcode
 py = python
 
 
+###############################################################################
+# Task controller section 
+###############################################################################
 [TASK]
 
 # Name of task controller program, e.g., milltask
@@ -73,16 +79,17 @@ TASK =                  milltask
 CYCLE_TIME =            0.010
 
 
-
-
+###############################################################################
+# Part program interpreter section 
+###############################################################################
 [RS274NGC]
 
 # File containing interpreter variables
 PARAMETER_FILE =        pru-stepper.var
 
-
-
-
+###############################################################################
+# Motion control section 
+###############################################################################
 [EMCMOT]
 
 EMCMOT =                motmod
@@ -97,8 +104,9 @@ COMM_WAIT =             0.010
 SERVO_PERIOD =          1000000
 
 
-
-
+###############################################################################
+# Hardware Abstraction Layer section
+###############################################################################
 [HAL]
 
 # The run script first uses halcmd to execute any HALFILE
@@ -116,6 +124,9 @@ HALFILE =		BeBoPr-Bridge.hal
 POSTGUI_HALFILE =       BeBoPr.postgui.hal
 
 
+###############################################################################
+# Trajectory planner section
+###############################################################################
 [TRAJ]
 
 AXES =                  4
@@ -132,6 +143,9 @@ MAX_LINEAR_VELOCITY = 200.00
 
 
 
+###############################################################################
+# Axes sections
+###############################################################################
 [AXIS_0]
 
 # 
@@ -182,6 +196,7 @@ STEPSPACE  =              1000
 
 
 
+################################################################
 [AXIS_1]
 
 TYPE =              LINEAR
@@ -203,11 +218,15 @@ MIN_FERROR = 0.25
 
 HOME =                  0.000
 HOME_OFFSET =           0.00
-HOME_SEARCH_VEL =       0.0
-HOME_LATCH_VEL =        0.0
 HOME_USE_INDEX =        NO
 HOME_IGNORE_LIMITS =    YES
 HOME_SEQUENCE =         0
+
+# Set to zero if you don't have physical home/limit switches
+# Set to the desired homing and latch velocity if you have switches
+# See: https://github.com/machinekit/machinekit-docs
+HOME_SEARCH_VEL =       0.0
+HOME_LATCH_VEL =        0.0
 
 # these are in nanoseconds
 DIRSETUP   =              200
@@ -218,6 +237,7 @@ STEPSPACE  =              1000
 
 
 
+################################################################
 [AXIS_2]
 
 TYPE =              LINEAR
@@ -239,11 +259,15 @@ MIN_FERROR = 0.25
 
 HOME =                  0.000
 HOME_OFFSET =           0.00
+HOME_IGNORE_LIMITS =    YES
+HOME_USE_INDEX =        NO
+HOME_SEQUENCE =         0
+
+# Set to zero if you don't have physical home/limit switches
+# Set to the desired homing and latch velocity if you have switches
+# See: https://github.com/machinekit/machinekit-docs
 HOME_SEARCH_VEL =       0.0
 HOME_LATCH_VEL =        0.0
-HOME_USE_INDEX =        NO
-HOME_IGNORE_LIMITS =    YES
-HOME_SEQUENCE =         0
 
 # these are in nanoseconds
 DIRSETUP   =              200
@@ -254,6 +278,7 @@ STEPSPACE  =              1000
 
 
 
+################################################################
 [AXIS_3]
 
 TYPE = ANGULAR
@@ -274,13 +299,17 @@ MAX_LIMIT = 999999999.0
 FERROR = 1.0
 MIN_FERROR = .25
 
-HOME = 0.0
-HOME_OFFSET = 0.0
+HOME =                  0.000
+HOME_OFFSET =           0.00
+HOME_IGNORE_LIMITS =    YES
+HOME_USE_INDEX =        NO
+HOME_SEQUENCE =         0
+
+# Set to zero if you don't have physical home/limit switches
+# Set to the desired homing and latch velocity if you have switches
+# See: https://github.com/machinekit/machinekit-docs
 HOME_SEARCH_VEL =       0.0
 HOME_LATCH_VEL =        0.0
-HOME_USE_INDEX =        NO
-HOME_IGNORE_LIMITS =    YES
-HOME_SEQUENCE =         0
 
 # these are in nanoseconds
 DIRSETUP   =              200

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
@@ -28,7 +28,8 @@ loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=lineardeltakins
 
 # load low-level drivers
-loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
+#loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
+loadrt hal_bb_gpio output_pins=807,826,917,918,924,926 input_pins=808,809,810,814,817,818
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
 loadrt pid count=2
 loadrt limit1 count=2
@@ -103,9 +104,9 @@ setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.00.step_type       0
 # P8.43 PRU1.out2
-setp hpg.stepgen.00.steppin         0x4C
+setp hpg.stepgen.00.steppin         843
 # P8.44 PRU1.out4
-setp hpg.stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.dirpin          844
 
 # because column C is connected to the X-axis output
 # the bebopr-bridge signal needs to be X-max means P8.9
@@ -146,9 +147,9 @@ setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.01.step_type       0
 # P8.42 PRU1.out5
-setp hpg.stepgen.01.steppin         0x4E
+setp hpg.stepgen.01.steppin         842
 # P8.39 PRU1.out6
-setp hpg.stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.dirpin          839
 
 
 # because column A is connected to the Y-axis output
@@ -190,9 +191,9 @@ setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.02.step_type       0
 # P8.27 PRU1.out8
-setp hpg.stepgen.02.steppin         0x50
+setp hpg.stepgen.02.steppin         827
 # P8.29 PRU1.out9
-setp hpg.stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.dirpin          829
 
 # because column B is connected to the Z-axis output
 # the bebopr-bridge signal needs to be Z-max means P8.18
@@ -233,9 +234,9 @@ setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.03.step_type       0
 # P8.30 GPIO2.25
-setp hpg.stepgen.03.steppin         0x22
+setp hpg.stepgen.03.steppin         830
 # P8.21 GPIO1.30
-setp hpg.stepgen.03.dirpin          0x23
+setp hpg.stepgen.03.dirpin          821
 
 
 # ##################################################
@@ -280,7 +281,7 @@ newsig fan.speed.set float
 setp hpg.pwmgen.00.pwm_period       10000000
 
 # J2 E0 Heater PRU1.out1
-setp hpg.pwmgen.00.out.00.pin       0x37
+setp hpg.pwmgen.00.out.00.pin       813
 setp hpg.pwmgen.00.out.00.enable    1
 setp hpg.pwmgen.00.out.00.value     0.0
 
@@ -314,7 +315,7 @@ net e0_temp_within_range wcomp.0.out => motion.digital-in-00
 # no longer J3 E1 Heater PRU1.out0
 # instead used for FAN control
 # we use scale 255 for compatibility with slicing software
-setp hpg.pwmgen.00.out.01.pin       0x36
+setp hpg.pwmgen.00.out.01.pin       819
 setp hpg.pwmgen.00.out.01.enable    1
 setp hpg.pwmgen.00.out.01.value     0.0
 setp hpg.pwmgen.00.out.01.scale     255
@@ -325,7 +326,7 @@ net fan.speed.set => hpg.pwmgen.00.out.01.value
 
 
 # J4 Bed Heater GPIO2.16
-setp hpg.pwmgen.00.out.02.pin       0x52
+setp hpg.pwmgen.00.out.02.pin       914
 setp hpg.pwmgen.00.out.02.enable    1
 setp hpg.pwmgen.00.out.02.value     0.0
 

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.ini
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.ini
@@ -66,6 +66,8 @@ MAX_FEED_OVERRIDE =     1.5
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../../nc_files/
+#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files/
+#PROGRAM_PREFIX = ~/machinekit/nc_files/
 
 # Introductory graphic
 INTRO_GRAPHIC =         machinekit.gif

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.ini
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.ini
@@ -1,10 +1,8 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=1 num_stepgens=4 num_pwmgens=3
-PRUBIN=xenomai/pru_generic.bin
-
-
-
+#PRUBIN=xenomai/pru_generic.bin
+PRUBIN=rt-preempt/pru_generic.bin
 
 [EMC]
 
@@ -12,9 +10,9 @@ PRUBIN=xenomai/pru_generic.bin
 MACHINE =              LinearDelta
 
 # Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+DEBUG = 0
 #DEBUG =                0x00000003
 #DEBUG =                0x00000007
-DEBUG = 0
 
 
 
@@ -79,9 +77,6 @@ INCREMENTS = 10 1 0.1 0.01
 
 PYVCP = BeBoPr.panel.xml
 
-
-
-
 [FILTER]
 PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
 PROGRAM_EXTENSION = .py Python Script
@@ -89,8 +84,6 @@ png = image-to-gcode
 gif = image-to-gcode
 jpg = image-to-gcode
 py = python
-
-
 
 
 [TASK]
@@ -371,7 +364,4 @@ EMCIO =                 io
 CYCLE_TIME =            0.100
 
 # tool table file
-TOOL_TABLE =            tool.tbl
-
-
-
+TOOL_TABLE = tool.tbl

--- a/configs/ARM/BeagleBone/CRAMPS/CRAMPS.bbio
+++ b/configs/ARM/BeagleBone/CRAMPS/CRAMPS.bbio
@@ -1,0 +1,52 @@
+# File generated with BB pin configurator
+# title: CRAMPS
+overlay cape-universal
+overlay cape-bone-iio
+#overlay cape-univ-emmc
+#P8_03 default
+#P8_04 default
+#P8_05 default
+#P8_06 default
+P8_07 in #X Max
+P8_08 in #X Min
+P8_09 in #Y Max
+P8_10 in #Y Min
+P8_11 low #FET 1 : Heated Bed
+P8_12 low #X Dir
+P8_13 low #X Step
+P8_14 low #Y Dir
+P8_15 low #Y Step
+P8_16 high #eMMC Enable
+P8_17 in #Estop In
+P8_18 low #Z Dir
+P8_19 low #Z Step
+#P8_20 default
+#P8_21 default
+#P8_22 low #Servo 4
+#P8_23 low #Servo 3
+#P8_24 low #Servo 2
+#P8_25 low #Servo 1
+P8_26 high #Estop out
+P9_11 in #Z Max
+P9_12 low #E0 Dir
+P9_13 in #Z Min
+P9_14 high #Axis Enable, act. low
+P9_15 low #FET 2 : E0
+P9_16 low #E0 Step
+P9_17 low #E1 Step
+P9_18 low #E1 Dir
+P9_21 low #FET 4 : E1
+P9_22 low #FET 6
+P9_23 low #Machine Power
+P9_24 low #E2 Step
+#P9_25 low #LED
+P9_26 low #E2 Dir
+P9_27 low #FET 3 : E2
+#P9_28 spi #SPI CS0
+#P9_29 spi #SPI MISO
+#P9_30 spi #SPI MOSI
+#P9_31 spi #SPI SCLK
+P9_41 low #FET 5
+#P9_42 spics #SPI CS1
+P9_91 in #Reserved, con. to P9.41 
+P9_92 in #Reserved, to P9.42

--- a/configs/ARM/BeagleBone/CRAMPS/CRAMPS.hal
+++ b/configs/ARM/BeagleBone/CRAMPS/CRAMPS.hal
@@ -1,27 +1,30 @@
 # #######################################
 #
-# HAL file for BeagleBone + BeBoPr cape with 4 steppers
+# HAL file for BeagleBone + CRAMPS cape with 4 steppers
 #
 # Derived from example hm2-stepper config
 #
 # ########################################
 
 # Launch the setup script to make sure hardware setup looks good
+#loadusr -w /home/machinekit/machinekit/configs/ARM.BeagleBone.CRAMPS/setup.sh
 loadusr -w ./setup.sh
+#loadusr -w config-pin -f ./CRAMPS.bbio
 
 
 # ###################################
 # Core EMC/HAL Loads
 # ###################################
-
 # kinematics
 loadrt trivkins
+#loadrt core_xy_kins
 
-# motion controller, get name and thread periods from ini file
 # trajectory planner
 loadrt tp
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
+# motion controller, get name and thread periods from ini file
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
+#loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=core_xy_kins
 
 # load low-level drivers
 loadrt hal_bb_gpio output_pins=816,822,823,824,825,826,914,923,925 input_pins=807,808,809,810,817,911,913
@@ -31,14 +34,16 @@ loadrt limit1 count=2
 
 
 # Python user-mode HAL module to read ADC value and generate a thermostat output for PWM
-# c = analog input channel and thermistor table
+# t = Thermistor table (only epcos_B57560G1104 or 1 supported for now)
+# a = analog input channel
+#loadusr -Wn Therm ./ReadTemp.py -n Therm --num_chan 2 -t 1 1 -a 4 5
 loadusr -Wn Therm hal_temp_bbb -n Therm -c 04:epcos_B57560G1104,05:epcos_B57560G1104 -b CRAMPS
 
 # ################################################
 # THREADS
 # ################################################
-
-addf hpg.capture-position   servo-thread
+# hpg = [PRUCONF](DRIVER)
+addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
@@ -46,19 +51,16 @@ addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
-addf hpg.update             servo-thread
+addf hpg.update                           servo-thread
 addf bb_gpio.write                        servo-thread
 
 
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
 # ######################################################
-
-
 # ################
 # X [0] Axis
 # ################
-
 # axis enable chain
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
@@ -238,7 +240,7 @@ net emcmot.00.enable => bb_gpio.p9.out-23
 
 # Tie machine power signal to the CRAMPS LED
 # Feel free to tie any other signal you like to the LED
-net emcmot.00.enable => bb_gpio.p9.out-25
+#net emcmot.00.enable => bb_gpio.p9.out-25
 
 # ################
 # Limit Switches

--- a/configs/ARM/BeagleBone/CRAMPS/CRAMPS.ini
+++ b/configs/ARM/BeagleBone/CRAMPS/CRAMPS.ini
@@ -47,6 +47,8 @@ MAX_FEED_OVERRIDE =     1.5
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../../nc_files/
+#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files/
+#PROGRAM_PREFIX = ~/machinekit/nc_files/
 
 # Introductory graphic
 INTRO_GRAPHIC =         machinekit.gif

--- a/configs/ARM/BeagleBone/CRAMPS/CRAMPS.ini
+++ b/configs/ARM/BeagleBone/CRAMPS/CRAMPS.ini
@@ -1,13 +1,16 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=0 num_stepgens=4 num_pwmgens=6
-PRUBIN=xenomai/pru_generic.bin
+#PRUBIN=xenomai/pru_generic.bin
+PRUBIN=rt-preempt/pru_generic.bin
 
-
+###############################################################################
+# Hardware Abstraction Layer section
+###############################################################################
 [EMC]
 
 # Name of machine, for use with display, etc.
-MACHINE =               MendelMax-CRAMPS
+MACHINE =               CRAMPS
 
 # Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
 #DEBUG =                0x00000003
@@ -15,14 +18,14 @@ MACHINE =               MendelMax-CRAMPS
 DEBUG = 0
 
 
-
-
+###############################################################################
+# Sections for display options 
+###############################################################################
 [DISPLAY]
-
 # Name of display program, e.g., tkemc
+DISPLAY = axis
 #DISPLAY = tkemc
 #DISPLAY = gscreen
-DISPLAY = axis
 
 # Touchy currently won't work without some hardware buttons/jog-wheel
 #DISPLAY = touchy
@@ -64,6 +67,9 @@ jpg = image-to-gcode
 py = python
 
 
+###############################################################################
+# Task controller section 
+###############################################################################
 [TASK]
 
 # Name of task controller program, e.g., milltask
@@ -73,16 +79,16 @@ TASK =                  milltask
 CYCLE_TIME =            0.010
 
 
-
-
+###############################################################################
+# Part program interpreter section 
+###############################################################################
 [RS274NGC]
-
 # File containing interpreter variables
 PARAMETER_FILE =        pru-stepper.var
 
-
-
-
+###############################################################################
+# Motion control section 
+###############################################################################
 [EMCMOT]
 
 EMCMOT =                motmod
@@ -97,8 +103,9 @@ COMM_WAIT =             0.010
 SERVO_PERIOD =          1000000
 
 
-
-
+###############################################################################
+# Hardware Abstraction Layer section
+###############################################################################
 [HAL]
 
 # The run script first uses halcmd to execute any HALFILE
@@ -107,7 +114,7 @@ SERVO_PERIOD =          1000000
 # list of hal config files to run through halcmd
 # files are executed in the order in which they appear
 
-HALFILE =		CRAMPS.hal
+HALFILE =               CRAMPS.hal
 
 # list of halcmd commands to execute
 # commands are executed in the order in which they appear
@@ -116,6 +123,9 @@ HALFILE =		CRAMPS.hal
 POSTGUI_HALFILE =       3D.postgui.hal
 
 
+###############################################################################
+# Trajectory planner section
+###############################################################################
 [TRAJ]
 
 AXES =                  4
@@ -132,6 +142,9 @@ MAX_LINEAR_VELOCITY = 200.00
 
 
 
+###############################################################################
+# Axes sections
+###############################################################################
 [AXIS_0]
 
 # 
@@ -186,6 +199,7 @@ STEPSPACE  =              1000
 
 
 
+################################################################
 [AXIS_1]
 
 TYPE =              LINEAR
@@ -226,6 +240,7 @@ STEPSPACE  =              1000
 
 
 
+################################################################
 [AXIS_2]
 
 TYPE =              LINEAR
@@ -267,6 +282,7 @@ STEPSPACE  =              1000
 
 
 
+################################################################
 [AXIS_3]
 
 TYPE = ANGULAR

--- a/configs/ARM/BeagleBone/CRAMPS/setup.sh
+++ b/configs/ARM/BeagleBone/CRAMPS/setup.sh
@@ -31,29 +31,21 @@ dir_err () {
 	exit 1
 }
 
-SLOTS=/sys/devices/bone_capemgr.*/slots
+PRU=/sys/class/uio/uio0
+echo -n "Waiting for $PRU "
 
-# Make sure required device tree overlay(s) are loaded
-for DTBO in cape-universal cape-bone-iio ; do
+while [ ! -r $PRU ]
+do
+    echo -n "."
+    sleep 1
+done
+echo OK
 
-	if grep -q $DTBO $SLOTS ; then
-		echo $DTBO overlay found
-	else
-		echo Loading $DTBO overlay
-		sudo -A su -c "echo $DTBO > $SLOTS" || dtbo_err
-		sleep 1
-	fi
-done;
-
-if [ ! -r /sys/devices/ocp.*/helper.*/AIN0 ] ; then
-	echo Analog input files not found in /sys/devices/ocp.*/helper.* >&2
+if [ ! -r $PRU ] ; then
+	echo PRU control files not found in $PRU >&2
 	exit 1;
 fi
 
-if [ ! -r /sys/class/uio/uio0 ] ; then
-	echo PRU control files not found in /sys/class/uio/uio0 >&2
-	exit 1;
-fi
 
 # Export GPIO pins:
 # One pin needs to be exported to enable the low-level clocks for the GPIO
@@ -90,7 +82,7 @@ sudo $(which config-pin) -f - <<- EOF
 	P8.19	low	# Z Step
 
 # eMMC signals, uncomment *ONLY* if you have disabled the on-board eMMC!
-# Machinekit images disable eMMC and HDMI audio by default in uEnv.txt:
+# MachineKit images disable eMMC and HDMI audio by default in uEnv.txt:
 #  capemgr.disable_partno=BB-BONELT-HDMI,BB-BONE-EMMC-2G
 #	P8.22	low	# Servo 4
 #	P8.23	low	# Servo 3
@@ -113,7 +105,7 @@ sudo $(which config-pin) -f - <<- EOF
 	P9.22	low	# FET 6
 	P9.23	low	# Machine Power
 	P9.24	low	# E2 Step
-	P9.25	low	# LED
+#	P9.25	low	# LED
 	P9.26	low	# E2 Dir
 	P9.27	low	# FET 3 : E2
 	P9.28	low	# SPI CS0
@@ -124,7 +116,7 @@ sudo $(which config-pin) -f - <<- EOF
 	P9.41	low	# FET 5
 	P9.91	in	# Reserved, connected to P9.41
 
-	P9.42	low	# SPI CS1
+#	P9.42	low	# SPI CS1
 	P9.92	in	# Reserved, connected to P9.42
 EOF
 

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.bbio
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.bbio
@@ -1,0 +1,27 @@
+# File generated with BB pin configurator
+# title: Xylotex
+overlay cape-universal
+overlay cape-bone-iio
+#overlay cape-univ-emmc
+P8_07 out # gpio2.2 Enable System
+P8_09 in # gpio2.5 ESTOPin
+P8_10 in # gpio2.4 XLIM
+P8_11 out # gpio1.13 X_Dir
+P8_12 out # gpio1.12 X_Step
+P8_13 out # gpio0.23 PWM0/SPINDLE
+P8_14 in # gpio0.26 YLIM
+P8_15 out # gpio1.15 Y_Dir
+P8_16 out # gpio1.14 Y_Step
+P8_18 in # gpio2.1 ZLIM
+P8_19 out # gpio0.22 PWM1
+P8_26 out # ESTOP Out (ENA_LED)
+P9_11 out # gpio0.31 A_Step
+P9_13 out # gpio0.30 A_Dir
+P9_14 out # gpio1.18 PWM2
+P9_15 out # gpio1.16 Z_Step
+#P9_17 out # gpio0.5 SCS
+#P9_18 in # gpio0.4 SDI
+#P9_21 out # gpio0.3 SDO
+#P9_22 out # gpio0.2 SCK
+P9_23 out # gpio1.17 Z_Dir
+

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.hal
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.hal
@@ -2,7 +2,7 @@
 # The board also has a pair of a set of four 0805 size jumper resistors
 # these can be used to output either the standard Spindle/Mist/flood and
 # input ALIM from the DB25 pins
-# or allow BBB SPI singnals to be routed to the DB25 connector instead.
+# or allow BBB SPI signals to be routed to the DB25 connector instead.
 # The ALIM RC buffer Capacitor would need to change if this
 # option was used.  The LIM Switch input signals are pulled to 3V3 through
 # 10K resistors
@@ -15,43 +15,44 @@
 # go directly to the BBB
 # At powerup the LVC541 enable signals are pulled high, disabling the
 # drivers until
-# the BBB and Machinekit pull the enable signal low.
+# the BBB and LinuxCNC pull the enable signal low.
 #
 ########################################
 
 
 # Launch the setup script to make sure hardware setup looks good
+#loadusr -w /home/machinekit/machinekit/configs/ARM.BeagleBone.Xylotex/setup.sh
 loadusr -w ./setup.sh
+#loadusr -w config-pin -f ./Xylotex.bbio
 
 # ###################################
 # Core EMC/HAL Loads
 # ###################################
-
 # kinematics
 loadrt trivkins
 
-# motion controller, get name and thread periods from ini file
 # trajectory planner
 loadrt tp
-loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=trivkins
 
+# motion controller, get name and thread periods from ini file
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES  tp=tp kins=trivkins
 
 # load low-level drivers
-loadrt hal_bb_gpio output_pins=107,113,119,126,214 input_pins=109,110,114,118,241
-loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg
-#(JP) Not suing PID loop so comment out
+loadrt hal_bb_gpio output_pins=807,811,812,813,815,816,819,826,914,915,923,913,911 input_pins=809,810,814,818
+
+loadrt [PRUCONF](DRIVER) prucode=$(LINUXCNC_HOME)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG) halname=hpg pru_period=25000
 loadrt pid count=4
 loadrt limit1 count=2
 
 # ################################################
 # THREADS
 # ################################################
-
+# hpg = [PRUCONF](DRIVER)
 addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread
 addf motion-controller                    servo-thread
-#(JP) Not doing PID for temperature sensor for PWM output
+# Not doing PID for temperature sensor for PWM output
 addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf pid.2.do-pid-calcs                   servo-thread
@@ -65,11 +66,9 @@ addf bb_gpio.write                        servo-thread
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
 # ######################################################
-
 # ################
 # X [0] Axis
 # ################
-
 # axis enable chain
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
@@ -100,8 +99,8 @@ setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 setp hpg.stepgen.00.control-type    1
 setp hpg.stepgen.00.stepinvert      [AXIS_0]STEP_INVERT
 #setp hpg.stepgen.00.step_type       0
-setp hpg.stepgen.00.steppin         0x4C
-setp hpg.stepgen.00.dirpin          0x4D
+setp hpg.stepgen.00.steppin         812
+setp hpg.stepgen.00.dirpin          811
 
 # set PID loop gains from inifile
 setp pid.0.Pgain [AXIS_0]P
@@ -114,14 +113,13 @@ setp pid.0.FF2 [AXIS_0]FF2
 setp pid.0.deadband [AXIS_0]DEADBAND
 setp pid.0.maxoutput [AXIS_0]MAX_OUTPUT
 
-#(JP) Add home switch input on DB25-11
+# Add X home switch input on DB25-11
 net home-x bb_gpio.p8.in-10 => axis.0.home-sw-in
 #setp bb_gpio.p8.in-10.invert 1
 
 # ################
 # Y [1] Axis
 # ################
-
 # axis enable chain
 newsig emcmot.01.enable bit
 sets emcmot.01.enable FALSE
@@ -152,8 +150,8 @@ setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 setp hpg.stepgen.01.control-type    1
 setp hpg.stepgen.01.stepinvert      [AXIS_1]STEP_INVERT
 #setp hpg.stepgen.01.step_type       0
-setp hpg.stepgen.01.steppin         0x4E
-setp hpg.stepgen.01.dirpin          0x4F
+setp hpg.stepgen.01.steppin         816
+setp hpg.stepgen.01.dirpin          815
 
 # set PID loop gains from inifile
 setp pid.1.Pgain [AXIS_1]P
@@ -166,15 +164,12 @@ setp pid.1.FF2 [AXIS_1]FF2
 setp pid.1.deadband [AXIS_1]DEADBAND
 setp pid.1.maxoutput [AXIS_1]MAX_OUTPUT
 
-
-#(JP) Add home switch input on DB25-12
+# Add Y home switch input on DB25-12
 net home-y bb_gpio.p8.in-14 => axis.1.home-sw-in
-#setp bb_gpio.p8.in-14.invert 1
 
 # ################
 # Z [2] Axis
 # ################
-
 # axis enable chain
 newsig emcmot.02.enable bit
 sets emcmot.02.enable FALSE
@@ -202,11 +197,11 @@ setp hpg.stepgen.02.position-scale  [AXIS_2]SCALE
 setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
 setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
-setp hpg.stepgen.02.control-type    1
+setp hpg.stepgen.02.control-type    1 
 setp hpg.stepgen.02.stepinvert      [AXIS_2]STEP_INVERT
 #setp hpg.stepgen.02.step_type       0
-setp hpg.stepgen.02.steppin         0x50
-setp hpg.stepgen.02.dirpin          0x51
+setp hpg.stepgen.02.steppin         915
+setp hpg.stepgen.02.dirpin          923
 
 # set PID loop gains from inifile
 setp pid.2.Pgain [AXIS_2]P
@@ -219,15 +214,12 @@ setp pid.2.FF2 [AXIS_2]FF2
 setp pid.2.deadband [AXIS_2]DEADBAND
 setp pid.2.maxoutput [AXIS_2]MAX_OUTPUT
 
-
-#(JP) Add home switch input on DB25-13
+# Add Z home switch input on DB25-13
 net home-z bb_gpio.p8.in-18 => axis.2.home-sw-in
-#setp bb_gpio.p8.in-18.invert 1
 
 # ################
 # A [3] Axis
 # ################
-
 # axis enable chain
 newsig emcmot.03.enable bit
 sets emcmot.03.enable FALSE
@@ -258,8 +250,8 @@ setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 setp hpg.stepgen.03.control-type    1
 setp hpg.stepgen.03.stepinvert      [AXIS_3]STEP_INVERT
 #setp hpg.stepgen.03.step_type       0
-setp hpg.stepgen.03.steppin         0x3E
-setp hpg.stepgen.03.dirpin          0x3F
+setp hpg.stepgen.03.steppin         911
+setp hpg.stepgen.03.dirpin          913
 
 # set PID loop gains from inifile
 setp pid.3.Pgain [AXIS_3]P
@@ -273,9 +265,8 @@ setp pid.3.deadband [AXIS_3]DEADBAND
 setp pid.3.maxoutput [AXIS_3]MAX_OUTPUT
 
 
-#(JP) Add home switch input
-net home-a bb_gpio.p9.in-41 => axis.3.home-sw-in
-#setp bb_gpio.p9.in-41.invert 1
+# Add A home switch input
+#net home-a bb_gpio.p9.in-41 => axis.3.home-sw-in
 
 # ##################################################
 # Standard I/O - EStop, Enables, Limit Switches, Etc
@@ -291,7 +282,7 @@ net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
 # (LOW) or unactive (HIGH) state
 # All external Inputs and Outputs on external boards
 # should have pullups/downs since when the interface board is
-# not enabled, it will look disconnected for all signals
+# not enabled, it will look dosconnected for all signals
 
 # this pin is output on DB25-1
 # it is also used to enable the LVC541 driver/receiver on the interface board
@@ -316,10 +307,15 @@ setp bb_gpio.p8.out-26.invert 1
 #net probe motion.probe-input <= bb_gpio.p8.in-18
 #setp bb_gpio.p8.in-18.invert 1
 
+# this currently goes to an LED on the interface board
+# it is simply a duplicate of the enable signal on DB25-1 right now
+setp bb_gpio.p8.out-26.invert 1
+
 # this input signal must be active LOW to allow the system to energize.
 # this should be fed through an NC STOP type switch from DB25-1 to DB25-10
 net estop-in bb_gpio.p8.in-09 => iocontrol.0.emc-enable-in
 setp bb_gpio.p8.in-09.invert 1
+
 
 # This output is on DB25-14 and is currently tied to spindle control (M3/M5)
 #net Output1 bb_gpio.p8.out-13 => motion.spindle-on
@@ -335,5 +331,4 @@ setp bb_gpio.p8.out-19.invert 1
 # This output is on DB25-17 (M8/M9)
 net Output3 bb_gpio.p9.out-14 => halui.flood.is-on
 setp bb_gpio.p9.out-14.invert 1
-
 

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.ini
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.ini
@@ -1,37 +1,41 @@
 [PRUCONF]
 DRIVER=hal_pru_generic
 CONFIG=pru=1 num_stepgens=4
-PRUBIN=xenomai/pru_generic.bin
+#PRUBIN=xenomai/pru_generic.bin
+#PRUBIN=lib/linuxcnc/rt-preempt/pru_generic.bin
+PRUBIN=rt-preempt/pru_generic.bin
 
+###############################################################################
+# General section 
+###############################################################################
 [EMC]
 
 # Name of machine, for use with display, etc.
 MACHINE =               Xylotex
 
 # Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+DEBUG = 0
 #DEBUG =                0x00000003
 #DEBUG =                0x00000007
-DEBUG = 0
 
 
-
-
+###############################################################################
+# Sections for display options 
+###############################################################################
 [DISPLAY]
-#uncomment the line below if the shuttleexpress is installed
-#(JP)GLADEVCP = shuttlexpress.glade
-#leave the follwoing two alone
-
-#EMBED_TAB_NAME = GladeVCP demo
-#EMBED_TAB_COMMAND = halcmd loadusr -Wn gladevcp gladevcp -c gladevcp -u shuttlexpress.py -x {XID} shuttlexpress.glade
-
 # Name of display program, e.g., tkemc
 DISPLAY = axis
 #DISPLAY = jtgremlin
-
-#EDITOR = mousepad
-
 # Touchy currently will not work without some hardware buttons/jog-wheel
 #DISPLAY = touchy
+
+#uncomment the line below if the shuttleexpress is installed
+#GLADEVCP = shuttlexpress.glade
+#leave the following two alone
+#EMBED_TAB_NAME = GladeVCP demo
+#EMBED_TAB_COMMAND = halcmd loadusr -Wn gladevcp gladevcp -c gladevcp -u shuttlexpress.py -x {XID} shuttlexpress.glade
+
+#EDITOR = mousepad
 
 # Cycle time, in seconds, that display will sleep between polls
 CYCLE_TIME =            0.200
@@ -40,19 +44,22 @@ CYCLE_TIME =            0.200
 HELP_FILE =             tklinucnc.txt
 
 # Initial display setting for position, RELATIVE or MACHINE
-POSITION_OFFSET =       RELATIVE
+POSITION_OFFSET =       MACHINE
 
 # Initial display setting for position, COMMANDED or ACTUAL
 POSITION_FEEDBACK =     ACTUAL
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.0
+MAX_SPINDLE_OVERRIDE =  1.0
+MIN_SPINDLE_OVERRIDE =  0.25
 
 # Prefix to be used
+#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files
 PROGRAM_PREFIX = ~/machinekit/nc_files/
 
 # Introductory graphic
-INTRO_GRAPHIC =         machinekit.gif
+INTRO_GRAPHIC =         linuxcnc.gif
 INTRO_TIME =            5
 
 # Increments for the JOG section
@@ -70,6 +77,9 @@ jpg = image-to-gcode
 py = python
 
 
+###############################################################################
+# Task controller section 
+###############################################################################
 [TASK]
 
 # Name of task controller program, e.g., milltask
@@ -79,195 +89,215 @@ TASK =                  milltask
 CYCLE_TIME =            0.010
 
 
-
-
+###############################################################################
+# Part program interpreter section 
+###############################################################################
 [RS274NGC]
-
 # File containing interpreter variables
 PARAMETER_FILE =        pru-stepper.var
 RS274NGC_STARTUP_CODE = G00 G17 G21 G40 G49 G64 P0.1 Q0.1 G80 G90
 
+###############################################################################
+# Motion control section 
+###############################################################################
 [EMCMOT]
-
 EMCMOT =                motmod
-
 # Timeout for comm to emcmot, in seconds
 COMM_TIMEOUT =          1.0
-
 # Interval between tries to emcmot, in seconds
 COMM_WAIT =             0.010
-
 # Servo task period, in nanoseconds
 SERVO_PERIOD =          1000000
 
-
+###############################################################################
+# Hardware Abstraction Layer section
+###############################################################################
 [HAL]
-
+HALUI = halui
 # The run script first uses halcmd to execute any HALFILE
 # files, and then to execute any individual HALCMD commands.
-
+HALFILE =                Xylotex.hal
+#HALFILE =               custom.hal
+# uncomment the line below if the shuttlexpress jig wheel is used
+#HALFILE =		../../../shuttlexpress.hal
+#POSTGUI_HALFILE =       Xylotex.postgui.hal
 # list of hal config files to run through halcmd
 # files are executed in the order in which they appear
-
-HALFILE =                Xylotex.hal
-#(JP) uncomment the line below if the shuttlexpress jig wheel is used
-#HALFILE =		../../../shuttlexpress.hal
-
-# list of halcmd commands to execute
-# commands are executed in the order in which they appear
 #HALCMD =               save neta
-HALUI = halui
-POSTGUI_HALFILE =       Xylotex.postgui.hal
+
+###############################################################################
+# Hardware Abstraction Layer User Interface section
+###############################################################################
+[HALUI]
+MDI_COMMAND = G0 X0 Y0 Z0
+MDI_COMMAND = G38.2 Z-2 f16
+MDI_COMMAND = G92 Z0.25
+MDI_COMMAND = G0 Z0.75
+MDI_COMMAND = G92 x2 y-.5
 
 
+###############################################################################
+# Trajectory planner section
+###############################################################################
 [TRAJ]
-
 AXES =                     4
 COORDINATES =              X Y Z A
+HOME =                     1 1 0 2
 MAX_ANGULAR_VELOCITY =     45.00
 DEFAULT_ANGULAR_VELOCITY = 4.50
 LINEAR_UNITS =             inch
 ANGULAR_UNITS =            degree
 CYCLE_TIME =               0.010
 DEFAULT_VELOCITY =         2.0
-MAX_LINEAR_VELOCITY =      2.0
+DEFAULT_ACCELERATION =    15.0
+MAX_LINEAR_VELOCITY =      2.6
 NO_FORCE_HOMING =          1
+# POSITION_FILE = position.txt
+#PROBE_INDEX =           0
+#PROBE_POLARITY =        1
 
-################################################################
+###############################################################################
+# section for main IO controller parameters 
+###############################################################################
+[EMCIO]
+
+#- Name of IO controller program, e.g., io
+EMCIO = 		io
+
+#- cycle time, in seconds
+CYCLE_TIME =            0.100
+
+#- tool table file
+TOOL_TABLE =            mill.tbl
+
+#- Tool Change Position specifies the location to move to for a tool change
+#TOOL_CHANGE_POSITION = 0 0 2
+
+###############################################################################
+# Axes sections
+###############################################################################
 [AXIS_0]
 
 #
-# Step timing is 40 us steplen + 40 us stepspace
-# That gives 80 us step period = 12.5 KHz step freq
+# Step timing is 25 us steplen + 25 us stepspace
+# That gives 50 us step period = 20 KHz step freq
 #
-# Bah, even software stepping can handle that, hm2 doesnt buy you much with
-# such slow steppers.
+# Scale is 200 steps/rev * 5 revs/inch * 2 microsteps = 2000 steps/inch
 #
-# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
-#
-# This gives a maxvel of 12.5/1 = 12.5 ips
+# This gives a maxvel of 20000/2000 = 10 ips
 #
 TYPE =              LINEAR
-MAX_VELOCITY =       1.0
+MAX_VELOCITY =       2.0
 MAX_ACCELERATION =   15.0
 # Set Stepgen max 20% higher than the axis
-STEPGEN_MAX_VEL =    1.2
+STEPGEN_MAX_VEL =    2.6
 STEPGEN_MAX_ACC =    18.75
 
 BACKLASH =           0.000
-# scale is 200 steps/rev * 8 mirostep * 10 tpi
-SCALE =  32000
+SCALE =              2000
 
-MIN_LIMIT =             -0.0
-MAX_LIMIT =             20.0
+MIN_LIMIT =          -0.0
+MAX_LIMIT =          13.0
 
-FERROR =     .1
-MIN_FERROR = 0.05
+FERROR =               .1
+MIN_FERROR =          0.05
 
-HOME =                  0.000
-HOME_OFFSET =           0.00
-HOME_SEARCH_VEL =       -.1
-HOME_LATCH_VEL =       0.2
-#HOME_USE_INDEX =        YES
-#HOME_IGNORE_LIMITS =    YES
-#HOME_IS_SHARED = 1
-#HOME_SEQUENCE = 2
+HOME                =   0.000
+HOME_OFFSET         =  -0.1
+HOME_SEARCH_VEL     =  -1.5
+HOME_LATCH_VEL      =   0.25
+HOME_USE_INDEX      =    NO
+HOME_IGNORE_LIMITS  =    YES
+HOME_IS_SHARED      =    1
+HOME_SEQUENCE       =    1
 
 # these are in nanoseconds
-DIRSETUP   =              1000
-DIRHOLD    =              20000
-STEPLEN    =              500
-STEPSPACE  =              4000
+DIRSETUP    =            25000
+DIRHOLD     =            25000
+STEPLEN     =            25000
+STEPSPACE   =            25000
 
 # Set to one for active low step pulses
-STEP_INVERT =           0
+STEP_INVERT =            0
 
 # PID tuning params
-DEADBAND =              0
-P =                     50
-I =                     0
-D =                     0
-FF0 =                   0
-FF1 =                   1
-FF2 =			0
-BIAS =                  0
-MAX_OUTPUT =		0
-
+DEADBAND    =            0
+P           =            50
+I           =            0
+D           =            0
+FF0         =            0
+FF1         =            1
+FF2         =            0
+BIAS        =            0
+MAX_OUTPUT  =            0
 
 ################################################################
 [AXIS_1]
 
 #
-# Step timing is 40 us steplen + 40 us stepspace
-# That gives 80 us step period = 12.5 KHz step freq
+# Step timing is 25 us steplen + 25 us stepspace
+# That gives 50 us step period = 12.5 KHz step freq
 #
-# Bah, even software stepping can handle that, hm2 doesnt buy you much with
-# such slow steppers.
+# Scale is 200 steps/rev * 5 revs/inch * 2 microsteps = 2000 steps/inch
 #
-# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
-#
-# This gives a maxvel of 12.5/1 = 12.5 ips
+# This gives a maxvel of 20000/2000 = 10 ips
 #
 TYPE =              LINEAR
-MAX_VELOCITY =       1.0
+MAX_VELOCITY =       2.0
 MAX_ACCELERATION =   15.0
 # Set Stepgen max 20% higher than the axis
-STEPGEN_MAX_VEL =    1.2
+STEPGEN_MAX_VEL =    2.6
 STEPGEN_MAX_ACC =    18.75
 
 BACKLASH =           0.000
-# scale is 200 steps/rev * 8 mirostep * 10 tpi
-SCALE =  32000
+# scale is 200 steps/rev * 2 microstep * 5 tpi = 2000 steps/inch
+SCALE =              2000
 
-MIN_LIMIT =             -0.0
-MAX_LIMIT =             20.0
+MIN_LIMIT =          -0.0
+MAX_LIMIT =          12.0
 
-FERROR =     .1
-MIN_FERROR = 0.05
+FERROR =               .1
+MIN_FERROR =          0.05
 
-HOME =                  0.000
-HOME_OFFSET =           0.00
-HOME_SEARCH_VEL =       -.1
-HOME_LATCH_VEL =       0.2
-#HOME_USE_INDEX =        YES
-#HOME_IGNORE_LIMITS =    YES
-#HOME_IS_SHARED = 1
-#HOME_SEQUENCE = 2
+HOME                =  0.000
+HOME_OFFSET         = -0.1
+HOME_SEARCH_VEL     = -1.5
+HOME_LATCH_VEL      =  0.250
+HOME_USE_INDEX     =   NO
+HOME_IGNORE_LIMITS  =  YES
+HOME_IS_SHARED      =  1
+HOME_SEQUENCE       =  1
 
 # these are in nanoseconds
-DIRSETUP   =              1000
-DIRHOLD    =              20000
-STEPLEN    =              500
-STEPSPACE  =              4000
+DIRSETUP    =            25000
+DIRHOLD     =            25000
+STEPLEN     =            25000
+STEPSPACE   =            25000
 
 # Set to one for active low step pulses
-STEP_INVERT =           0
+STEP_INVERT =            0
 
 # PID tuning params
-DEADBAND =              0
-P =                     50
-I =                     0
-D =                     0
-FF0 =                   0
-FF1 =                   1
-FF2 =			0
-BIAS =                  0
-MAX_OUTPUT =		0
+DEADBAND    =            0
+P           =            50
+I           =            0
+D           =            0
+FF0         =            0
+FF1         =            1
+FF2         =            0
+BIAS        =            0
+MAX_OUTPUT  =            0
 
 
 ################################################################
 [AXIS_2]
 
 #
-# Step timing is 40 us steplen + 40 us stepspace
-# That gives 80 us step period = 12.5 KHz step freq
+# Step timing is 25 us steplen + 25 us stepspace
+# That gives 50 us step period = 20 KHz step freq
 #
-# Bah, even software stepping can handle that, hm2 doesnt buy you much with
-# such slow steppers.
-#
-# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
-#
-# This gives a maxvel of 12.5/1 = 12.5 ips
+# SCALE is 200 steps/rev * 2 microstep * 4:1 gearing * 5 tpi = 8000 steps/inch
+# This gives a maxvel of 20000/8000 = 2.5 ips
 #
 TYPE =              LINEAR
 MAX_VELOCITY =       1.0
@@ -277,55 +307,50 @@ STEPGEN_MAX_VEL =    1.2
 STEPGEN_MAX_ACC =    18.75
 
 BACKLASH =           0.000
-# scale is 200 steps/rev * 8 mirostep * 10 tpi
-SCALE =  32000
+# SCALE is 200 steps/rev * 2 microstep * 4:1 gearing * 5 turns/inch = 8000 steps/inch
+SCALE =              8000
 
-MIN_LIMIT =             -20.0
-MAX_LIMIT =             20.0
+MIN_LIMIT =           0.0
+MAX_LIMIT =           5.0
 
 FERROR =     .1
 MIN_FERROR = 0.05
 
-HOME =                  0.000
-HOME_OFFSET =           0.00
-HOME_SEARCH_VEL =       -.1
-HOME_LATCH_VEL =       0.2
-#HOME_USE_INDEX =        YES
-#HOME_IGNORE_LIMITS =    YES
-#HOME_IS_SHARED = 1
-#HOME_SEQUENCE = 2
+HOME                =   0.000
+HOME_OFFSET         =   0.00
+HOME_SEARCH_VEL     =   1.0
+HOME_LATCH_VEL      =  -0.250
+HOME_USE_INDEX      =   NO
+HOME_IGNORE_LIMITS  =   YES
+HOME_IS_SHARED      =   1
+HOME_SEQUENCE       =   0
 
 # these are in nanoseconds
-DIRSETUP   =              1000
-DIRHOLD    =              20000
-STEPLEN    =              500
-STEPSPACE  =              4000
+DIRSETUP    =            25000
+DIRHOLD     =            25000
+STEPLEN     =            25000
+STEPSPACE   =            25000
 
 # Set to one for active low step pulses
-STEP_INVERT =           0
+STEP_INVERT =            0
 
 # PID tuning params
-DEADBAND =              0
-P =                     50
-I =                     0
-D =                     0
-FF0 =                   0
-FF1 =                   1
-FF2 =			0
-BIAS =                  0
-MAX_OUTPUT =		0
+DEADBAND    =            0
+P           =            50
+I           =            0
+D           =            0
+FF0         =            0
+FF1         =            1
+FF2         =            0
+BIAS        =            0
+MAX_OUTPUT  =            0
 
 ################################################################
 [AXIS_3]
 
 #
-# Step timing is 40 us steplen + 40 us stepspace
-# That gives 80 us step period = 12.5 KHz step freq
-#
-# Bah, even software stepping can handle that, hm2 doesnt buy you much with
-# such slow steppers.
-#
-# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
+# Step timing is 25 us steplen + 25 us stepspace
+# That gives 50 us step period = 20 KHz step freq
 #
 # This gives a maxvel of 12.5/1 = 12.5 ips
 #
@@ -337,8 +362,8 @@ STEPGEN_MAX_VEL =    1.2
 STEPGEN_MAX_ACC =    18.75
 
 BACKLASH =           0.000
-# scale is 200 steps/rev * 8 mirostep * 10 tpi
-SCALE =  32000
+# SCALE is 200 steps/rev * 2 microstep * 5 revs/inch = 2000 steps/inch
+SCALE =  2000
 
 MIN_LIMIT =             -0.0
 MAX_LIMIT =             15.0
@@ -349,44 +374,29 @@ MIN_FERROR = 0.05
 HOME =                  0.000
 HOME_OFFSET =           0.00
 HOME_SEARCH_VEL =       -.1
-HOME_LATCH_VEL =       0.2
+HOME_LATCH_VEL =        0.2
 #HOME_USE_INDEX =        YES
 #HOME_IGNORE_LIMITS =    YES
-#HOME_IS_SHARED = 1
-#HOME_SEQUENCE = 2
+#HOME_IS_SHARED =        1
+#HOME_SEQUENCE =         2
 
 # these are in nanoseconds
-DIRSETUP   =              1000
-DIRHOLD    =              20000
-STEPLEN    =              500
-STEPSPACE  =              4000
+DIRSETUP    =            25000
+DIRHOLD     =            25000
+STEPLEN     =            25000
+STEPSPACE   =            25000
 
 # Set to one for active low step pulses
-STEP_INVERT =           0
+STEP_INVERT =            0
 
 # PID tuning params
-DEADBAND =              0
-P =                     50
-I =                     0
-D =                     0
-FF0 =                   0
-FF1 =                   1
-FF2 =			0
-BIAS =                  0
-MAX_OUTPUT =		0
+DEADBAND    =            0
+P           =            50
+I           =            0
+D           =            0
+FF0         =            0
+FF1         =            1
+FF2         =            0
+BIAS        =            0
+MAX_OUTPUT  =            0
 
-
-
-
-############################
-
-[EMCIO]
-
-# Name of IO controller program, e.g., io
-EMCIO =                 io
-
-# cycle time, in seconds
-CYCLE_TIME =            0.100
-
-# tool table file
-TOOL_TABLE =            tool.tbl

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.ini
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.ini
@@ -55,8 +55,9 @@ MAX_SPINDLE_OVERRIDE =  1.0
 MIN_SPINDLE_OVERRIDE =  0.25
 
 # Prefix to be used
-#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files
-PROGRAM_PREFIX = ~/machinekit/nc_files/
+PROGRAM_PREFIX = ../../../nc_files/
+#PROGRAM_PREFIX = /home/machinekit/machinekit/nc_files/
+#PROGRAM_PREFIX = ~/machinekit/nc_files/
 
 # Introductory graphic
 INTRO_GRAPHIC =         linuxcnc.gif

--- a/debian/configure
+++ b/debian/configure
@@ -130,11 +130,14 @@ BUILD_DEPS=  # List of Build-Depends
 HAVE_FLAVOR=false
 
 # copy base templates into place
-## need python-gst0.10 for Jessie, none for Stretch, no python-gtksourceview2 for Buster
+## need python-gst0.10 for Jessie, none for Stretch,  
+## no python-gtksourceview2 for Buster and python-gst-1.0, python-pil and python-pil.imagegtk for SID
 if [ "$DISTRO_CODENAME" == "stretch" ]; then
     cp control.stretch.in control
 elif [ "$DISTRO_CODENAME" == "buster" ]; then
     cp control.buster.in control   	
+elif [ "$DISTRO_CODENAME" == "sid" ]; then
+    cp control.sid.in control   	
 else
     cp control.in control
 fi

--- a/debian/control.buster.in
+++ b/debian/control.buster.in
@@ -46,13 +46,13 @@ Architecture: any
 Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
     bwidget (>= 1.7), libtk-img (>=1.13),
     ${python:Depends}, ${misc:Depends},
-    python-tk, python-imaging, python-imaging-tk,
+    python-tk, python-pil, python-pil.imagetk,
     python-gnome2, python-glade2,
     python-numpy,
     python-vte, python-xlib, python-gtkglext1, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, python-simplejson, python-pyftpdlib,
-    python-pydot, xdot,
+    python-pydot, xdot, python-gst-1.0, python-gtksourceview2,
     tclreadline, bc, procps, psmisc
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/debian/control.sid.in
+++ b/debian/control.sid.in
@@ -1,0 +1,60 @@
+Source: machinekit
+Section: misc
+Priority: extra
+Maintainer: John Morris <john@dovetail-automata.com>
+Build-Depends: debhelper (>= 6),
+    autoconf (>= 2.63), automake, libboost-python-dev, libgl1-mesa-dev,
+    libglu1-mesa-dev, libgtk2.0-dev, libmodbus-dev (>= 3.0), libudev-dev,
+    libncurses-dev, libreadline-dev, libusb-1.0-0-dev, libxmu-dev,
+    libxmu-headers, python (>= 2.6.6), python-dev (>= 2.6.6),
+    cython (>= 0.19), dh-python,
+    pkg-config, psmisc, python-tk, libxaw7-dev, libboost-serialization-dev,
+    libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson-dev (>= 2.5),
+    libwebsockets-dev (>= 1.2.2),
+    python-zmq (>= 14.0.1), procps,
+    liburiparser-dev, libssl-dev, python-setuptools,
+    uuid-dev, uuid-runtime, libavahi-client-dev,
+    libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
+    python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
+    python-simplejson, libtk-img, libboost-thread-dev,
+    python-pyftpdlib, tcl8.6-dev, tk8.6-dev @BUILD_DEPS@
+Standards-Version: 2.1.0
+
+#########################################################################
+## not built any more, components of it are in flavour packages
+##
+#Package: machinekit-dev
+#Architecture: any
+#Depends: make, g++, tcl8.6, tk8.6,
+#    ${shlibs:Depends}, ${misc:Depends},
+#    machinekit (= ${binary:Version}),
+#    yapps2-runtime
+#Section: libs
+#Description: PC based motion controller for real-time Linux
+# Machinekit is the next-generation Enhanced Machine Controller which
+# provides motion control for CNC machine tools and robotic
+# applications (milling, cutting, routing, etc.).
+# .
+# This package includes files needed to build new realtime components and
+# alternate front-ends for machinekit
+#########################################################################
+
+Package: machinekit
+Breaks: linuxcnc
+Replaces: linuxcnc
+Architecture: any
+Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
+    bwidget (>= 1.7), libtk-img (>=1.13),
+    ${python:Depends}, ${misc:Depends},
+    python-tk, python-pil, python-pil.imagetk,
+    python-gnome2, python-glade2,
+    python-numpy,
+    python-vte, python-xlib, python-gtkglext1, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1),
+    python-avahi, python-simplejson, python-pyftpdlib,
+    python-pydot, xdot, python-gst-1.0,
+    tclreadline, bc, procps, psmisc
+Description: PC based motion controller for real-time Linux
+ Machinekit is the next-generation Enhanced Machine Controller which
+ provides motion control for CNC machine tools and robotic
+ applications (milling, cutting, routing, etc.).

--- a/debian/control.sid.in
+++ b/debian/control.sid.in
@@ -47,12 +47,11 @@ Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
     bwidget (>= 1.7), libtk-img (>=1.13),
     ${python:Depends}, ${misc:Depends},
     python-tk, python-pil, python-pil.imagetk,
-    python-gnome2, python-glade2,
-    python-numpy,
+    python-gnome2, python-glade2, python-numpy, 
     python-vte, python-xlib, python-gtkglext1, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, python-simplejson, python-pyftpdlib,
-    python-pydot, xdot, python-gst-1.0,
+    python-pydot, xdot, python-gst-1.0, python-gtksourceview2,
     tclreadline, bc, procps, psmisc
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/debian/control.stretch.in
+++ b/debian/control.stretch.in
@@ -52,7 +52,7 @@ Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
     python-vte, python-xlib, python-gtkglext1, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, python-simplejson, python-pyftpdlib,
-    python-pydot, xdot,
+    python-pydot, xdot, python-gst-1.0,
     tclreadline, bc, procps, psmisc
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/debian/control.stretch.in
+++ b/debian/control.stretch.in
@@ -47,12 +47,11 @@ Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
     bwidget (>= 1.7), libtk-img (>=1.13),
     ${python:Depends}, ${misc:Depends},
     python-tk, python-imaging, python-imaging-tk,
-    python-gnome2, python-glade2,
-    python-numpy, python-gtksourceview2,
+    python-gnome2, python-glade2, python-numpy, 
     python-vte, python-xlib, python-gtkglext1, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, python-simplejson, python-pyftpdlib,
-    python-pydot, xdot, python-gst-1.0,
+    python-pydot, xdot, python-gst-1.0, python-gtksourceview2,
     tclreadline, bc, procps, psmisc
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/src/Makefile
+++ b/src/Makefile
@@ -1571,6 +1571,9 @@ rotatekins-objs := emc/kinematics/rotatekins.o
 obj-m += tripodkins.o
 tripodkins-objs := emc/kinematics/tripodkins.o
 
+obj-m += itripodkins.o
+itripodkins-objs := emc/kinematics/itripodkins.o
+
 obj-m += lineardeltakins.o
 lineardeltakins-objs := emc/kinematics/lineardeltakins.o
 
@@ -1894,6 +1897,7 @@ $(RTLIBDIR)/maxkins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(maxkins-objs))
 $(RTLIBDIR)/gantrykins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(gantrykins-objs))
 $(RTLIBDIR)/rotatekins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(rotatekins-objs))
 $(RTLIBDIR)/tripodkins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(tripodkins-objs))
+$(RTLIBDIR)/itripodkins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(itripodkins-objs))
 $(RTLIBDIR)/lineardeltakins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(lineardeltakins-objs))
 $(RTLIBDIR)/genhexkins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(genhexkins-objs))
 $(RTLIBDIR)/genserkins$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(genserkins-objs))

--- a/src/emc/kinematics/itripodkins.c
+++ b/src/emc/kinematics/itripodkins.c
@@ -1,0 +1,405 @@
+/********************************************************************
+* Description: itripodkins.c
+*   Kinematics for 3 axis inverted Tripod machine
+*   with passthrough for A B C rotational axis.
+*
+*   Derived from a work by Fred Proctor
+*
+* Author: 
+* License: GPL Version 2
+* System: Linux
+*    
+* Copyright (c) 2004 All rights reserved.
+*
+* Last change: 
+* Added passthrough and forced inverted. - Daren Schwenke
+********************************************************************/
+
+/*
+  These kinematics are for a tripod with point vertices.
+
+  Vertices A, B, and C are the base, and vertex D is the controlled point.
+  Three tripod strut lengths AD, BD, and CD are the joints that move
+  point D around.
+
+  Point A is the origin, with coordinates (0, 0, 0). Point B lies on the
+  x axis, with coordinates (Bx, 0, 0). Point C lies in the xy plane, with
+  coordinates (Cx, Cy, 0). Point D has coordinates (Dx, Dy, Dz).
+
+  The controlled Cartesian values are Dx, Dy, and Dz. A frame attached to
+  D, say with x parallel to AD and y in the plane ABD, would change its
+  orientation as the strut lengths changed. The orientation of this frame
+  relative to the world frame is not computed.
+
+  With respect to the kinematics functions,
+
+  pos->tran.x = Dx
+  pos->tran.y = Dy
+  pos->tran.z = Dz
+  pos->a,b,c  = 0
+
+  joints[0] = AD
+  joints[1] = BD
+  joints[2] = CD
+
+  The inverse kinematics have no singularities. Any values for Dx, Dy, and
+  Dz will yield numerical results. Of course, these may be beyond the
+  strut length limits, but there are no singular effects like infinite speed.
+
+  The forward kinematics has a singularity due to the triangle inequalities
+  for triangles ABD, BCD, and CAD. When any of these approach the limit,
+  Dz is zero and D lies in the base plane.
+
+  The forward kinematics flags, referred to in kinematicsForward and
+  set in kinematicsInverse, let the forward kinematics select between
+  the positive and negative values of Dz for given strut values.
+  Dz > 0 is "above", Dz < 0 is "below". Dz = 0 is the singularity.
+
+  fflags == 0 selects Dz > 0,
+  fflags != 0 selects Dz < 0.
+
+  The inverse kinematics flags let the inverse kinematics select between
+  multiple valid solutions of strut lengths for given Cartesian values
+  for D. There are no multiple solutions: D constrains the strut lengths
+  completely. So, the inverse flags are ignored.
+ */
+
+#include "kinematics.h"             /* these decls */
+#include "rtapi_math.h"
+
+#define VTVERSION VTKINEMATICS_VERSION1
+
+#ifndef __GNUC__
+#ifndef __attribute__
+#define __attribute__(x)
+#endif
+#endif
+
+#include "hal.h"
+
+struct haldata {
+    hal_float_t *bx, *cx, *cy;
+} *haldata = 0;
+
+#define Bx (*(haldata->bx))
+#define Cx (*(haldata->cx))
+#define Cy (*(haldata->cy))
+
+#define sq(x) ((x)*(x))
+
+/*
+  forward kinematics takes three strut lengths and computes Dx, Dy, and Dz
+  pos->tran.x,y,z, respectively. The forward flag is used to resolve
+  D above/below the xy plane. The inverse flags are not set since there
+  are no ambiguities going from world to joint coordinates.
+
+  The forward kins are derived as follows:
+
+  1. Let x, y, z be Dx, Dy, Dz to save pixels. Cartesian displacement from
+  D to A, B, and C gives
+
+  AD^2 = x^2 + y^2 + z^2
+  BD^2 = (x - Bx)^2 + y^2 + z^2
+  CD^2 = (x - Cx)^2 + (y - Cy)^2 + z^2
+
+  This yields
+
+  I.   P = x^2 + y^2 + z^2
+  II.  Q = x^2 + y^2 + z^2 + sx
+  III. R = x^2 + y^2 + z^2 + tx + uy
+
+  Where
+
+  P = AD^2,
+  Q = BD^2 - Bx^2
+  R = CD^2 - Cx^2 - Cy^2
+  s = -2Bx
+  t = -2Cx
+  u = -2Cy
+
+  II - I gives Q - P = sx, so x = (Q - P)/s, s != 0. The constraint on s
+  means that Bx != 0, or points A and B can't be the same.
+
+  III - II gives R - Q = (t - s)x + uy, so y = (R - Q - (t - s)x)/u, u != 0.
+  The constraint on u means that Cy != 0, or points A B C can't be collinear.
+
+  Substituting x, y into I gives z = sqrt(P - x^2 - y^2), which has two
+  solutions. Positive means the tripod is above the xy plane, negative
+  means below.
+*/
+int kinematicsForward(const double * joints,
+                      EmcPose * pos,
+                      const KINEMATICS_FORWARD_FLAGS * fflags,
+                      KINEMATICS_INVERSE_FLAGS * iflags)
+{
+#define AD (joints[0])
+#define BD (joints[1])
+#define CD (joints[2])
+#define Dx (pos->tran.x)
+#define Dy (pos->tran.y)
+#define Dz (pos->tran.z)
+  double P, Q, R;
+  double s, t, u;
+
+  P = sq(AD);
+  Q = sq(BD) - sq(Bx);
+  R = sq(CD) - sq(Cx) - sq(Cy);
+  s = -2.0 * Bx;
+  t = -2.0 * Cx;
+  u = -2.0 * Cy;
+
+  if (s == 0.0) {
+    /* points A and B coincident. Fix Bx, #defined up top. */
+    return -1;
+  }
+  Dx = (Q - P) / s;
+
+  if (u == 0.0) {
+    /* points A B C are colinear. Fix Cy, #defined up top. */
+    return -1;
+  }
+  Dy = (R - Q - (t - s) * Dx) / u;
+  Dz = P - sq(Dx) - sq(Dy);
+  if (Dz < 0.0) {
+    /* triangle inequality violated */
+    return -1;
+  }
+  Dz = rtapi_sqrt(Dz);
+  if (*fflags) {
+    Dz = -Dz;
+  }
+
+  pos->a = joints[3];
+  pos->b = joints[4];
+  pos->c = joints[5];
+
+  return 0;
+
+#undef AD
+#undef BD
+#undef CD
+#undef Dx
+#undef Dy
+#undef Dz
+}
+
+int kinematicsInverse(const EmcPose * pos,
+                      double * joints,
+                      const KINEMATICS_INVERSE_FLAGS * iflags,
+                      KINEMATICS_FORWARD_FLAGS * fflags)
+{
+#define AD (joints[0])
+#define BD (joints[1])
+#define CD (joints[2])
+#define Dx (pos->tran.x)
+#define Dy (pos->tran.y)
+#define Dz (pos->tran.z)
+
+  AD = rtapi_sqrt(sq(Dx) + sq(Dy) + sq(Dz));
+  BD = rtapi_sqrt(sq(Dx - Bx) + sq(Dy) + sq(Dz));
+  CD = rtapi_sqrt(sq(Dx - Cx) + sq(Dy - Cy) + sq(Dz));
+
+  *fflags = 1;
+/*  if (Dz < 0.0) {
+    *fflags = 1;
+  }
+*/
+  joints[3] = pos->a;
+  joints[4] = pos->b;
+  joints[5] = pos->c;
+
+  return 0;
+
+#undef AD
+#undef BD
+#undef CD
+#undef Dx
+#undef Dy
+#undef Dz
+}
+
+KINEMATICS_TYPE kinematicsType(void)
+{
+  return KINEMATICS_BOTH;
+}
+
+#ifdef MAIN
+
+#include <stdio.h>
+#include <string.h>
+
+/*
+  Interactive testing of kins.
+
+  Syntax: a.out <Bx> <Cx> <Cy>
+*/
+int main(int argc, char *argv[])
+{
+#ifndef BUFFERLEN
+#define BUFFERLEN 256
+#endif
+  char buffer[BUFFERLEN];
+  char cmd[BUFFERLEN];
+  EmcPose pos, vel;
+  double joints[3], jointvels[3];
+  char inverse;
+  char flags;
+  KINEMATICS_FORWARD_FLAGS fflags;
+
+  inverse = 0;			/* forwards, by default */
+  flags = 0;			/* didn't provide flags */
+  fflags = 1;			/* below xy plane, by default */
+  if (argc != 4 ||
+      1 != sscanf(argv[1], "%lf", &Bx) ||
+      1 != sscanf(argv[2], "%lf", &Cx) ||
+      1 != sscanf(argv[3], "%lf", &Cy)) {
+    fprintf(stderr, "syntax: %s Bx Cx Cy\n", argv[0]);
+    return 1;
+  }
+
+  while (! feof(stdin)) {
+    if (inverse) {
+	printf("inv> ");
+    }
+    else {
+	printf("fwd> ");
+    }
+    fflush(stdout);
+
+    if (NULL == fgets(buffer, BUFFERLEN, stdin)) {
+      break;
+    }
+    if (1 != sscanf(buffer, "%s", cmd)) {
+      continue;
+    }
+
+    if (! strcmp(cmd, "quit")) {
+      break;
+    }
+    if (! strcmp(cmd, "i")) {
+      inverse = 1;
+      continue;
+    }
+    if (! strcmp(cmd, "f")) {
+      inverse = 0;
+      continue;
+    }
+    if (! strcmp(cmd, "ff")) {
+      if (1 != sscanf(buffer, "%*s %d", &fflags)) {
+	printf("need forward flag\n");
+      }
+      continue;
+    }
+
+    if (inverse) {		/* inverse kins */
+      if (3 != sscanf(buffer, "%lf %lf %lf", 
+		      &pos.tran.x,
+		      &pos.tran.y,
+		      &pos.tran.z)) {
+	printf("need X Y Z\n");
+	continue;
+      }
+      if (0 != kinematicsInverse(&pos, joints, NULL, &fflags)) {
+	printf("inverse kin error\n");
+      }
+      else {
+	printf("%f\t%f\t%f\n", joints[0], joints[1], joints[2]);
+	if (0 != kinematicsForward(joints, &pos, &fflags, NULL)) {
+	  printf("forward kin error\n");
+	}
+	else {
+	  printf("%f\t%f\t%f\n", pos.tran.x, pos.tran.y, pos.tran.z);
+	}
+      }
+    }
+    else {			/* forward kins */
+      if (flags) {
+	if (4 != sscanf(buffer, "%lf %lf %lf %d", 
+			&joints[0],
+			&joints[1],
+			&joints[2],
+			&fflags)) {
+	  printf("need 3 strut values and flag\n");
+	  continue;
+	}
+      }
+      else {
+	if (3 != sscanf(buffer, "%lf %lf %lf", 
+			&joints[0],
+			&joints[1],
+			&joints[2])) {
+	  printf("need 3 strut values\n");
+	  continue;
+	}
+      }
+      if (0 != kinematicsForward(joints, &pos, &fflags, NULL)) {
+	printf("forward kin error\n");
+      }
+      else {
+	printf("%f\t%f\t%f\n", pos.tran.x, pos.tran.y, pos.tran.z);
+	if (0 != kinematicsInverse(&pos, joints, NULL, &fflags)) {
+	  printf("inverse kin error\n");
+	}
+	else {
+	  printf("%f\t%f\t%f\n", joints[0], joints[1], joints[2]);
+	}
+      }
+    }
+  } /* end while (! feof(stdin)) */
+
+  return 0;
+}
+
+#endif /* MAIN */
+
+#include "rtapi.h"		/* RTAPI realtime OS API */
+#include "rtapi_app.h"		/* RTAPI realtime module decls */
+#include "hal.h"
+
+static vtkins_t vtk = {
+    .kinematicsForward = kinematicsForward,
+    .kinematicsInverse  = kinematicsInverse,
+    // .kinematicsHome = kinematicsHome,
+    .kinematicsType = kinematicsType
+};
+
+static int comp_id, vtable_id;
+static const char *name = "tripodkins";
+
+MODULE_LICENSE("GPL");
+
+int rtapi_app_main(void) {
+    int res = 0;
+
+    comp_id = hal_init(name);
+    if(comp_id < 0) return comp_id;
+
+    vtable_id = hal_export_vtable(name, VTVERSION, &vtk, comp_id);
+    if (vtable_id < 0) {
+	rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: ERROR: hal_export_vtable(%s,%d,%p) failed: %d\n",
+			name, name, VTVERSION, &vtk, vtable_id );
+	return -ENOENT;
+    }
+
+    haldata = hal_malloc(sizeof(struct haldata));
+    if(!haldata) goto error;
+
+    if((res = hal_pin_float_new("tripodkins.Bx", HAL_IO, &(haldata->bx), comp_id)) < 0) goto error;
+    if((res = hal_pin_float_new("tripodkins.Cx", HAL_IO, &(haldata->cx), comp_id)) < 0) goto error;
+    if((res = hal_pin_float_new("tripodkins.Cy", HAL_IO, &(haldata->cy), comp_id)) < 0) goto error;
+
+    Bx = Cx = Cy = 1.0;
+    hal_ready(comp_id);
+    return 0;
+
+error:
+    hal_exit(comp_id);
+    return res;
+}
+
+void rtapi_app_exit(void)
+{
+    hal_remove_vtable(vtable_id);
+    hal_exit(comp_id);
+}

--- a/src/emc/kinematics/itripodkins.c
+++ b/src/emc/kinematics/itripodkins.c
@@ -165,9 +165,7 @@ int kinematicsForward(const double * joints,
     return -1;
   }
   Dz = rtapi_sqrt(Dz);
-  if (*fflags) {
-    Dz = -Dz;
-  }
+  Dz = -Dz;
 
   pos->a = joints[3];
   pos->b = joints[4];
@@ -200,10 +198,7 @@ int kinematicsInverse(const EmcPose * pos,
   CD = rtapi_sqrt(sq(Dx - Cx) + sq(Dy - Cy) + sq(Dz));
 
   *fflags = 1;
-/*  if (Dz < 0.0) {
-    *fflags = 1;
-  }
-*/
+
   joints[3] = pos->a;
   joints[4] = pos->b;
   joints[5] = pos->c;
@@ -364,7 +359,7 @@ static vtkins_t vtk = {
 };
 
 static int comp_id, vtable_id;
-static const char *name = "tripodkins";
+static const char *name = "itripodkins";
 
 MODULE_LICENSE("GPL");
 
@@ -385,9 +380,9 @@ int rtapi_app_main(void) {
     haldata = hal_malloc(sizeof(struct haldata));
     if(!haldata) goto error;
 
-    if((res = hal_pin_float_new("tripodkins.Bx", HAL_IO, &(haldata->bx), comp_id)) < 0) goto error;
-    if((res = hal_pin_float_new("tripodkins.Cx", HAL_IO, &(haldata->cx), comp_id)) < 0) goto error;
-    if((res = hal_pin_float_new("tripodkins.Cy", HAL_IO, &(haldata->cy), comp_id)) < 0) goto error;
+    if((res = hal_pin_float_new("itripodkins.Bx", HAL_IO, &(haldata->bx), comp_id)) < 0) goto error;
+    if((res = hal_pin_float_new("itripodkins.Cx", HAL_IO, &(haldata->cx), comp_id)) < 0) goto error;
+    if((res = hal_pin_float_new("itripodkins.Cy", HAL_IO, &(haldata->cy), comp_id)) < 0) goto error;
 
     Bx = Cx = Cy = 1.0;
     hal_ready(comp_id);

--- a/src/hal/user_icomps/Submakefile
+++ b/src/hal/user_icomps/Submakefile
@@ -1,42 +1,13 @@
-##  A rather hacky but effective way to build components from C code using instcomp
-##  The dependencies to watch.so include instcomp and the userpci headers 
-##  These are jobs, so this build happens after they are completed.
-##  The creation of RTLIBDIRs are not jobs, so we have to make them first or this fails
-##
-##  Most of this can go once we just have one modules dir, they are binary identical between flavours.
+##  An effective way to build instantiated components from C code
+##  RTLIBDIR is permanant at present, need to add a job to make it later
 
 HALUSERICOMPDIR= hal/user_icomps
 
 HALUSERICOMP_SUBMAKEFILE= $(HALUSERICOMPDIR)/Submakefile
 
-$(RTLIBDIR): Makefile.inc
-ifeq ($(HAVE_POSIX_THREADS),yes)
-	mkdir -p $(EMC2_RTLIB_BASE_DIR)/posix
-endif
-ifeq ($(HAVE_RT_PREEMPT_THREADS),yes)
-	mkdir -p $(EMC2_RTLIB_BASE_DIR)/rt-preempt
-endif
-ifeq ($(HAVE_XENOMAI_THREADS),yes)
-	mkdir -p $(EMC2_RTLIB_BASE_DIR)/xenomai
-endif
+obj-m += watch.o
+# the list of parts
+watch-objs := $(HALUSERICOMPDIR)/watch.o
 
-$(RTLIBDIR)/watch.so: $(HALUSERICOMPDIR)/watch.c ../bin/instcomp ../include/userpci/module.h $(RTLIBDIR)
-	$(Q)../bin/instcomp --require-license --install $(HALUSERICOMPDIR)/watch.c
-ifeq ($(HAVE_POSIX_THREADS),yes)
-ifneq ($(RTLIBDIR),$(EMC2_RTLIB_BASE_DIR)/posix)
-	$(Q)/bin/cp -rf $(RTLIBDIR)/watch.so $(RTLIBDIR)/../posix 2>/dev/null || true
-endif
-endif
-ifeq ($(HAVE_RT_PREEMPT_THREADS),yes)
-ifneq ($(RTLIBDIR),$(EMC2_RTLIB_BASE_DIR)/rt-preempt)
-	$(Q)/bin/cp -rf $(RTLIBDIR)/watch.so $(RTLIBDIR)/../rt-preempt 2>/dev/null || true
-endif
-endif
-ifeq ($(HAVE_XENOMAI_THREADS),yes)
-ifneq ($(RTLIBDIR),$(EMC2_RTLIB_BASE_DIR)/xenomai)
-	$(Q)/bin/cp -rf $(RTLIBDIR)/watch.so $(RTLIBDIR)/../xenomai 2>/dev/null || true
-endif
-endif
-
-TARGETS += $(RTLIBDIR)/watch.so
+$(RTLIBDIR)/watch$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(watch-objs))
 


### PR DESCRIPTION
The flavour changes had resulted in the current flavour not being set properly for rtapi_main
which caused a fatal error.
Unfortunately this was not picked up, because the unset variable equates to `0` which is the enum for `posix`, so if you test it on a posix build (as I did) it all works fine.

I don't have time to fix right now, so this PR is a hard reset back to before the commits which caused problems with the non-controversial commits cherry-picked back in.

This works on a rt-preempt kernel and all flavour package builds work locally, so hopefully will provide breathing space until I have time to revisit