### PR TITLE
Mk pr compiler warnings 2018 10 10

### DIFF
--- a/src/hal/components/encoder_ratiov2.c
+++ b/src/hal/components/encoder_ratiov2.c
@@ -199,7 +199,7 @@ static int export_encoder_pair(const char *name, const int inst_id,
 			       encoder_pair_t * addr);
 static int sample(void *arg, const hal_funct_args_t *fa);
 static int update(void *arg, const hal_funct_args_t *fa);
-static int instantiate_encoder_pair(const int argc, const char**argv);
+static int instantiate_encoder_pair(const int argc, char* const *argv);
 static int delete_encoder_pair(const char *name, void *inst, const int inst_size);
 
 /***********************************************************************
@@ -250,7 +250,7 @@ void rtapi_app_exit(void)
     hal_exit(comp_id);
 }
 
-static int instantiate_encoder_pair(const int argc, const char**argv)
+static int instantiate_encoder_pair(const int argc, char* const *argv)
 {
     encoder_pair_t *p;
     int retval;

--- a/src/hal/components/encoderv2.c
+++ b/src/hal/components/encoderv2.c
@@ -203,7 +203,7 @@ static const char *prefix = "encoderv2";
 static int export_encoder(const char *name, const int inst_id, counter_t *p);
 static int update(void *arg, const hal_funct_args_t *fa);
 static int capture(void *arg, const hal_funct_args_t *fa);
-static int instantiate_encoder(const int argc, const char**argv);
+static int instantiate_encoder(const int argc, char* const *argv);
 static int delete_encoder(const char *name, void *inst, const int inst_size);
 
 /***********************************************************************
@@ -252,7 +252,7 @@ void rtapi_app_exit(void)
     hal_exit(comp_id);
 }
 
-static int instantiate_encoder(const int argc, const char**argv)
+static int instantiate_encoder(const int argc, char* const *argv)
 {
     counter_t *p;
     int retval;

--- a/src/hal/components/pwmgenv2.c
+++ b/src/hal/components/pwmgenv2.c
@@ -187,7 +187,7 @@ static int export_pwmgen(const char *name, const int inst_id,
 			 pwmgen_t * addr, const int output_type);
 static int make_pulses(void *arg, const hal_funct_args_t *fa);
 static int update(void *arg, const hal_funct_args_t *fa);
-static int instantiate_pwmgen(const int argc, const char**argv);
+static int instantiate_pwmgen(const int argc, char* const *argv);
 static int delete_pwmgen(const char *name, void *inst, const int inst_size);
 
 /***********************************************************************
@@ -236,7 +236,7 @@ void rtapi_app_exit(void)
     hal_exit(comp_id);
 }
 
-static int instantiate_pwmgen(const int argc, const char**argv)
+static int instantiate_pwmgen(const int argc, char* const *argv)
 {
     pwmgen_t *p;
     int retval;

--- a/src/hal/components/rtfault.comp
+++ b/src/hal/components/rtfault.comp
@@ -13,6 +13,7 @@ license "GPL";
 #include "rtapi.h"
 #if defined(BUILD_SYS_USER_DSO)
 #include <time.h>
+#include <stdio.h>
 #endif
 #include <stdbool.h>
 static bool previous_fault;

--- a/src/hal/components/stepgenv2.c
+++ b/src/hal/components/stepgenv2.c
@@ -504,7 +504,7 @@ static int update_freq(void *arg, const hal_funct_args_t *fa);
 static int update_pos(void *arg,  const hal_funct_args_t *fa);
 static int setup_user_step_type(void);
 static CONTROL parse_ctrl_type(const char *ctrl);
-static int instantiate_stepgen( const int argc, const char**argv);
+static int instantiate_stepgen( const int argc, char* const *argv);
 static int delete_stepgen(const char *name, void *inst, const int inst_size);
 
 
@@ -579,7 +579,7 @@ int rtapi_app_main(void)
     return 0;
 }
 
-static int instantiate_stepgen(const int argc, const char**argv)
+static int instantiate_stepgen(const int argc, char* const *argv)
 {
     int retval;
     const char* name;

--- a/src/hal/cython/machinekit/hal_component.pyx
+++ b/src/hal/cython/machinekit/hal_component.pyx
@@ -168,7 +168,7 @@ cdef class Component(HALObject):
 # fail changed() if not one of the above
 cdef int comp_callback(const int phase,
                        const hal_compiled_comp_t * cc,
-                       const hal_pin_t *p,
+                       hal_pin_t *p,
                        const hal_data_u *value,
                        void *userdata):
     arg =  <object>userdata

--- a/src/hal/cython/machinekit/hal_util.pxd
+++ b/src/hal/cython/machinekit/hal_util.pxd
@@ -24,7 +24,7 @@ cdef inline int shmoff(char *ptr):
     return ptr - hal_shmem_base
 
 
-cdef inline pypin_value(const hal_pin_t *pin):
+cdef inline pypin_value(hal_pin_t *pin):
     return hal2py(pin_type(pin), pin_value(pin))
 
 

--- a/src/hal/i_components/Submakefile
+++ b/src/hal/i_components/Submakefile
@@ -129,7 +129,7 @@ hal/i_components/conv_float_s64.icomp: hal/i_components/conv.icomp.in hal/i_comp
     
 hal/i_components/conv_float_u64.icomp: hal/i_components/conv.icomp.in hal/i_components/mkconv.sh $(HALCOMP_SUBMAKEFILE)
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/i_components/mkconv.sh float u64 "" 0 18446744073709551615 < $< > $@
+	$(Q)sh hal/i_components/mkconv.sh float u64 "" 0 18446744073709551615UL < $< > $@
     
 hal/i_components/conv_bit_s64.icomp: hal/i_components/conv.icomp.in hal/i_components/mkconv.sh $(HALCOMP_SUBMAKEFILE)
 	$(ECHO) converting conv for $(notdir $@)

--- a/src/hal/icomp-example/icomp.c
+++ b/src/hal/icomp-example/icomp.c
@@ -97,7 +97,7 @@ static int export_halobjs(struct inst_data *ip, int owner_id, const char *name)
 }
 
 // constructor - init all HAL pins, params, funct etc here
-static int instantiate(const int argc, const char**argv)
+static int instantiate(const int argc, char* const *argv)
 {
     // argv[0]: component name
     const char *name = argv[1]; // instance name
@@ -130,6 +130,7 @@ static int instantiate(const int argc, const char**argv)
     };
     int c;
     while ((c = getopt_long(argc, argv, ":f:", longopts, NULL)) != -1) {
+        // char * const argv[]
 	switch (c) {
 	case 'f':
 	    myfile = optarg;

--- a/src/hal/icomp-example/lutn-demo.c
+++ b/src/hal/icomp-example/lutn-demo.c
@@ -76,7 +76,7 @@ static int lutn(void *arg, const hal_funct_args_t *fa)
 }
 
 static int instantiate_lutn(const int argc,
-			    const char**argv)
+			    char* const *argv)
 {
     const char *name = argv[1];
     struct inst_data *ip;

--- a/src/hal/lib/hal.h
+++ b/src/hal/lib/hal.h
@@ -293,7 +293,7 @@ typedef enum {
 // no instparms are applied as all arguments follow the '--' separator
 // argv = [foo, bar, instparm1=123, instparm2=3.14, --foo, --bar, baz, key=value]
 // argc = 8
-typedef int (*hal_constructor_t) (const int argc, const char**argv);
+typedef int (*hal_constructor_t) (const int argc, char* const *argv);
 typedef int (*hal_destructor_t) (const char *name, void *inst, const int inst_size);
 
 // generic base function
@@ -1149,7 +1149,8 @@ static inline int hal_unreference_vtable(int vtable_id)
 // if the return value < 0, this signifies a HAL library error code.
 // if the return value is 0, and ureturn is not NULL,
 // the usrfunct's return value is stored in *ureturn.
-int hal_call_usrfunct(const char *name, const int argc, const char **argv, int *ureturn);
+int hal_call_usrfunct(const char *name, const int argc,
+                      char * const *argv, int *ureturn);
 
 // public instance API:
 

--- a/src/hal/lib/hal_comp.c
+++ b/src/hal/lib/hal_comp.c
@@ -477,7 +477,7 @@ int free_comp_struct(hal_comp_t * comp)
 static int create_instance(const hal_funct_args_t *fa)
 {
     const int argc = fa_argc(fa);
-    const char **argv = fa_argv(fa);
+    char * const *argv = fa_argv(fa);
 
 #if 0
     HALDBG("'%s' called, arg=%p argc=%d",
@@ -510,7 +510,7 @@ static int create_instance(const hal_funct_args_t *fa)
 static int delete_instance(const hal_funct_args_t *fa)
 {
     const int argc = fa_argc(fa);
-    const char **argv = fa_argv(fa);
+    char * const *argv = fa_argv(fa);
 
     HALDBG("'%s' called, arg=%p argc=%d",
 	   fa_funct_name(fa), fa_arg(fa), argc);

--- a/src/hal/lib/hal_funct.c
+++ b/src/hal/lib/hal_funct.c
@@ -145,7 +145,8 @@ static int halg_export_xfunctfv(const int use_hal_mutex,
 }
 #endif // RTAPI
 
-int hal_call_usrfunct(const char *name, const int argc, const char **argv, int *ureturn)
+int hal_call_usrfunct(const char *name, const int argc, char * const *argv,
+                      int *ureturn)
 {
     hal_funct_t *funct;
     int i;

--- a/src/hal/lib/hal_internal.h
+++ b/src/hal/lib/hal_internal.h
@@ -74,7 +74,7 @@ int halg_free_argv(const bool use_hal_mutex,
 		    char **argv);
 char **halg_dupargv(const bool use_hal_mutex,
 		     const int argc,
-		     const char **argv);
+		     char * const *argv);
 
 RTAPI_END_DECLS
 

--- a/src/hal/lib/hal_memory.c
+++ b/src/hal/lib/hal_memory.c
@@ -218,7 +218,7 @@ int halg_free_single_str(char *s)
 
 char **halg_dupargv(const bool use_hal_mutex,
 		    const int argc,
-		    const char **argv)
+		    char * const *argv)
 {
     int i;
     if (argc > MAX_ARGC)

--- a/src/hal/lib/hal_object_selectors.c
+++ b/src/hal/lib/hal_object_selectors.c
@@ -20,7 +20,7 @@ int yield_match(hal_object_ptr o, foreach_args_t *args)
 
 int yield_name(hal_object_ptr o, foreach_args_t *args)
 {
-    args->user_ptr1 = hh_get_name(o.hdr);
+    args->user_ptr1 = (void *)hh_get_name(o.hdr);
     return 1;  // terminate visit on first match
 }
 

--- a/src/hal/lib/hal_priv.h
+++ b/src/hal/lib/hal_priv.h
@@ -539,7 +539,7 @@ typedef struct hal_funct_args {
 
     // argument vector for FS_USERLAND; 0/NULL for others
     int argc;
-    const char **argv;
+    char * const *argv;
 } hal_funct_args_t ;
 
 // signatures
@@ -659,7 +659,8 @@ static inline const char* fa_funct_name(const hal_funct_args_t *fa)
 }
 
 static inline const int fa_argc(const hal_funct_args_t *fa) { return fa->argc; }
-static inline const char** fa_argv(const hal_funct_args_t *fa) { return fa->argv; }
+static inline char* const * fa_argv(
+    const hal_funct_args_t *fa) { return fa->argv; }
 static inline const void * fa_arg(const hal_funct_args_t *fa) { return fa->funct->arg; }
 
 
@@ -855,7 +856,8 @@ void report_memory_usage(void);
 
 char *halg_strdup(const int use_hal_mutex, const char *paramptr);
 int halg_free_str(char **s);  // will set *s to NULL
-char **halg_dupargv(const bool use_hal_mutex, const int argc, const char **argv);
+char **halg_dupargv(const bool use_hal_mutex, const int argc,
+                    char * const *argv);
 int halg_free_argv(const bool use_hal_mutex, char **argv);
 int halg_free_single_str(char *s);
 

--- a/src/hal/lib/hal_priv.h
+++ b/src/hal/lib/hal_priv.h
@@ -380,7 +380,7 @@ static inline hal_data_u *sig_value(hal_sig_t *sig) {
     return &sig->value;
 }
 
-static inline const hal_data_u *param_value(const hal_param_t *param)
+static inline hal_data_u *param_value(const hal_param_t *param)
 {
     return (hal_data_u *)SHMPTR(param->data_ptr);
 }

--- a/src/hal/lib/hal_rcomp.c
+++ b/src/hal/lib/hal_rcomp.c
@@ -301,7 +301,7 @@ int hal_ccomp_report(hal_compiled_comp_t *cc,
 
     for (i = 0; i < cc->n_pins; i++) {
 	if (report_all || RTAPI_BIT_TEST(cc->changed, i)) {
-	    const hal_pin_t *pin = cc->pin[i];
+	    hal_pin_t *pin = cc->pin[i];
 	    // XXX this is not a good API
 	    // drop the fourth argument and pass only the pin
 	    // to force accessor use in the report callback

--- a/src/hal/lib/hal_rcomp.h
+++ b/src/hal/lib/hal_rcomp.h
@@ -11,7 +11,7 @@ typedef struct {
     int magic;
     hal_comp_t *comp;
     int n_pins;
-    const hal_pin_t  **pin;
+    hal_pin_t  **pin;
     unsigned long *changed;      // bitmap
     hal_data_u    *tracking;     // tracking values of monitored pins
     void *user_data;             // uninterpreted by HAL code
@@ -35,7 +35,7 @@ typedef enum {
 
 typedef int(*comp_report_callback_t)(const int phase,
 				     const hal_compiled_comp_t *cc,
-				     const hal_pin_t  *pin,
+				     hal_pin_t  *pin,
 				     const hal_data_u *value,
 				     void *cb_data);
 

--- a/src/hal/user_icomps/watch.c
+++ b/src/hal/user_icomps/watch.c
@@ -158,9 +158,10 @@ static int maxpins __attribute__((unused)) = 1;
 
 static int watch_(void *arg, const hal_funct_args_t *fa);
 
-static int instantiate(const int argc, const char**argv);
+static int instantiate(const int argc, char* const *argv);
 
-static int extra_inst_setup(struct inst_data* ip, const char *name, int argc, const char**argv);
+static int extra_inst_setup(struct inst_data* ip, const char *name, int argc,
+                            char* const *argv);
 
 // var to take pin names passed to newinst
 char target_pin_name[HAL_NAME_LEN];
@@ -168,7 +169,8 @@ char preset_name[HAL_NAME_LEN];
 int preset_type;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static int export_halobjs(struct inst_data *ip, int owner_id, const char *name, const int argc, const char **argv)
+static int export_halobjs(struct inst_data *ip, int owner_id, const char *name,
+                          const int argc, char * const *argv)
 {
 char buf[HAL_NAME_LEN + 1];
 int r = 0;
@@ -232,7 +234,7 @@ int r = 0;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static int instantiate(const int argc, const char**argv)
+static int instantiate(const int argc, char* const *argv)
 {
 struct inst_data *ip;
 // argv[0]: component name argv[1]: instance
@@ -640,7 +642,8 @@ static hal_bit_t latched = 0, triggered = 0;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static int extra_inst_setup(struct inst_data *ip, const char *name, int argc, const char**argv)
+static int extra_inst_setup(struct inst_data *ip, const char *name,
+                            int argc, char* const *argv)
 {
 int x;
 

--- a/src/hal/user_icomps/watch.c
+++ b/src/hal/user_icomps/watch.c
@@ -419,8 +419,6 @@ int retval = 0;
 double fval;
 long lval;
 unsigned long ulval;
-unsigned long long ullval;
-long long llval;
 char *cp = value;
 
     switch (type) {
@@ -569,12 +567,11 @@ static int watch_(void *arg, const hal_funct_args_t *fa)
 long period __attribute__((unused)) = fa_period(fa);
 struct inst_data *ip __attribute__((unused)) = arg;
 
-hal_s32_t n;
 hal_float_t valuel = 0.0;
 char value[16];
 static int counter = 0;
 static hal_float_t valuef = 0.0;
-static hal_bit_t latched = 0, triggered = 0;
+static hal_bit_t latched = 0;
 
     if(*(ip->_reset))
 	{

--- a/src/hal/userfunct-example/ufdemo.c
+++ b/src/hal/userfunct-example/ufdemo.c
@@ -51,7 +51,7 @@ static int xthread_funct(void *arg, const hal_funct_args_t *fa)
 static int usrfunct_demo(const hal_funct_args_t *fa)
 {
     const int argc = fa_argc(fa);
-    const char **argv = fa_argv(fa);
+    char * const *argv = fa_argv(fa);
 
     rtapi_print_msg(RTAPI_MSG_INFO, "%s: userfunct '%s' called, arg='%s' argc=%d\n",
 		    compname,  fa_funct_name(fa), (const char *)fa_arg(fa), argc);

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -647,11 +647,13 @@ def prologue(f):
             print >>f, "static int %s(void *arg, const hal_funct_args_t *fa);\n" % to_c(name)
         names[name] = 1
 
-    print >>f, "static int instantiate(const int argc, const char**argv);\n"
+    print >>f, "static int instantiate(const int argc, char* const *argv);\n"
     # we always have a delete function now - to free local_argv
     print >>f, "static int delete(const char *name, void *inst, const int inst_size);\n"
     if options.get("extra_inst_setup") :
-        print >>f, "static int extra_inst_setup(struct inst_data* ip, const char *name, int argc, const char**argv);\n"
+        print >>f, "static int extra_inst_setup(\n" \
+            "struct inst_data* ip, const char *name, int argc,\n" \
+            "char* const *argv);\n"
     if options.get("extra_inst_cleanup"):
         print >>f, "static void extra_inst_cleanup(const char *name, void *inst, const int inst_size);\n"
 
@@ -684,7 +686,9 @@ def prologue(f):
 #
 ###########################  export_halobjs()  ######################################################
 
-    print >>f, "static int export_halobjs(struct inst_data *ip, int owner_id, const char *name, const int argc, const char **argv)\n{"
+    print >>f, "static int export_halobjs(\n" \
+        "struct inst_data *ip, int owner_id, const char *name,\n" \
+        "const int argc, char * const *argv)\n{"
 
     print >>f, "    char buf[HAL_NAME_LEN + 1];"
     print >>f, "    int r = 0;"
@@ -823,7 +827,7 @@ def prologue(f):
 ###########################  instantiate() ###############################################################
 
     print >>f, "\n// constructor - init all HAL pins, funct etc here"
-    print >>f, "static int instantiate(const int argc, const char**argv)\n{"
+    print >>f, "static int instantiate(const int argc, char* const *argv)\n{"
     print >>f, "struct inst_data *ip;"
     print >>f, "// argv[0]: component name"
     print >>f, "const char *name = argv[1];" # instance name
@@ -970,7 +974,10 @@ def prologue(f):
         if options.get("extra_inst_setup"):
             print >>f, "// if the extra_inst_setup returns non zero it will abort the module creation"
             print >>f, "#undef EXTRA_INST_SETUP"
-            print >>f, "#define EXTRA_INST_SETUP() static int extra_inst_setup(struct inst_data *ip, const char *name, int argc, const char**argv)"
+            print >>f, "#define EXTRA_INST_SETUP() \\\n" \
+                "static int extra_inst_setup( \\\n" \
+                "struct inst_data *ip, const char *name, \\\n" \
+                "int argc, char* const *argv)"
         if options.get("extra_inst_cleanup"):
             print >>f, "#undef EXTRA_INST_CLEANUP"
             print >>f, "#define EXTRA_INST_CLEANUP() static void extra_inst_cleanup(const char *name, void *inst, const int inst_size)"

--- a/src/machinetalk/haltalk/haltalk_rcomp.cc
+++ b/src/machinetalk/haltalk/haltalk_rcomp.cc
@@ -23,14 +23,14 @@
 static int
 comp_report_cb(const int phase,
            const  hal_compiled_comp_t *cc,
-           const hal_pin_t *pin,
+           hal_pin_t *pin,
            const hal_data_u *vp,
            void *cb_data);
 
 static int
 add_pins_to_items(const int phase,
           const hal_compiled_comp_t *cc,
-          const hal_pin_t *pin,
+          hal_pin_t *pin,
           const hal_data_u *vp,
           void *cb_data);
 
@@ -286,7 +286,7 @@ int release_comps(htself_t *self)
 static int
 comp_report_cb(const int phase,
            const  hal_compiled_comp_t *cc,
-           const hal_pin_t *pin,
+           hal_pin_t *pin,
            const hal_data_u *vp,
            void *cb_data)
 {
@@ -323,7 +323,7 @@ comp_report_cb(const int phase,
 static int
 add_pins_to_items(const int phase,
           const hal_compiled_comp_t *cc,
-          const hal_pin_t *pin,
+          hal_pin_t *pin,
           const hal_data_u *vp,
           void *cb_data)
 {


### PR DESCRIPTION
This silences the compiler warnings related to `const` not addressed in PR #1410.

See machinekit/machinekit-cnc#45