### PR TITLE
Change hal_spi driver to test for Rpi version

### DIFF
--- a/src/hal/drivers/hal_spi.h
+++ b/src/hal/drivers/hal_spi.h
@@ -38,7 +38,8 @@
 
 /* Broadcom defines */
 
-#define BCM2835_PERI_BASE	0x20000000
+//#define BCM2835_PERI_BASE	0x20000000
+unsigned int BCM2835_PERI_BASE;
 #define BCM2835_GPIO_BASE	(BCM2835_PERI_BASE + 0x200000) /* GPIO controller */
 #define BCM2835_SPI_BASE	(BCM2835_PERI_BASE + 0x204000) /* SPI controller */
 


### PR DESCRIPTION
Driver was written when only Rpi 1 & 2 existed
RPi 3B has a different base address from which everything
thereafter is offset from

Test version and set base address.

Signed-off-by: Mick <arceye@mgware.co.uk>