### PR TITLE
Update debian/control.xxx.in files

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -29,7 +29,7 @@ rules_enable_threads() {
     FLAVOR=$1
     FLAVOR_VAR=THREADS_$(echo $FLAVOR | tr 'a-z-' 'A-Z_')
     sed -i rules \
-	-e "s/^${FLAVOR_VAR}[^_].*/${FLAVOR_VAR} = --with-${FLAVOR}/"
+    -e "s/^${FLAVOR_VAR}[^_].*/${FLAVOR_VAR} = --with-${FLAVOR}/"
     echo "debian/rules:  enabled ${FLAVOR} threads" >&2
 }
 
@@ -55,7 +55,7 @@ do_xenomai() {
     # Be sure the -dev files only appear once
     BUILD_DEPS+=", libxenomai-dev"
     echo "debian/control:  added Xenomai (userland) threads package" \
-	"with Build-Depends:" >&2
+    "with Build-Depends:" >&2
     echo "    libxenomai-dev" >&2
     rules_enable_threads xenomai
     HAVE_FLAVOR=true
@@ -103,14 +103,14 @@ cd $OWD
 
 usage() {
     {
-	test -z "$1" || echo "$1"
-	echo "Usage:  $0 [ arg ... ]"
-	echo "   arg:		function:"
-	echo "   -p		build POSIX threads"
-	echo "   -r		build RT_PREEMPT threads"
-	echo "   -x		build Xenomai threads"
-	echo "   -c		rewrite changelog to set package version from git commit"
-	echo "	 -s		create source tarball for non binary package builds"
+    test -z "$1" || echo "$1"
+    echo "Usage:  $0 [ arg ... ]"
+    echo "   arg:		function:"
+    echo "   -p		build POSIX threads"
+    echo "   -r		build RT_PREEMPT threads"
+    echo "   -x		build Xenomai threads"
+    echo "   -c		rewrite changelog to set package version from git commit"
+    echo "   -s		create source tarball for non binary package builds"
     } >&2
     exit 1
 }
@@ -129,12 +129,23 @@ test "$1" != --help || usage
 BUILD_DEPS=  # List of Build-Depends
 HAVE_FLAVOR=false
 
-# copy base templates into place
-## need python-gst0.10 for Jessie, none for Stretch, no python-gtksourceview2 for Buster
+## copy base templates into place
+
+## situation at 20092018
+## python-gst1.0 backported to Jessie + Stretch
+## python-gtksourceview2 not available for Buster but is for Sid, meaning gladevcp widgets keep working.
+## python-pil and python-pil.imagegtk active for Sid replacing python-imaging and python-imaging-tk
+## however selecting python-imaging and python-imaging-tk in Stretch actually
+## results in python-pil and python-pil.imagegtk being installed, so will probably completely backport soon.
+
+## Keep individual control files, so they can easily be amended as things change
+
 if [ "$DISTRO_CODENAME" == "stretch" ]; then
     cp control.stretch.in control
 elif [ "$DISTRO_CODENAME" == "buster" ]; then
     cp control.buster.in control   	
+elif [ "$DISTRO_CODENAME" == "sid" ]; then
+    cp control.sid.in control   	
 else
     cp control.in control
 fi
@@ -148,13 +159,13 @@ echo "debian/machinekit.install.in:  copied base template" >&2
 # read command line options
 while getopts prxcsd?h ARG; do
     case $ARG in
-	p) do_posix ;;
-	r) do_rt-preempt ;;
-	x) do_xenomai ;;
-	c) do_changelog ;;  # set new changelog with package versions from git
-	s) do_source_tarball ;; # create tarball for non binary builds
-	?|h) usage ;;
-	*) usage "Unknown arg: '-$ARG'" ;;
+    p) do_posix ;;
+    r) do_rt-preempt ;;
+    x) do_xenomai ;;
+    c) do_changelog ;;  # set new changelog with package versions from git
+    s) do_source_tarball ;; # create tarball for non binary builds
+    ?|h) usage ;;
+    *) usage "Unknown arg: '-$ARG'" ;;
     esac
 done
 

--- a/debian/control.sid.in
+++ b/debian/control.sid.in
@@ -46,13 +46,13 @@ Architecture: any
 Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
     bwidget (>= 1.7), libtk-img (>=1.13),
     ${python:Depends}, ${misc:Depends},
-    python-tk, python-imaging, python-imaging-tk,
+    python-tk, python-pil, python-pil.imagetk,
     python-gnome2, python-glade2,
     python-numpy,
     python-vte, python-xlib, python-gtkglext1, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, python-simplejson, python-pyftpdlib,
-    python-pydot, xdot, python-gst-1.0,
+    python-pydot, xdot, python-gst-1.0, python-gtksourceview2,
     tclreadline, bc, procps, psmisc
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/debian/control.stretch.in
+++ b/debian/control.stretch.in
@@ -52,7 +52,7 @@ Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
     python-vte, python-xlib, python-gtkglext1, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, python-simplejson, python-pyftpdlib,
-    python-pydot, xdot,
+    python-pydot, xdot, python-gst-1.0, python-gtksourceview2,
     tclreadline, bc, procps, psmisc
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which


### PR DESCRIPTION
Situation at 20092018

python-gst1.0 backported to Jessie + Stretch
This affects gmoccapy, which uses functions in the old lib, but checks were introduced in
https://github.com/machinekit/machinekit/commit/5e5bb64 to remove those if newer distro used.
These remain valid as python-gst-0.10 is not available for Stretch and above even though the
newer lib is available in Jessie.

python-gtksourceview2 is still not available for Buster, but Sid has it, so expect backport soon
This is used in gladevcp widgets.

python-pil and python-pil.imagegtk active for Sid replacing python-imaging and python-imaging-tk
however selecting python-imaging and python-imaging-tk in Stretch actually
results in python-pil and python-pil.imagegtk being installed, so will probably completely backport soon.

Keep individual control files, so they can easily be amended as things change

Signed-off-by: Mick <arceye@mgware.co.uk>