### PR TITLE
Remove double printed line in event of no match L:1978 halcmd_commands.c

### DIFF
--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -2020,7 +2020,6 @@ static int print_comp_entry(hal_object_ptr o, foreach_args_t *args)
                     halcmd_output(", unbound:%lds", comp->last_unbound-now);
                 } else
                     halcmd_output(", unbound:never");
-                halcmd_output(", u1:%d u2:%d", comp->userarg1, comp->userarg2);
                 break;
             default:
                 halcmd_output(" %-5s %s", "", state_name(comp->state));


### PR DESCRIPTION
Made this change in machinekit-hal repo as part of the compiler silencing
commits, but omitted from machinekit.

The print line is executed anyway at the end of the switch() block

Signed-off-by: Mick <arceye@mgware.co.uk>