### PR TITLE
hal/hostmot2: make watchdog timeout_ns a pin

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hostmot2.c
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.c
@@ -1760,7 +1760,7 @@ void hm2_unregister(hm2_lowlevel_io_t *llio) {
         // if there's a watchdog, set it to safe the board right away
         if (hm2->watchdog.num_instances > 0) {
             hm2->watchdog.instance[0].enable = 1;
-            hm2->watchdog.instance[0].hal.param.timeout_ns = 1;
+            (*hm2->watchdog.instance[0].hal.pin.timeout_ns) = 1;
             hm2_watchdog_force_write(hm2);
         }
 

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -985,11 +985,8 @@ typedef struct {
 
         struct {
             hal_bit_t *has_bit;
+            hal_u32_t *timeout_ns;
         } pin;
-
-        struct {
-            hal_u32_t timeout_ns;
-        } param;
 
     } hal;
 

--- a/src/hal/drivers/mesa-hostmot2/watchdog.c
+++ b/src/hal/drivers/mesa-hostmot2/watchdog.c
@@ -166,16 +166,15 @@ int hm2_watchdog_parse_md(hostmot2_t *hm2, int md_index) {
         goto fail1;
     }
 
-    // params
-    r = hal_param_u32_newf(
-        HAL_RW,
-        &(hm2->watchdog.instance[0].hal.param.timeout_ns),
+    r = hal_pin_u32_newf(
+        HAL_IO,
+        &(hm2->watchdog.instance[0].hal.pin.timeout_ns),
         hm2->llio->comp_id,
         "%s.watchdog.timeout_ns",
         hm2->llio->name
     );
     if (r < 0) {
-        HM2_ERR("error adding param, aborting\n");
+        HM2_ERR("error adding pin, aborting\n");
         r = -EINVAL;
         goto fail1;
     }
@@ -207,7 +206,7 @@ int hm2_watchdog_parse_md(hostmot2_t *hm2, int md_index) {
     //
 
     *hm2->watchdog.instance[0].hal.pin.has_bit = 0;
-    hm2->watchdog.instance[0].hal.param.timeout_ns = 5 * 1000 * 1000;  // default timeout is 5 milliseconds
+    *hm2->watchdog.instance[0].hal.pin.timeout_ns = 5 * 1000 * 1000;  // default timeout is 5 milliseconds
     hm2->watchdog.instance[0].enable = 0;  // the first pet_watchdog will turn it on
 
     return hm2->watchdog.num_instances;
@@ -232,7 +231,7 @@ void hm2_watchdog_print_module(hostmot2_t *hm2) {
     HM2_PRINT("    reset_addr: 0x%04X\n", hm2->watchdog.reset_addr);
     for (i = 0; i < hm2->watchdog.num_instances; i ++) {
         HM2_PRINT("    instance %d:\n", i);
-        HM2_PRINT("        param timeout_ns = %u\n", hm2->watchdog.instance[i].hal.param.timeout_ns);
+        HM2_PRINT("        pin timeout_ns = %u\n", (*hm2->watchdog.instance[i].hal.pin.timeout_ns));
         HM2_PRINT("        pin has_bit = %d\n", (*hm2->watchdog.instance[i].hal.pin.has_bit));
         HM2_PRINT("        reg timer = 0x%08X\n", hm2->watchdog.timer_reg[i]);
     }
@@ -268,11 +267,11 @@ void hm2_watchdog_force_write(hostmot2_t *hm2) {
          linking with gcc, but kbuild links directly with ld; instead,
          use kernel-supplied functions; in this case, replace
          __udivdi3 with do_div */
-        tmp = ((u64)hm2->watchdog.instance[0].hal.param.timeout_ns *
+        tmp = ((u64)(*hm2->watchdog.instance[0].hal.pin.timeout_ns) *
                hm2->watchdog.clock_frequency);
         do_div(tmp,(u64)(1000 * 1000 * 1000)) - 1;
 #else
-        tmp = ((u64)hm2->watchdog.instance[0].hal.param.timeout_ns *
+        tmp = ((u64)(*hm2->watchdog.instance[0].hal.pin.timeout_ns) *
 	       hm2->watchdog.clock_frequency / (1000 * 1000 * 1000)) - 1;
 #endif
         if (tmp < 0x80000000) {
@@ -281,14 +280,14 @@ void hm2_watchdog_force_write(hostmot2_t *hm2) {
             // truncate watchdog timeout
             tmp = 0x7FFFFFFF;
             hm2->watchdog.timer_reg[0] = tmp;
-            hm2->watchdog.instance[0].hal.param.timeout_ns = (tmp + 1) / ((double)hm2->watchdog.clock_frequency / (double)(1000 * 1000 * 1000));
-            HM2_ERR("requested watchdog timeout is out of range, setting it to max: %u ns\n", hm2->watchdog.instance[0].hal.param.timeout_ns);
+            *hm2->watchdog.instance[0].hal.pin.timeout_ns = (tmp + 1) / ((double)hm2->watchdog.clock_frequency / (double)(1000 * 1000 * 1000));
+            HM2_ERR("requested watchdog timeout is out of range, setting it to max: %u ns\n", (*hm2->watchdog.instance[0].hal.pin.timeout_ns));
         }
     }
 
     // set the watchdog timeout (we'll check for i/o errors later)
     hm2->llio->write(hm2->llio, hm2->watchdog.timer_addr, hm2->watchdog.timer_reg, (hm2->watchdog.num_instances * sizeof(u32)));
-    hm2->watchdog.instance[0].written_timeout_ns = hm2->watchdog.instance[0].hal.param.timeout_ns;
+    hm2->watchdog.instance[0].written_timeout_ns = (*hm2->watchdog.instance[0].hal.pin.timeout_ns);
     hm2->watchdog.instance[0].written_enable = hm2->watchdog.instance[0].enable;
 
     // clear the has-bit bit
@@ -328,7 +327,7 @@ void hm2_watchdog_write(hostmot2_t *hm2, long period_ns) {
     }
 
     if (
-        (hm2->watchdog.instance[0].hal.param.timeout_ns == hm2->watchdog.instance[0].written_timeout_ns)
+        ((*hm2->watchdog.instance[0].hal.pin.timeout_ns) == hm2->watchdog.instance[0].written_timeout_ns)
         &&
         (hm2->watchdog.instance[0].enable == hm2->watchdog.instance[0].written_enable)
     ) {
@@ -336,10 +335,10 @@ void hm2_watchdog_write(hostmot2_t *hm2, long period_ns) {
     }
 
     // if the requested timeout is dangerously short compared to the petting-period, warn the user once
-    if (hm2->watchdog.instance[0].hal.param.timeout_ns < (1.5 * period_ns)) {
+    if ((*hm2->watchdog.instance[0].hal.pin.timeout_ns) < (1.5 * period_ns)) {
         HM2_PRINT(
             "Watchdog timeout (%u ns) is dangerously short compared to hm2_write() period (%ld ns)\n",
-            hm2->watchdog.instance[0].hal.param.timeout_ns,
+            (*hm2->watchdog.instance[0].hal.pin.timeout_ns),
             period_ns
         );
     }


### PR DESCRIPTION
This patch converts the `timeout_ns` pin of the hm2 watchdog to a pin.

In the long-term, all params should be converted to pins as this makes using the new-style Python API possible and params don't provide any benefits.