### PR TITLE
CI system updates

### DIFF
--- a/.travis/check_sftp.sh
+++ b/.travis/check_sftp.sh
@@ -23,7 +23,7 @@ fi
 # test conection
 FILE="${TRAVIS_REPO_SLUG//\//.}_${TRAVIS_BRANCH}_${TRAVIS_JOB_NUMBER}"
 
-cat >${TRAVIS_BUILD_DIR}/../${FILE} << EOF 
+cat >${TRAVIS_BUILD_DIR}/../${FILE} << EOF
 TRAVIS_BRANCH=${TRAVIS_BRANCH}
 TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}
 TRAVIS_BUILD_ID=${TRAVIS_BUILD_ID}
@@ -50,3 +50,5 @@ sshpass -p ${SFTP_PASSWD} sftp -P ${SFTP_PORT} -o StrictHostKeyChecking=no \
 if [ $err -ne 0 ]; then
     die "Error connecting with sftp. Exit code: ${err}"
 fi
+
+echo "Successfully configured sftp"

--- a/.travis/send_binaries.sh
+++ b/.travis/send_binaries.sh
@@ -3,18 +3,34 @@
 FILE="${TRAVIS_REPO_SLUG//\//.}_${TRAVIS_BRANCH}_${TRAVIS_JOB_NUMBER}.tgz"
 
 if [ "${CMD}" = "run_tests" ]; then
+    echo "Skipping upload on regression test run" >&2
     exit 0
 fi
 
-# skip upload on failure
-if [ "${TRAVIS_TEST_RESULT}" -eq 0 ] && [ ! -f ~/no_sftp ]; then
-    if [ -d ${ROOTFS}/${MACHINEKIT_PATH}/deploy ]; then
-        cd ${TRAVIS_BUILD_DIR}
-	tar cvzf ${FILE} -C ${ROOTFS}/${MACHINEKIT_PATH}/deploy .
-    else
-	echo "${ROOTFS}/${MACHINEKIT_PATH}/deploy is missing";
-	ls -alR ${ROOTFS}/${MACHINEKIT_PATH}/
-    fi
+if [ "${TRAVIS_TEST_RESULT}" -ne 0 ]; then
+    echo "Skipping upload on failure" >&2
+    exit 0
+fi
+
+if [ ! -f ~/no_sftp ]; then
+    echo "Skipping upload when sftp unavailable" >&2
+    exit 0
+fi
+
+if [ -z "${SFTP_PASSWD}" ]; then
+    echo "Not sending status:  sftp parameters unconfigured" >&2
+    exit 0
+fi
+
+if [ ! -d ${ROOTFS}/${MACHINEKIT_PATH}/deploy ]; then
+    echo "Skipping upload when deploy directory absent" >&2
+    exit 1
+fi
+
+
+# Tar up results and ship them out
+cd ${TRAVIS_BUILD_DIR}
+tar cvzf ${FILE} -C ${ROOTFS}/${MACHINEKIT_PATH}/deploy .
 
 cat >sftp_cmds <<EOF
 cd shared/incoming
@@ -22,7 +38,5 @@ put ${FILE}
 bye
 EOF
 
-    sshpass -p ${SFTP_PASSWD} sftp -P ${SFTP_PORT} -o StrictHostKeyChecking=no \
+sshpass -p ${SFTP_PASSWD} sftp -P ${SFTP_PORT} -o StrictHostKeyChecking=no \
         -oBatchMode=no -b sftp_cmds ${SFTP_USER}@${SFTP_ADDR}
-
-fi

--- a/.travis/send_status.sh
+++ b/.travis/send_status.sh
@@ -10,6 +10,11 @@ if [ -f ~/no_sftp ]; then
     exit 0
 fi
 
+if [ -z "${SFTP_PASSWD}" ]; then
+    echo "Not sending status:  sftp parameters unconfigured" >&2
+    exit 0
+fi
+
 FILE="${TRAVIS_REPO_SLUG//\//.}_${TRAVIS_BRANCH}_${TRAVIS_JOB_NUMBER}_"
 if [ ${TRAVIS_TEST_RESULT} ]; then
     FILE+="passed"

--- a/debian/configure
+++ b/debian/configure
@@ -43,7 +43,7 @@ do_posix() {
 do_rt-preempt() {
     cat control.rt-preempt.in >> control
     echo "debian/control:  added RT_PREEMPT threads package" >&2
-    
+
     rules_enable_threads rt-preempt
     HAVE_FLAVOR=true
 }
@@ -82,9 +82,9 @@ machinekit (${MKVERSION}) ${DISTRO_UC}; urgency=low
 
 EOF
 
-cat changelog # debug output
-cat changelog.in >> changelog
-echo "New package version number added to changelog"
+    cat changelog # debug output
+    cat changelog.in >> changelog
+    echo "New package version number added to changelog"
 }
 
 ## Create source orig tarball in format required for creation of debian tarball and .dsc file
@@ -143,9 +143,9 @@ HAVE_FLAVOR=false
 if [ "$DISTRO_CODENAME" == "stretch" ]; then
     cp control.stretch.in control
 elif [ "$DISTRO_CODENAME" == "buster" ]; then
-    cp control.buster.in control   	
+    cp control.buster.in control
 elif [ "$DISTRO_CODENAME" == "sid" ]; then
-    cp control.sid.in control   	
+    cp control.sid.in control
 else
     cp control.in control
 fi
@@ -176,4 +176,3 @@ echo "debian/control:  add final Build-Depends: list" >&2
 
 # Warn if no flavor configured
 $HAVE_FLAVOR || usage "WARNING:  No thread flavors configured"
-

--- a/debian/configure
+++ b/debian/configure
@@ -26,6 +26,11 @@ rules_enable_threads() {
     # enable thread flavors in debian/rules; e.g.
     #    THREADS_POSIX = --with-posix
     # ...unnecessary for control-only
+    if test -n "$MK_CROSS_BUILDER"; then
+        # Reduce file req'ts in mk-cross-builder
+        echo "debian/rules:  skip ${FLAVOR} config in mk-cross-builder" >&2
+        return
+    fi
     FLAVOR=$1
     FLAVOR_VAR=THREADS_$(echo $FLAVOR | tr 'a-z-' 'A-Z_')
     sed -i rules \
@@ -150,11 +155,13 @@ else
     cp control.in control
 fi
 
-echo "debian/control:  copied base template" >&2
-cp rules.in rules; chmod +x rules
-echo "debian/rules:  copied base template" >&2
-cp machinekit.install.in machinekit.install
-echo "debian/machinekit.install.in:  copied base template" >&2
+if test -z "$MK_CROSS_BUILDER"; then # Reduce file req'ts in mk-cross-builder
+    echo "debian/control:  copied base template" >&2
+    cp rules.in rules; chmod +x rules
+    echo "debian/rules:  copied base template" >&2
+    cp machinekit.install.in machinekit.install
+    echo "debian/machinekit.install.in:  copied base template" >&2
+fi
 
 # read command line options
 while getopts prxcsd?h ARG; do

--- a/debian/linuxcnc-sim.sharedmimeinfo
+++ b/debian/linuxcnc-sim.sharedmimeinfo
@@ -1,1 +1,0 @@
-linuxcnc.sharedmimeinfo

--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -98,7 +98,7 @@ export TAG
 declare -a BUILD_CL DOCKER_EXTRA_OPTS
 case $CMD in
     "shell"|"") # Interactive shell (default)
-	DOCKER_EXTRA_OPTS=( --privileged --interactive --tty )
+	DOCKER_EXTRA_OPTS=( --privileged --interactive )
 	if test -z "$*"; then
 	    BUILD_CL=( bash -i )
 	else
@@ -197,6 +197,7 @@ set -x  # Show user the command
 # hide --it
 exec docker run \
     --rm \
+    --tty \
     "${DOCKER_EXTRA_OPTS[@]}" \
     -u ${UID_GID} -e USER=${USER} \
     -v ${HOME}:${HOME} -e HOME=${HOME} \

--- a/src/Makefile
+++ b/src/Makefile
@@ -1679,7 +1679,7 @@ $(sort $(RTOBJS)) : $(OBJDIR)/%.o : %.c $(DEPDIR)/%.d
 	$(ECHO) Compiling realtime $(threads) $<
 	@rm -f $@
 	@mkdir -p $(dir $@)
-	$(Q)$(CC) -c $(OPT) $(DPKG_CFLAGS) $(DEBUG) \
+	$(Q)$(CC) -c $(OPT) $(DPKG_CFLAGS) $(DEBUG) $(CPPFLAGS) \
 	    $(EXTRA_CFLAGS) $< -o $@
 
 # Rules to make .o (object) files from .cc
@@ -1687,7 +1687,8 @@ $(sort $(CXXRTOBJS)) : $(OBJDIR)/%.o : %.cc $(DEPDIR)/%.d
 	$(ECHO) Compiling realtime++ $<
 	@rm -f $@
 	@mkdir -p $(dir $@)
-	$(Q)$(CXX) -c $(OPT) $(DEBUG) $(RT_CXXFLAGS) $(EXTRA_CFLAGS) $< -o $@
+	$(Q)$(CXX) -c $(OPT) $(DEBUG) $(RT_CXXFLAGS) $(CPPFLAGS) \
+	    $(EXTRA_CFLAGS) $< -o $@
 
 endif # end BUILD_SYS=user-dso
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -659,7 +659,7 @@ HEADERS := \
     rtapi/shmdrv/shmdrv.h
 
 
-    
+
 ## the "headers" target installs all the header files in ../include
 .PHONY: headers
 HEADERS := $(patsubst %,../include/%,$(foreach h,$(HEADERS),$(notdir $h)))

--- a/tests/pll_correction/skip
+++ b/tests/pll_correction/skip
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This test doesn't work reliably, especially on Travis CI.
+exit 1


### PR DESCRIPTION
This PR contains several patches related to the CI system and package builds.

As discussed in machinekit/machinekit-hal#150 and Dovetail-Automata/mk-cross-builder#3, the Emdebian project is defunct, and it became impossible to rebuild the Docker images to support `armhf` builds for Jessie.  @dkhughes provided the initial example I used to replace the Emdebian's cross-compile toolchain with Linaro's, and mk-cross-builder again builds images that are at least able to build the Jessie ARM packages (running them has not been tested).  A couple of patches here are related to that, and the RT `CPPFLAGS` patch is required to complete Xenomai builds (the commit log will inadequately elucidate why).

Other patches tidy up, fix unofficial Travis CI instances, disable the unreliable `pll_correction` test, and allocate a ptty to Docker containers so keyboard interrupts are passed through.