### PR TITLE
Add missing index handling to the pru encoder

### DIFF
--- a/src/hal/drivers/hal_pru_generic/hal_pru_generic.h
+++ b/src/hal/drivers/hal_pru_generic/hal_pru_generic.h
@@ -258,6 +258,8 @@ typedef struct {
 
     } hal;
 
+    u8 prev_Z_count; // detect index events
+
     s32 zero_offset;  // *hal.pin.counts == (*hal.pin.rawcounts - zero_offset)
 
     u16 prev_reg_count;  // from this and the current count in the register we compute a change-in-counts, which we add to rawcounts


### PR DESCRIPTION
I made this change to my local RIP build about 2 years ago and forgot to share it, so my memory is a little hazy.
I have been using it on my lathe for both threading and rigid tapping with a 1024 P/Rev quadrature spindle encoder and it works well for me.