### PR TITLE
Mk pr compiler warnings 2018 10 08

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -27,12 +27,16 @@ SHLIBDEPS_X :=  # add patterns here
 #
 # The name 'libtk8.6.so' can't be parsed by dpkg-shlibdeps, it seems:
 #     "can't extract name and version from library name 'libtk8.6.so'
-SHLIBDEPS_X += tcltk/linuxcnc/linuxcnc.so dist-packages/_togl _togl.so
+SHLIBDEPS_X += linuxcnc.so _togl.so
 #
 # libcanterp.so.0 and librs274.so.0: hack for now:  see
 # https://github.com/machinekit/machinekit/issues/324
 #     "symbol ... used by ... found in none of the libraries"
 SHLIBDEPS_X += libcanterp.so.0 librs274.so.0
+#
+# halmeter classicladder halscope link to $(GTK_LIBS), which includes
+# several libs that aren't used (but several that are needed)
+SHLIBDEPS_X += halmeter classicladder halscope
 
 # Enable/disable thread flavors; all flavors disabled by default
 THREADS_POSIX = --without-posix

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -22,6 +22,18 @@ endif
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+# dpkg-shlibdeps warning exclusions
+SHLIBDEPS_X :=  # add patterns here
+#
+# The name 'libtk8.6.so' can't be parsed by dpkg-shlibdeps, it seems:
+#     "can't extract name and version from library name 'libtk8.6.so'
+SHLIBDEPS_X += tcltk/linuxcnc/linuxcnc.so dist-packages/_togl _togl.so
+#
+# libcanterp.so.0 and librs274.so.0: hack for now:  see
+# https://github.com/machinekit/machinekit/issues/324
+#     "symbol ... used by ... found in none of the libraries"
+SHLIBDEPS_X += libcanterp.so.0 librs274.so.0
+
 # Enable/disable thread flavors; all flavors disabled by default
 THREADS_POSIX = --without-posix
 THREADS_RT_PREEMPT = --without-rt-preempt
@@ -223,10 +235,11 @@ binary-arch: build install
 
 	cat debian/machinekit/DEBIAN/shlibs debian/shlibs.pre > \
 	    debian/shlibs.local
-	#enable buster builds to work with problematic shlib deps in current packages
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info -l debian/machinekit/usr/lib
+        #enable buster builds to work with problematic shlib deps in current packages
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info \
+            $(foreach p, $(SHLIBDEPS_X), -X $(p))
 	dh_gencontrol
-	
+
 	dh_md5sums
 	dh_builddeb
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1902,7 +1902,8 @@ objects/var-%: Makefile $(wildcard $(SUBMAKEFILES)) Makefile.inc
 	@sh move-if-change $@.tmp $@
 
 ../lib/%.so: ../lib/%.so.0
-	ln -sf $(notdir $<) $@
+	$(ECHO) Symlinking $(notdir $<) to $(notdir $@)
+	$(Q)ln -sf $(notdir $<) $@
 
 cscope:
 	cscope -Rb

--- a/src/Makefile
+++ b/src/Makefile
@@ -1648,7 +1648,7 @@ RTDEPS := $(sort $(patsubst $(OBJDIR)/%.o,$(DEPDIR)/%.d, $(RTOBJS)))
 #
 modules: $(patsubst %.o,$(RTLIBDIR)/%.so,$(obj-m))
 $(RTLIBDIR)/%.so:
-	$(ECHO) Linking $@
+	$(ECHO) Linking realtime $(threads) $(notdir $@)
 	@mkdir -p $(dir $@)
 	@# link all objects files into a single .so
 	$(Q)$(LD) -d -r -o $(OBJDIR)/$*.tmp $^
@@ -1668,7 +1668,7 @@ $(sort $(RTDEPS)): $(DEPDIR)/%.d: %.c
 
 # Rules to make .o (object) files
 $(sort $(RTOBJS)) : $(OBJDIR)/%.o : %.c $(DEPDIR)/%.d
-	$(ECHO) Compiling realtime $<
+	$(ECHO) Compiling realtime $(threads) $<
 	@rm -f $@
 	@mkdir -p $(dir $@)
 	$(Q)$(CC) -c $(OPT) $(DEBUG) $(EXTRA_CFLAGS) $< -o $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -934,7 +934,8 @@ endif
 	$(FILE) $(filter ../lib/%.a ../lib/%.so.0,$(TARGETS)) $(DESTDIR)$(libdir)
 	cp --no-dereference $(filter ../lib/%.so, $(TARGETS)) $(DESTDIR)$(libdir)
 	$(FILE) ../rtlib/ulapi-*.so $(DESTDIR)$(EMC2_RTLIB_BASE_DIR)
-	-ldconfig $(DESTDIR)$(libdir)
+#	# don't run ldconfig under fakeroot (silence dpkg-build warning)
+	-test -n "$$FAKED_MODE" || ldconfig $(DESTDIR)$(libdir)
 	$(FILE) $(HEADERS) $(DESTDIR)$(includedir)/linuxcnc/
 ifeq ($(USERMODE_PCI),yes)
 	$(FILE) $(USERPCI_HEADERS) $(DESTDIR)$(includedir)/linuxcnc/userpci

--- a/src/Makefile.modinc.in
+++ b/src/Makefile.modinc.in
@@ -107,7 +107,7 @@ $(foreach mod,$(patsubst %.o,%,$(obj-m)),\
 
 .PHONY: %.so
 %.so:
-	$(ECHO) Linking $@
+	$(ECHO) Linking $(notdir $@)
 	$(Q)$(LD) -d -r -o $*.tmp $^
 	$(Q)objcopy -j .rtapi_export -O binary $*.tmp $*.exported
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2887,7 +2887,7 @@ fi
 if test "x$HAVE_XAW" = "xno"; then
     AC_MSG_WARN([Xaw lib missing, you won't be able to build/run xemc. try installing it with 'apt-get install libxaw7-dev'])
 else
-    XAW_LIBS="$X_PRE_LIBS $X_LIBS -lX11 -lXaw -lXt"
+    XAW_LIBS="-lX11 -lXaw -lXt"
 fi
 AC_SUBST([HAVE_XAW])
 AC_SUBST([XAW_LIBS])

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3099,7 +3099,6 @@ AC_SUBST([SITEPY])
 
 if test "$BUILD_EMCWEB" = yes; then
    # these are needed for the emcweb interface only
-   AX_BOOST_SERIALIZATION()
    AX_BOOST_THREAD()
    AX_BOOST_SYSTEM()
 fi

--- a/src/emc/canterp/Submakefile
+++ b/src/emc/canterp/Submakefile
@@ -3,7 +3,7 @@ USERSRCS += $(LIBCANTERPSRCS)
 TARGETS += ../lib/libcanterp.so ../lib/libcanterp.so.0
 $(call TOOBJSDEPS, $(LIBCANTERPSRCS)) : EXTRAFLAGS=-fPIC
 ../lib/libcanterp.so.0: $(patsubst %.cc,objects/%.o,$(LIBCANTERPSRCS)) ../lib/liblinuxcncini.so ../lib/librs274.so
-	$(ECHO) Linking $(notdir $@)
+	$(ECHO) Creating shared library $(notdir $@)
 	@mkdir -p ../lib
 	@rm -f $@
 	@$(CXX) $(LDFLAGS) -Wl,-soname,$(notdir $@) -shared -o $@ $^ -ldl

--- a/src/emc/ini/inihal.hh
+++ b/src/emc/ini/inihal.hh
@@ -68,7 +68,9 @@ struct PTR {
 };
 
 #pragma GCC diagnostic push
+#if defined(__GNUC__) && (__GNUC__ > 4)
 #pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
 template<class T> struct NATIVE {};
 template<> struct NATIVE<hal_bit_t> { typedef bool type; };
 template<> struct NATIVE<hal_s32_t> { typedef __s32 type; };

--- a/src/emc/ini/inihal.hh
+++ b/src/emc/ini/inihal.hh
@@ -67,6 +67,8 @@ struct PTR {
     struct field { typedef T *type; };
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
 template<class T> struct NATIVE {};
 template<> struct NATIVE<hal_bit_t> { typedef bool type; };
 template<> struct NATIVE<hal_s32_t> { typedef __s32 type; };
@@ -88,5 +90,6 @@ HAL_FIELDS
 
 typedef inihal_base<PTR> ptr_inihal_data;
 typedef inihal_base<VALUE> value_inihal_data;
+#pragma GCC diagnostic pop
 
 #endif

--- a/src/emc/kinematics/Submakefile
+++ b/src/emc/kinematics/Submakefile
@@ -16,7 +16,7 @@ $(call TOOBJS, $(DELTAMODULESRCS)): CFLAGS += -x c++ -Wno-declaration-after-stat
 DELTAMODULE := ../lib/python/lineardeltakins.so
 $(DELTAMODULE): $(call TOOBJS, $(DELTAMODULESRCS))
 	$(ECHO) Linking python module $(notdir $@)
-	$(CXX) $(LDFLAGS) -shared -o $@ $^ -l$(BOOST_PYTHON_LIB)
+	$(Q)$(CXX) $(LDFLAGS) -shared -o $@ $^ -l$(BOOST_PYTHON_LIB)
 PYTARGETS += $(DELTAMODULE)
 
 ../bin/genserkins: $(call TOOBJS, $(GENSERKINSSRCS)) \

--- a/src/emc/kinematics/drawbotkins.c
+++ b/src/emc/kinematics/drawbotkins.c
@@ -290,7 +290,6 @@ void halt_motion(struct hal_joint_t *joints) {
 
 void drawbot_home(void *args, long period) {
   int idx;
-  hal_bit_t homing = 0;
 
   for(idx = 0; idx < 4; ++idx) {
     *(haldata->joint[idx].home) = 0;
@@ -388,7 +387,7 @@ void drawbot_home_a(struct hal_joint_t *joint) {
     joint[3].tripped = 1;
     halt_motion(joint);
   } else if(!joint[3].started) {
-    joint[3].started;
+    joint[3].started = 1;
     *(joint[1].jog) = 1.0;
     *(joint[3].jog) = -1.0;
   }

--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -24,8 +24,6 @@
     } while (0)
 
 
-extern const char *strstore(const char *s);
-
 int PythonPlugin::run_string(const char *cmd, bp::object &retval, bool as_file)
 {
     reload();
@@ -383,4 +381,3 @@ PythonPlugin *PythonPlugin::instantiate(struct _inittab *inittab)
     }
     return (python_plugin->usable()) ? python_plugin : NULL;
 }
-

--- a/src/emc/rs274ngc/Submakefile
+++ b/src/emc/rs274ngc/Submakefile
@@ -60,7 +60,7 @@ PYSRCS += $(GCODEMODULESRCS)
 GCODEMODULE := ../lib/python/gcode.so
 $(GCODEMODULE): $(call TOOBJS, $(GCODEMODULESRCS)) ../lib/librs274.so.0
 	$(ECHO) Linking python module $(notdir $@)
-	$(CXX) $(LDFLAGS) -shared -o $@ $^ -lstdc++
+	$(Q)$(CXX) $(LDFLAGS) -shared -o $@ $^ -lstdc++
 
 
 PYTARGETS += $(GCODEMODULE)

--- a/src/emc/rs274ngc/Submakefile
+++ b/src/emc/rs274ngc/Submakefile
@@ -78,7 +78,8 @@ $(PREVIEWMODULE): $(call TOOBJS, $(PREVIEWMODULESRCS)) \
 	../lib/libmachinetalk-pb2++.so.0 \
 	../lib/libmtalk.so
 	$(ECHO) Linking python module $(notdir $@)
-	$(CXX) $(LDFLAGS) -shared -o $@ $^ -lstdc++  $(CZMQ_LIBS)  $(PROTOBUF_LIBS)
+	$(Q)$(CXX) $(LDFLAGS) -shared -o $@ $^ -lstdc++  $(CZMQ_LIBS) \
+	    $(PROTOBUF_LIBS)
 
 
 PYTARGETS += $(PREVIEWMODULE)

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -281,10 +281,6 @@ typedef enum
 { R_PLANE, OLD_Z }
 RETRACT_MODE;
 
-// string table - to get rid of strdup/free
-const char *strstore(const char *s);
-
-
 // Block execution phases in execution order
 // very carefully check code for sequencing when
 // adding phases!

--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -28,6 +28,7 @@
 #include "interp_return.hh"
 #include "interp_internal.hh"
 #include "rs274ngc_interp.hh"
+#include "inifile.hh"		// strstore()
 
 namespace bp = boost::python;
 

--- a/src/emc/rs274ngc/interp_read.cc
+++ b/src/emc/rs274ngc/interp_read.cc
@@ -28,6 +28,7 @@
 #include "rs274ngc_return.hh"
 #include "interp_internal.hh"
 #include "rs274ngc_interp.hh"
+#include "inifile.hh"		// strstore()
 
 /****************************************************************************/
 

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -24,6 +24,7 @@
 #include "rs274ngc_return.hh"
 #include "rs274ngc_interp.hh"
 #include "interp_internal.hh"
+#include "inifile.hh"		// strstore()
 
 namespace bp = boost::python;
 

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -79,8 +79,6 @@ include an option for suppressing superfluous commands.
 #include <time.h>
 #include <unistd.h>
 #include <libintl.h>
-#include <set>
-#include <stdexcept>
 
 #include "inifile.hh"		// INIFILE
 #include "rs274ngc.hh"
@@ -2595,23 +2593,3 @@ FILE *Interp::find_ngc_file(setup_pointer settings,const char *basename, char *f
 	strcpy(foundhere, newFileName);
     return newFP;
 }
-
-
-static std::set<std::string>  stringtable;
-
-const char *strstore(const char *s)
-{
-    using namespace std;
-
-    if (s == NULL)
-        throw invalid_argument("strstore(): NULL argument");
-
-    std::set<std::string>::iterator it = stringtable.find(s);
-    if (it == stringtable.end()) {
-	std::string *p = new std::string(s);
-	stringtable.insert(*p);
-	return p->c_str();
-    }
-    return (*it).c_str();
-}
-

--- a/src/emc/usr_intf/Submakefile
+++ b/src/emc/usr_intf/Submakefile
@@ -123,7 +123,7 @@ ifeq "$(BUILD_EMCWEB)" "yes"
 	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) $(LDFLAGS) $(BOOST_LDFLAGS) -o $@ $(ULFLAGS) $^ \
-	    $(BOOST_SERIALIZATION_LIB) $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) \
+	    $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) \
 	    -lpthread -ldl	
 TARGETS += ../bin/emcweb
 endif

--- a/src/emc/usr_intf/emcweb.cc
+++ b/src/emc/usr_intf/emcweb.cc
@@ -119,7 +119,9 @@ class WebPage
 public:
 	virtual void Init() {};
 	virtual void Exit() {};
-	virtual bool HandleReq(mongoose::web_response &response, mongoose::web_request &request);
+	virtual bool HandleReq(mongoose::web_response &response,
+			       mongoose::web_request &request);
+	virtual ~WebPage(){};
 };
 
 
@@ -355,7 +357,11 @@ void GenerateJson(const char *filename)
 		 */
 		int fd = open(filename, O_WRONLY | O_TRUNC | O_SYNC | O_CREAT, 0666);
 		if (fd >= 0) {
-			write(fd, buff, strlen(buff));
+			if (write(fd, buff, strlen(buff)) <
+			    (ssize_t)strlen(buff))
+				fprintf(stderr,
+					"unable to write DYNAMIC_JSON buffer "
+					"to file");
 			fsync(fd);
 			close(fd);
 		} else {

--- a/src/emc/usr_intf/emcweb/mongoose.c
+++ b/src/emc/usr_intf/emcweb/mongoose.c
@@ -461,13 +461,13 @@ struct mg_connection {
 
 void *_calloc (size_t __nmemb, size_t __size)
 {
-    fprintf(stderr, "Try to calloc %d blocks of %d bytes\n", __nmemb, __size );
+    fprintf(stderr, "Try to calloc %zu blocks of %zu bytes\n", __nmemb, __size );
     return calloc( __nmemb, __size );
 }
 
 void *_realloc (void *__ptr, size_t __size)
 {
-    fprintf(stderr, "Try to re-alloc ptr %p to size %d bytes\n", __ptr, __size );
+    fprintf(stderr, "Try to re-alloc ptr %p to size %zu bytes\n", __ptr, __size );
     return realloc( __ptr, __size );
 }
 
@@ -3697,10 +3697,8 @@ static void close_connection(struct mg_connection *conn) {
 }
 
 static void discard_current_request_from_buffer(struct mg_connection *conn) {
-  char *buffered;
   int buffered_len, body_len;
 
-  buffered = conn->buf + conn->request_len;
   buffered_len = conn->data_len - conn->request_len;
   assert(buffered_len >= 0);
 
@@ -3887,7 +3885,8 @@ static void worker_thread(struct mg_context *ctx) {
   conn = _calloc(1, sizeof(*conn) + buf_size);
   if( !conn )
   {
-      fprintf(stderr, "%s: error when allocating memory of size %d\n", __func__, sizeof(*conn) + buf_size );
+      fprintf(stderr, "%s: error when allocating memory of size %zu\n",
+              __func__, sizeof(*conn) + buf_size );
       exit(1);
   }
   conn->buf_size = buf_size;

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -224,6 +224,9 @@ DONE: - spindle-override
 
 #define MDI_MAX 64
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+
 #define HAL_FIELDS \
     FIELD(hal_bit_t,machine_on) /* pin for setting machine On */ \
     FIELD(hal_bit_t,machine_off) /* pin for setting machine Off */ \
@@ -380,6 +383,7 @@ HAL_FIELDS
 
 typedef halui_str_base<PTR> halui_str;
 typedef halui_str_base<VALUE> local_halui_str;
+#pragma GCC diagnostic pop
 
 static halui_str *halui_data;
 static local_halui_str old_halui_data;

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -225,7 +225,9 @@ DONE: - spindle-override
 #define MDI_MAX 64
 
 #pragma GCC diagnostic push
+#if defined(__GNUC__) && (__GNUC__ > 4)
 #pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
 
 #define HAL_FIELDS \
     FIELD(hal_bit_t,machine_on) /* pin for setting machine On */ \

--- a/src/emc/usr_intf/schedrmt.cc
+++ b/src/emc/usr_intf/schedrmt.cc
@@ -1186,19 +1186,18 @@ void *readClient(void *arg)
     while (i <= strlen(buf)) {
       if ((buf[i] != '\n') && (buf[i] != '\r')) {
         context->inBuf[j] = buf[i];
-	j++;
-	}
-      else
-        if (j > 0)
-          {
-  	    context->inBuf[j] = 0;
-            if (parseCommand(context) == -1) goto finished;
-	    j = 0;
-	}
-        i++;	
+        j++;
       }
+      else
+        if (j > 0) {
+  	    context->inBuf[j] = 0;
+        if (parseCommand(context) == -1) goto finished;
+	    j = 0;
+        }
+      i++;
+    }
     buf[0] = 0;
-    } 
+  }
 
 finished:
   close(context->cliSock);

--- a/src/hal/classicladder/module_hal.c
+++ b/src/hal/classicladder/module_hal.c
@@ -293,12 +293,13 @@ void CopySizesInfosFromModuleParams( void ) {
 		GeneralParamsMirror.SizesInfos.nbr_phys_float_inputs = numFloatIn;
 	if ( numFloatOut>0 )
 		GeneralParamsMirror.SizesInfos.nbr_phys_float_outputs = numFloatOut;        
-		GeneralParamsMirror.SizesInfos.nbr_symbols = pSizesInfos->nbr_bits + pSizesInfos->nbr_words ;
-		GeneralParamsMirror.SizesInfos.nbr_symbols += pSizesInfos->nbr_timers + pSizesInfos->nbr_monostables ;
-		GeneralParamsMirror.SizesInfos.nbr_symbols += pSizesInfos->nbr_counters + pSizesInfos->nbr_timers_iec ;
-		GeneralParamsMirror.SizesInfos.nbr_symbols += pSizesInfos->nbr_phys_inputs + pSizesInfos->nbr_phys_outputs ;
-		GeneralParamsMirror.SizesInfos.nbr_symbols += pSizesInfos->nbr_phys_words_inputs + pSizesInfos->nbr_phys_words_outputs;
-		GeneralParamsMirror.SizesInfos.nbr_symbols += pSizesInfos->nbr_phys_float_inputs + pSizesInfos->nbr_phys_float_outputs + NBR_ERROR_BITS_DEF ;
+
+        GeneralParamsMirror.SizesInfos.nbr_symbols = pSizesInfos->nbr_bits + pSizesInfos->nbr_words ;
+        GeneralParamsMirror.SizesInfos.nbr_symbols += pSizesInfos->nbr_timers + pSizesInfos->nbr_monostables ;
+        GeneralParamsMirror.SizesInfos.nbr_symbols += pSizesInfos->nbr_counters + pSizesInfos->nbr_timers_iec ;
+        GeneralParamsMirror.SizesInfos.nbr_symbols += pSizesInfos->nbr_phys_inputs + pSizesInfos->nbr_phys_outputs ;
+        GeneralParamsMirror.SizesInfos.nbr_symbols += pSizesInfos->nbr_phys_words_inputs + pSizesInfos->nbr_phys_words_outputs;
+        GeneralParamsMirror.SizesInfos.nbr_symbols += pSizesInfos->nbr_phys_float_inputs + pSizesInfos->nbr_phys_float_outputs + NBR_ERROR_BITS_DEF ;
 	if (numSymbols < GeneralParamsMirror.SizesInfos.nbr_symbols ) {  GeneralParamsMirror.SizesInfos.nbr_symbols = numSymbols;  }
     
 	#endif

--- a/src/hal/cython/Submakefile
+++ b/src/hal/cython/Submakefile
@@ -29,7 +29,7 @@ TARGETS += ../lib/python/machinekit/hal.so
 		../lib/libmtalk.so.0 \
 		$(patsubst %.c,objects/%.o,$(HALSO_SRCS)) \
 		$(patsubst %.cc,objects/%.o,$(HALSO_CXXSRCS))
-	$(ECHO) Linking $(notdir $@)
+	$(ECHO) Linking python module $(notdir $@)
 	@mkdir -p $(dir $@)
 	$(Q)$(CC) -g $(LDFLAGS) -shared -o $@ $^
 
@@ -70,7 +70,7 @@ TARGETS += ../lib/python/machinekit/compat.so
 ../lib/python/machinekit/compat.so: \
 		$(patsubst %.c,objects/%.o,$(COMPATSO_CSRCS)) \
 		../lib/liblinuxcnchal.so.0
-	$(ECHO) Linking $@
+	$(ECHO) Linking python module $(notdir $@)
 	@mkdir -p $(dir $@)
 	$(Q)$(CC) -g $(LDFLAGS) -shared -o $@ $^
 
@@ -84,7 +84,7 @@ $(call TOOBJSDEPS, $(SHMCOMMONSO_CSRCS)) : EXTRAFLAGS=-fPIC -Irtapi/shmdrv
 TARGETS += ../lib/python/machinekit/shmcommon.so
 ../lib/python/machinekit/shmcommon.so: \
 		$(patsubst %.c,objects/%.o,$(SHMCOMMONSO_CSRCS))
-	$(ECHO) Linking $@
+	$(ECHO) Linking python module $(notdir $@)
 	@mkdir -p $(dir $@)
 	$(Q)$(CC) -g  -shared -o $@ $^ $(LDFLAGS) -lrt
 

--- a/src/hal/cython/Submakefile
+++ b/src/hal/cython/Submakefile
@@ -24,13 +24,14 @@ $(call TOOBJSDEPS, $(HALSO_CXXSRCS)) : EXTRAFLAGS=-fPIC -Ihal/utils -I.
 $(HALNGMKDIR)/hal.c: $(wildcard $(HALNGMKDIR)/*.pyx $(HALNGMKDIR)/*.pxd)
 
 TARGETS += ../lib/python/machinekit/hal.so
-../lib/python/machinekit/hal.so:	../lib/liblinuxcnchal.so.0 \
-	../lib/libmtalk.so.0 \
-	 $(patsubst %.c,objects/%.o,$(HALSO_SRCS)) \
-	 $(patsubst %.cc,objects/%.o,$(HALSO_CXXSRCS))
-	$(ECHO) Linking $($@)
+../lib/python/machinekit/hal.so: \
+		../lib/liblinuxcnchal.so.0 \
+		../lib/libmtalk.so.0 \
+		$(patsubst %.c,objects/%.o,$(HALSO_SRCS)) \
+		$(patsubst %.cc,objects/%.o,$(HALSO_CXXSRCS))
+	$(ECHO) Linking $(notdir $@)
 	@mkdir -p $(dir $@)
-	$(CC) -g $(LDFLAGS) -shared -o $@ $^
+	$(Q)$(CC) -g $(LDFLAGS) -shared -o $@ $^
 
 
 RTAPISO_CSRCS := $(addprefix $(HALNGMKDIR)/, \
@@ -48,14 +49,14 @@ $(call TOOBJSDEPS, $(RTAPISO_CXXSRCS)) : EXTRAFLAGS=-fPIC -Ihal/utils -I.
 TARGETS += ../lib/python/machinekit/rtapi.so
 
 ../lib/python/machinekit/rtapi.so: \
-	 $(patsubst %.c,objects/%.o,$(RTAPISO_CSRCS)) \
-	 $(patsubst %.cc,objects/%.o,$(RTAPISO_CXXSRCS)) \
-	../lib/liblinuxcnchal.so.0 \
-	../lib/libmachinetalk-pb2++.so.0 \
-	../lib/libmtalk.so.0
-	$(ECHO) Linking $($@)
+		$(patsubst %.c,objects/%.o,$(RTAPISO_CSRCS)) \
+		$(patsubst %.cc,objects/%.o,$(RTAPISO_CXXSRCS)) \
+		../lib/liblinuxcnchal.so.0 \
+		../lib/libmachinetalk-pb2++.so.0 \
+		../lib/libmtalk.so.0
+	$(ECHO) Linking $(notdir $@)
 	@mkdir -p $(dir $@)
-	$(CC) -g $(LDFLAGS) -shared -o $@ $^
+	$(Q)$(CC) -g $(LDFLAGS) -shared -o $@ $^
 
 
 COMPATSO_CSRCS := $(addprefix $(HALNGMKDIR)/, \
@@ -67,11 +68,11 @@ USERSRCS += $(COMPATSO_CSRCS)
 $(call TOOBJSDEPS, $(COMPATSO_CSRCS)) : EXTRAFLAGS=-fPIC
 TARGETS += ../lib/python/machinekit/compat.so
 ../lib/python/machinekit/compat.so: \
-	 $(patsubst %.c,objects/%.o,$(COMPATSO_CSRCS)) \
-	../lib/liblinuxcnchal.so.0
-	$(ECHO) Linking $($@)
+		$(patsubst %.c,objects/%.o,$(COMPATSO_CSRCS)) \
+		../lib/liblinuxcnchal.so.0
+	$(ECHO) Linking $@
 	@mkdir -p $(dir $@)
-	$(CC) -g $(LDFLAGS) -shared -o $@ $^
+	$(Q)$(CC) -g $(LDFLAGS) -shared -o $@ $^
 
 
 SHMCOMMONSO_CSRCS := $(addprefix $(HALNGMKDIR)/, \
@@ -82,10 +83,10 @@ USERSRCS += $(SHMCOMMONSO_CSRCS)
 $(call TOOBJSDEPS, $(SHMCOMMONSO_CSRCS)) : EXTRAFLAGS=-fPIC -Irtapi/shmdrv
 TARGETS += ../lib/python/machinekit/shmcommon.so
 ../lib/python/machinekit/shmcommon.so: \
-	 $(patsubst %.c,objects/%.o,$(SHMCOMMONSO_CSRCS))
-	$(ECHO) Linking $($@)
+		$(patsubst %.c,objects/%.o,$(SHMCOMMONSO_CSRCS))
+	$(ECHO) Linking $@
 	@mkdir -p $(dir $@)
-	$(CC) -g  -shared -o $@ $^ $(LDFLAGS) -lrt
+	$(Q)$(CC) -g  -shared -o $@ $^ $(LDFLAGS) -lrt
 
 $(HALNGDIR)/machinekit/%.c: $(addprefix $(HALNGDIR)/machinekit/, %.pyx %.pxd)
 	$(CYTHON) -o $@ $<

--- a/src/hal/drivers/hal_p260c.c
+++ b/src/hal/drivers/hal_p260c.c
@@ -558,32 +558,32 @@ static void set_debug( int pin, int val )
 
 ***/
 
-static void flush_input( int board )
-{
-	unsigned char inp;
-	int cnt = 0;
+/* static void flush_input( int board ) */
+/* { */
+/* 	unsigned char inp; */
+/* 	int cnt = 0; */
 
-	// Flush the input data first
-	while ( read( sfd, &inp, 1 ) > 0 && cnt++ < 1000 )
-	{
-		if ( debug_fd )
-		{
-			write( debug_fd, &inp, 1 );
-		}
-	}
+/* 	// Flush the input data first */
+/* 	while ( read( sfd, &inp, 1 ) > 0 && cnt++ < 1000 ) */
+/* 	{ */
+/* 		if ( debug_fd ) */
+/* 		{ */
+/* 			write( debug_fd, &inp, 1 ); */
+/* 		} */
+/* 	} */
 
-#ifdef DEBUG_RX
-	if ( boards[board].readbeforewritecount != NULL )
-	{
-		*(boards[board].readbeforewritecount) = cnt;
-	}
-#endif
-	if ( cnt )
-	{
-		set_debug( 0, 0 );
-		set_debug( 0, 1 );
-	}
-}
+/* #ifdef DEBUG_RX */
+/* 	if ( boards[board].readbeforewritecount != NULL ) */
+/* 	{ */
+/* 		*(boards[board].readbeforewritecount) = cnt; */
+/* 	} */
+/* #endif */
+/* 	if ( cnt ) */
+/* 	{ */
+/* 		set_debug( 0, 0 ); */
+/* 		set_debug( 0, 1 ); */
+/* 	} */
+/* } */
 
 static void wait_tx_empty()
 {
@@ -594,7 +594,7 @@ static void wait_tx_empty()
 static void send_data( int board )
 {
 #ifdef DEBUG_RX
-//	flush_input( board );
+	/* flush_input( board ); */
 #endif
 
 	// Write protocol data
@@ -970,7 +970,7 @@ static void serial_port_task( void *arg, long period )
 	// Start the transmit to the first board.
 	set_debug( 1, 0 );
 //	set_debug( 0, 1 );
-//  flush_input( 0 );
+        /* flush_input( 0 ); */
 	set_debug( 0, 0 );
 
 	// Send data to all boards

--- a/src/hal/drivers/hal_vti.c
+++ b/src/hal/drivers/hal_vti.c
@@ -798,6 +798,7 @@ static int vti_dac_write(int axis, short value)
       }
 
     junk = dac->mode;         // Read from mode to trigger update dac immediately
+    junk++;		      // Silence compiler '-Wunused-value' warnings
     dac->dac[axis] = value;   // Write dac value
     
      return 0;

--- a/src/hal/drivers/mesa-hostmot2/irq.c
+++ b/src/hal/drivers/mesa-hostmot2/irq.c
@@ -37,7 +37,6 @@ static int hm2_waitirq(void *void_hm2, const hal_funct_args_t *fa);
 
 int hm2_irq_setup(hostmot2_t *hm2, long period) {
     int r;
-    char name[HAL_NAME_LEN + 1];
 
     // Fake the module count - if it gets promoted this will be populated
     // by the module descriptor parse function

--- a/src/hal/drivers/mesa-hostmot2/pktuart.c
+++ b/src/hal/drivers/mesa-hostmot2/pktuart.c
@@ -400,7 +400,7 @@ int hm2_pktuart_read(char *name, unsigned char data[], u8 *num_frames, u16 *max_
     r = hm2->llio->read(hm2->llio, hm2->pktuart.instance[inst].rx_mode_addr,
                         &buff, sizeof(u32));
     if (r < 0) {
-        HM2_ERR("%s read: hm2->llio->write failure %s\n", name);
+        HM2_ERR("%s read: hm2->llio->write failure\n", name);
                 return -1; // make the error message more detailed
     }
     countp = (buff >> 16)  & 0x1f; 

--- a/src/hal/drivers/mesa-hostmot2/pktuart.c
+++ b/src/hal/drivers/mesa-hostmot2/pktuart.c
@@ -230,7 +230,7 @@ int hm2_pktuart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode, int txc
         buff = ((u32)rx_mode) & 0x3fc0ffff; // 0011 1111 1100 0000 1111 1111 1111 1111
         // the expert user is allowed to pass his own FilterReg value,
         // otherwise it will be calculated as floor( 0.5*bittime*ClockLow -1 )
-        if ( (buff >> 22) & 0xff == 0x0) {
+        if ( (buff >> 22) & (0xff == 0x0)) {
             u32 filter_reg = rtapi_floor(0.5*inst->clock_freq/inst->bitrate - 1.0) ;
             if (filter_reg > 255)
                 filter_reg = 255;

--- a/src/hal/drivers/mesa_7i65.comp
+++ b/src/hal/drivers/mesa_7i65.comp
@@ -50,7 +50,7 @@ include "../../../hal/drivers/mesa-hostmot2/hostmot2.h";
 char *bspi_chans[16] = {0,};
 RTAPI_MP_ARRAY_STRING(bspi_chans, 16, "BSPI Channel names");
 
-static void read(struct __comp_state *__comp_inst){
+static int read(struct __comp_state *__comp_inst){
     int i;
     double aout[8];
 
@@ -153,6 +153,8 @@ static void read(struct __comp_state *__comp_inst){
     for(i=0; i < 8; i++) {
         analogue_in(i) = (double)((s16)((*AD7329_read[i] & 0x1FFF) << 3)) / 3276.8;
     }
+
+    return 0;
 }
 
 EXTRA_SETUP(){
@@ -224,7 +226,7 @@ EXTRA_SETUP(){
     r += hm2_allocate_bspi_tram(name);
 
     // Tell the bspi driver which function to call
-    r += hm2_bspi_set_read_function(name, &read, __comp_inst);
+    r += hm2_bspi_set_read_function(name, (int (*)(void *))&read, __comp_inst);
 
     // no separate write function in this example, but it would be:
     // r += hm2_bspi_set_write_function(name, &write, __comp_inst);

--- a/src/hal/utils/Submakefile
+++ b/src/hal/utils/Submakefile
@@ -16,7 +16,7 @@ $(call TOOBJSDEPS, hal/utils/halsh.c) : EXTRAFLAGS += $(TCL_CFLAGS)
 	../lib/libmtalk.so.0 \
 	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
-	$(Q)$(CC) $(LDFLAGS) -shared $^  $(TCL_LIBS) -o $@
+	$(Q)$(CC) $(LDFLAGS) -shared $^  -o $@
 TARGETS += ../tcl/hal.so
 
 $(call TOOBJSDEPS, $(HALCMDCCSRCS)) : EXTRAFLAGS =  \

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -1975,58 +1975,58 @@ static int print_comp_entry(hal_object_ptr o, foreach_args_t *args)
 
     if (match(args->user_ptr1, ho_name(comp))) {
 
-	halcmd_output(" %5d  %-4s %c%c%c%c  %4d %-*s",
-		      ho_id(comp),
-		      type_name(comp),
-		      has_ctor ? 'c': ' ',
-		      has_dtor ? 'd': ' ',
-		      is_hallib ? 'i': ' ',
-		      ' ',
-		      inst_count(0, comp),
-		      HAL_NAME_LEN,
-		      ho_name(comp));
+        halcmd_output(" %5d  %-4s %c%c%c%c  %4d %-*s",
+                      ho_id(comp),
+                      type_name(comp),
+                      has_ctor ? 'c': ' ',
+                      has_dtor ? 'd': ' ',
+                      is_hallib ? 'i': ' ',
+                      ' ',
+                      inst_count(0, comp),
+                      HAL_NAME_LEN,
+                      ho_name(comp));
 
-	switch (comp->type) {
-	case TYPE_USER:
-	case TYPE_HALLIB:
+        switch (comp->type) {
+            case TYPE_USER:
+            case TYPE_HALLIB:
 
-	    halcmd_output(" %-5d %s", comp->pid,
-			  state_name(comp->state));
-	    break;
+                halcmd_output(" %-5d %s", comp->pid,
+                              state_name(comp->state));
+                break;
 
-	case TYPE_RT:
-	    halcmd_output(" RT    %s",
-			  state_name(comp->state));
-	    break;
+            case TYPE_RT:
+                halcmd_output(" RT    %s",
+                              state_name(comp->state));
+                break;
 
-	case TYPE_REMOTE:
-	    halcmd_output(" %-5d %s", comp->pid,
-			  state_name(comp->state));
-	    time_t now = time(NULL);
-	    if (comp->last_update) {
+            case TYPE_REMOTE:
+                halcmd_output(" %-5d %s", comp->pid,
+                              state_name(comp->state));
+                time_t now = time(NULL);
+                if (comp->last_update) {
 
-		halcmd_output(", update:-%ld",-(comp->last_update-now));
-	    } else
-		halcmd_output(", update:never");
+                    halcmd_output(", update:-%ld",-(comp->last_update-now));
+                } else
+                    halcmd_output(", update:never");
 
-	    if (comp->last_bound) {
+                if (comp->last_bound) {
 
-		halcmd_output(", bound:%lds",comp->last_bound-now);
-	    } else
-		halcmd_output(", bound:never");
-	    if (comp->last_unbound) {
-		time_t now = time(NULL);
+                    halcmd_output(", bound:%lds",comp->last_bound-now);
+                } else
+                    halcmd_output(", bound:never");
+                if (comp->last_unbound) {
+                    time_t now = time(NULL);
 
-		halcmd_output(", unbound:%lds", comp->last_unbound-now);
-	    } else
-		halcmd_output(", unbound:never");
-		halcmd_output(", u1:%d u2:%d", comp->userarg1, comp->userarg2);
-	    break;
-	default:
-	    halcmd_output(" %-5s %s", "", state_name(comp->state));
-	}
-	halcmd_output(", u1:%d u2:%d", comp->userarg1, comp->userarg2);
-	halcmd_output("\n");
+                    halcmd_output(", unbound:%lds", comp->last_unbound-now);
+                } else
+                    halcmd_output(", unbound:never");
+                halcmd_output(", u1:%d u2:%d", comp->userarg1, comp->userarg2);
+                break;
+            default:
+                halcmd_output(" %-5s %s", "", state_name(comp->state));
+        }
+        halcmd_output(", u1:%d u2:%d", comp->userarg1, comp->userarg2);
+        halcmd_output("\n");
     }
     return 0;
 }

--- a/src/libnml/inifile/inifile.cc
+++ b/src/libnml/inifile/inifile.cc
@@ -18,6 +18,9 @@
 #include <string.h>             /* strstr() */
 #include <ctype.h>              /* isspace() */
 #include <fcntl.h>
+#include <set>			/* std::set */
+#include <string>		/* std::string */
+#include <stdexcept>		/* invalid_argument() */
 
 
 #include "config.h"
@@ -671,4 +674,23 @@ iniFindDouble(FILE *fp, const char *tag, const char *section, double *result)
 {
     IniFile f(false, fp);
     return(f.Find(result, tag, section));
+}
+
+
+static std::set<std::string>  stringtable;
+
+const char *strstore(const char *s)
+{
+    using namespace std;
+
+    if (s == NULL)
+        throw invalid_argument("strstore(): NULL argument");
+
+    std::set<std::string>::iterator it = stringtable.find(s);
+    if (it == stringtable.end()) {
+	std::string *p = new std::string(s);
+	stringtable.insert(*p);
+	return p->c_str();
+    }
+    return (*it).c_str();
 }

--- a/src/libnml/inifile/inifile.h
+++ b/src/libnml/inifile/inifile.h
@@ -31,6 +31,9 @@ extern const int iniFindInt(FILE *fp, const char *tag, const char *section, int 
 extern const int iniFindDouble(FILE *fp, const char *tag, const char *section, double *result);
 extern int TildeExpansion(const char *file, char *path, size_t size);
 
+// string table - to get rid of strdup/free
+extern const char *strstore(const char *s);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libnml/posemath/_posemath.c
+++ b/src/libnml/posemath/_posemath.c
@@ -8,10 +8,10 @@
 * Author:
 * License: LGPL Version 2
 * System: Linux
-*    
+*
 * Copyright (c) 2004 All rights reserved.
 *
-* Last change: 
+* Last change:
 ********************************************************************/
 
 #if defined(PM_PRINT_ERROR) && defined(rtai)
@@ -432,7 +432,7 @@ int pmMatRotConvert(PmRotationMatrix const * const m, PmRotationVector * const r
 
 int pmMatQuatConvert(PmRotationMatrix const * const m, PmQuaternion * const q)
 {
-    /* 
+    /*
        from Stephe's "space" book e1 = (c32 - c23) / 4*e4 e2 = (c13 - c31) /
        4*e4 e3 = (c21 - c12) / 4*e4 e4 = sqrt(1 + c11 + c22 + c33) / 2
 
@@ -442,7 +442,7 @@ int pmMatQuatConvert(PmRotationMatrix const * const m, PmQuaternion * const q)
        180* rotation then (0 x y z) = (0 -x -y -z). Thus some generallities
        can be used: 1) find which of e1, e2, or e3 has the largest magnitude
        and leave it pos. 2) if e1 is largest then if c21 < 0 then take the
-       negative for e2 if c31 < 0 then take the negative for e3 3) else if e2 
+       negative for e2 if c31 < 0 then take the negative for e3 3) else if e2
        is largest then if c21 < 0 then take the negative for e1 if c32 < 0
        then take the negative for e3 4) else if e3 is larget then if c31 < 0
        then take the negative for e1 if c32 < 0 then take the negative for e2
@@ -523,14 +523,14 @@ int pmMatZyxConvert(PmRotationMatrix const * const m, PmEulerZyx * const zyx)
 {
     zyx->y = rtapi_atan2(-m->x.z, pmSqrt(pmSq(m->x.x) + pmSq(m->x.y)));
 
-    if (fabs(zyx->y - PM_PI_2) < ZYX_Y_FUZZ) {
+    if (rtapi_fabs(zyx->y - PM_PI_2) < ZYX_Y_FUZZ) {
 	zyx->z = 0.0;
 	zyx->y = PM_PI_2;	/* force it */
-	zyx->x = atan2(m->y.x, m->y.y);
-    } else if (fabs(zyx->y + PM_PI_2) < ZYX_Y_FUZZ) {
+	zyx->x = rtapi_atan2(m->y.x, m->y.y);
+    } else if (rtapi_fabs(zyx->y + PM_PI_2) < ZYX_Y_FUZZ) {
 	zyx->z = 0.0;
 	zyx->y = -PM_PI_2;	/* force it */
-	zyx->x = -atan2(m->y.z, m->y.y);
+	zyx->x = -rtapi_atan2(m->y.z, m->y.y);
     } else {
 	zyx->z = rtapi_atan2(m->x.y, m->x.x);
 	zyx->x = rtapi_atan2(m->y.z, m->z.z);
@@ -543,12 +543,12 @@ int pmMatRpyConvert(PmRotationMatrix const * const m, PmRpy * const rpy)
 {
     rpy->p = rtapi_atan2(-m->x.z, pmSqrt(pmSq(m->x.x) + pmSq(m->x.y)));
 
-    if (fabs(rpy->p - PM_PI_2) < RPY_P_FUZZ) {
-	rpy->r = atan2(m->y.x, m->y.y);
+    if (rtapi_fabs(rpy->p - PM_PI_2) < RPY_P_FUZZ) {
+	rpy->r = rtapi_atan2(m->y.x, m->y.y);
 	rpy->p = PM_PI_2;	/* force it */
 	rpy->y = 0.0;
-    } else if (fabs(rpy->p + PM_PI_2) < RPY_P_FUZZ) {
-	rpy->r = -atan2(m->y.x, m->y.y);
+    } else if (rtapi_fabs(rpy->p + PM_PI_2) < RPY_P_FUZZ) {
+	rpy->r = -rtapi_atan2(m->y.x, m->y.y);
 	rpy->p = -PM_PI_2;	/* force it */
 	rpy->y = 0.0;
     } else {
@@ -1017,7 +1017,7 @@ int pmCartUnitEq(PmCartesian * const v)
 }
 
 /*! \todo This is if 0'd out so we can find all the pmCartNorm calls that should
- be renamed pmCartUnit. 
+ be renamed pmCartUnit.
  Later we'll put this back. */
 #if 0
 
@@ -1043,7 +1043,7 @@ int pmCartCartProj(PmCartesian const * const v1, PmCartesian const * const v2, P
     int r3=1;
     double d12;
     double d22;
-    
+
     r1 = pmCartCartDot(v1, v2, &d12);
     r2 = pmCartCartDot(v2, v2, &d22);
     if (!(r1 || r1)){
@@ -1760,7 +1760,7 @@ int pmCircleInit(PmCircle * const circle,
     pmCartCartAdd(&v, center, &circle->center);
 
     /* normalize and redirect normal vector based on turns. If turn is less
-       than 0, point normal vector in other direction and make turn positive, 
+       than 0, point normal vector in other direction and make turn positive,
        -1 -> 0, -2 -> 1, etc. */
     pmCartUnit(normal, &circle->normal);
     if (turn < 0) {
@@ -1930,7 +1930,7 @@ int pmCircleStretch(PmCircle * const circ, double new_angle, int from_end)
         pmCartCartSub(&new_start, &circ->center, &circ->rTan);
         pmCartCartCross(&circ->normal, &circ->rTan, &circ->rPerp);
         pmCartMag(&circ->rTan, &circ->radius);
-    } 
+    }
     //Reduce the spiral proportionally
     circ->spiral *= (new_angle / circ->angle);
     // Easy to grow / shrink from start

--- a/src/machinetalk/Submakefile
+++ b/src/machinetalk/Submakefile
@@ -324,7 +324,8 @@ $(PROTOCXXLIB).0: $(patsubst %.cc,objects/%.o,$(PROTO_CXX_SRCS))
 	$(ECHO) Linking $(notdir $@)
 	@mkdir -p ../lib
 	@rm -f $@
-	$(Q)$(CXX) $(LDFLAGS) -Wl,-soname,$(notdir $@) -shared -o $@ $^
+	$(Q)$(CXX) $(LDFLAGS) -Wl,-soname,$(notdir $@) -shared -o $@ $^ \
+		$(PROTOBUF_LIBS)
 
 # protoc generated headers are exported to ../include
 ../include/%.h: ./$(NAMESPACEDIR)/$(PBGEN)/%.h

--- a/src/machinetalk/support/unionread.c
+++ b/src/machinetalk/support/unionread.c
@@ -57,7 +57,7 @@ bool print_container(pb_istream_t *stream)
     if (!pb_decode_varint(stream, &length)) {
 	printf("Parsing field#2 failed: %s\n", PB_GET_ERROR(stream));
     }
-    printf("submessage length=%llu\n", length);
+    printf("submessage length=%lu\n", length);
 
     printf("submessage: %s NML; %s Motion\n",
 	   is_NML_container(tag) ? "is" : "not",

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -252,7 +252,7 @@ $(call TOOBJSDEPS, rtapi/$(threads)/rtapi_app.cc): EXTRAFLAGS = \
 	    $(RTAPI_APP_RPATH) \
 	    -o $@ \
 	    $^ \
-	    $(LDFLAGS) $(RT_LDFLAGS) \
+	    $(LDFLAGS) \
 	    $(PROTOBUF_LIBS) $(CZMQ_LIBS) $(LTTNG_UST_LIBS) \
 	    -lstdc++ -ldl -luuid
 

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -85,7 +85,7 @@ ULAPISO := ../rtlib/ulapi-$(threads).so
 
 $(ULAPISO): ../lib/liblinuxcnchal.so ../lib/liblinuxcncshm.so \
 		$(call TOOBJS, $(ULAPI_SRCS))
-	$(ECHO) Creating shared object $@
+	$(ECHO) Creating shared object $(notdir $@)
 	@mkdir -p ../rtlib
 	@rm -f $@
 	$(Q)$(CC) $(LDFLAGS)  -Wl,-soname,$(notdir $@) -shared \

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -110,7 +110,8 @@ ULAPI_AUTOLOAD_SRCS := \
 	rtapi/ulapi_autoload.c \
 	rtapi/rtapi_compat.c \
 	rtapi/rtapi_hexdump.c \
-	rtapi/rtapi_support.c
+	rtapi/rtapi_support.c \
+	machinetalk/lib/syslog_async.c
 
 USERSRCS += $(ULAPI_AUTOLOAD_SRCS)
 

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -356,7 +356,7 @@ RTAPI_MSGD_CFLAGS := \
 
 RTAPI_MSGD_LDFLAGS := \
 	$(PROTOBUF_LIBS) $(CZMQ_LIBS) $(AVAHI_LIBS) \
-	-lstdc++ -ldl -lz -luuid
+	-lstdc++ -ldl -luuid
 
 #	$(LIBBACKTRACE) # already linked into libmtalk
 

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -253,7 +253,7 @@ $(call TOOBJSDEPS, rtapi/$(threads)/rtapi_app.cc): EXTRAFLAGS = \
 	    -o $@ \
 	    $^ \
 	    $(LDFLAGS) $(RT_LDFLAGS) \
-	    $(PROTOBUF_LIBS) $(CZMQ_LIBS) $(AVAHI_LIBS) $(LTTNG_UST_LIBS) \
+	    $(PROTOBUF_LIBS) $(CZMQ_LIBS) $(LTTNG_UST_LIBS) \
 	    -lstdc++ -ldl -luuid
 
 #	$(LIBBACKTRACE) # already linked into libmtalk

--- a/src/rtapi/rtapi_pci.c
+++ b/src/rtapi/rtapi_pci.c
@@ -133,7 +133,7 @@ struct rtapi_pcidev * rtapi_pci_get_device(__u16 vendor, __u16 device,
 {
 	int err;
 	DIR *dir;
-	struct dirent dirent_buf, *dirent;
+	struct dirent *dirent;
 	ssize_t res;
 	char buf[256], path[256];
 	struct rtapi_pcidev *dev = NULL;
@@ -184,14 +184,17 @@ rtapi_print_msg(RTAPI_MSG_ERR,
 	while (1) {
 		unsigned int tmp;
 
-		err = readdir_r(dir, &dirent_buf, &dirent);
-		if (err) {
+		dirent = readdir(dir);
+                if (dirent==NULL) {
+                    if (errno) {
 			rtapi_print_msg(RTAPI_MSG_ERR,
 					"Failed to read UIO-pci-generic sysfs directory. (%s)\n",
 					strerror(errno));
 			closedir(dir);
 			goto error;
-		}
+                    } else // end of directory
+                        break;
+                }
 		if (from && !found_start) {
 			if (strcmp(dirent->d_name, from->busid) == 0) {
 				/* Found the start entry. */
@@ -251,14 +254,17 @@ rtapi_print_msg(RTAPI_MSG_ERR,
 	while (1) {
 		unsigned int tmp;
 
-		err = readdir_r(dir, &dirent_buf, &dirent);
-		if (err) {
+		dirent = readdir(dir);
+                if (dirent==NULL) {
+                    if (errno) {
 			rtapi_print_msg(RTAPI_MSG_ERR,
 					"Failed to read UIO directory. (%s)\n",
 					strerror(errno));
 			closedir(dir);
 			goto error;
-		}
+                    } else // end of directory
+                        break;
+                }
 		res = sscanf(dirent->d_name, "uio%u", &tmp);
 		if (res != 1)
 			continue;


### PR DESCRIPTION
This silences almost all compiler warnings not related to `const` that I'm seeing while building rt-preempt threads in Stretch.  It also streamlines a few bits of the `make` output.

A few commits are thanks to @jepler, committed over at the LCNC repo.  A few more are from machinekit/machinekit#327, unmerged from several years ago.

One warning:  I'm not sure how to test the changes in `src/rtapi/rtapi_pci.c`, since I'm assuming the regression tests don't cover that code, and I don't have any PCI cards.

See machinekit/machinekit-cnc#45