### PR TITLE
Add libmodbus version checks

### DIFF
--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -359,14 +359,26 @@ retCode get_tx_connection(const int this_mb_tx_num, int *ret_connected)
     //set response and byte timeout according to each mb_tx
     timeout.tv_sec  = this_mb_tx->mb_response_timeout_ms / 1000;
     timeout.tv_usec = (this_mb_tx->mb_response_timeout_ms % 1000) * 1000;
+#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+    modbus_set_response_timeout(this_mb_link->modbus, timeout.tv_sec, timeout.tv_usec);
+#else
     modbus_set_response_timeout(this_mb_link->modbus, &timeout);
+#endif
+    //modbus_set_response_timeout(this_mb_link->modbus, &timeout);
+
     //DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] response timeout [%d] ([%d] [%d])",
     //    this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_tx->mb_response_timeout_ms,
     //    (int) timeout.tv_sec, (int) timeout.tv_usec);
 
     timeout.tv_sec  = this_mb_tx->mb_byte_timeout_ms / 1000;
     timeout.tv_usec = (this_mb_tx->mb_byte_timeout_ms % 1000) * 1000;
+#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+    modbus_set_byte_timeout(this_mb_link->modbus, timeout.tv_sec, timeout.tv_usec);
+#else
     modbus_set_byte_timeout(this_mb_link->modbus, &timeout);
+#endif
+    //modbus_set_byte_timeout(this_mb_link->modbus, &timeout);
+
     //DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] byte timeout [%d] ([%d] [%d])",
     //    this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_tx->mb_byte_timeout_ms,
     //    (int) timeout.tv_sec, (int) timeout.tv_usec);


### PR DESCRIPTION
Courtesy of Dale Lukas Peterson <hazelnusse@gmail.com> and linuxcnc commit
https://github.com/LinuxCNC/linuxcnc/pull/106/commits/5bdebef86dce6b56ecbb122f6dde29f85afbef0f

Debian sid now includes libmodbus 3.1.4-1 which breaks existing API
Can be expected to filter down through the backports

Fixes machinekit-hal/issues/166

Signed-off-by: Mick <arceye@mgware.co.uk>