### PR TITLE
Add missing backslash to escape quote

### DIFF
--- a/src/machinetalk/videoserver/videoserver.py
+++ b/src/machinetalk/videoserver/videoserver.py
@@ -98,7 +98,7 @@ class VideoServer(threading.Thread):
             arguments = ' ' + video_device.arguments
 
         command = [
-            'mjpg_streamer -i \"{libpath}input_uvc.so -n -f {framerate} -r {resolution} -q {quality} -d {device}" '
+            'mjpg_streamer -i \"{libpath}input_uvc.so -n -f {framerate} -r {resolution} -q {quality} -d {device}\" '
             '-o \" {libpath}output_zmqserver.so --address {uri} --buffer_size {buffer_size}\"{args}'.format(
                 libpath=libpath,
                 framerate=video_device.framerate,

--- a/src/machinetalk/videoserver/videoserver.py
+++ b/src/machinetalk/videoserver/videoserver.py
@@ -98,8 +98,8 @@ class VideoServer(threading.Thread):
             arguments = ' ' + video_device.arguments
 
         command = [
-            'mjpg_streamer -i \"{libpath}input_uvc.so -n -f {framerate} -r {resolution} -q {quality} -d {device}\" '
-            '-o \" {libpath}output_zmqserver.so --address {uri} --buffer_size {buffer_size}\"{args}'.format(
+            'mjpg_streamer -i "{libpath}input_uvc.so -n -f {framerate} -r {resolution} -q {quality} -d {device}" '
+            '-o " {libpath}output_zmqserver.so --address {uri} --buffer_size {buffer_size}"{args}'.format(
                 libpath=libpath,
                 framerate=video_device.framerate,
                 resolution=video_device.resolution,


### PR DESCRIPTION
Videoserver currently fails to launch mjpg-streamer:

user.log:Dec 10 06:26:12 hevo MJPG-streamer [2303]:        dlopen:  /usr/local/lib/mjpg-streamer/output_zmqserver.so --address tcp://*:59241 --buffer_size 1: cannot open shared object file: No such file or directory