### PR TITLE
xhc-whb04b-6 component: code cleanup

### DIFF
--- a/src/hal/user_comps/xhc-whb04b-6/hal.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.cc
@@ -182,10 +182,13 @@ Hal::~Hal()
     freeSimulatedPin((void**)(&memory->out.axisBSetVelocityMode));
     freeSimulatedPin((void**)(&memory->out.axisCSetVelocityMode));
 
-    freeSimulatedPin((void**)(&memory->out.feedValueSelected0_001));
-    freeSimulatedPin((void**)(&memory->out.feedValueSelected0_01));
-    freeSimulatedPin((void**)(&memory->out.feedValueSelected0_1));
-    freeSimulatedPin((void**)(&memory->out.feedValueSelected1_0));
+    freeSimulatedPin((void**)(&memory->out.feedValueSelected_0_001));
+    freeSimulatedPin((void**)(&memory->out.feedValueSelected_0_01));
+    freeSimulatedPin((void**)(&memory->out.feedValueSelected_0_1));
+    freeSimulatedPin((void**)(&memory->out.feedValueSelected_1_0));
+    freeSimulatedPin((void**)(&memory->out.feedValueSelected_60));
+    freeSimulatedPin((void**)(&memory->out.feedValueSelected_100));
+    freeSimulatedPin((void**)(&memory->out.feedValueSelected_lead));
 
     freeSimulatedPin((void**)(&memory->out.feedOverrideScale));
     freeSimulatedPin((void**)(&memory->out.feedOverrideCountEnable));
@@ -194,6 +197,7 @@ Hal::~Hal()
     freeSimulatedPin((void**)(&memory->out.feedOverrideDecrease));
     freeSimulatedPin((void**)(&memory->out.feedOverrideIncrease));
 
+    freeSimulatedPin((void**)(&memory->out.spindleStart));
     freeSimulatedPin((void**)(&memory->out.spindleStop));
     freeSimulatedPin((void**)(&memory->out.spindleDoRunForward));
     freeSimulatedPin((void**)(&memory->out.spindleDoRunReverse));
@@ -201,8 +205,6 @@ Hal::~Hal()
     freeSimulatedPin((void**)(&memory->out.spindleDoIncrease));
     freeSimulatedPin((void**)(&memory->out.spindleOverrideDoDecrease));
     freeSimulatedPin((void**)(&memory->out.spindleOverrideDoIncrease));
-
-    freeSimulatedPin((void**)(&memory->out.jogSpeedValue));
 
     freeSimulatedPin((void**)(&memory->out.homeAll));
 
@@ -508,29 +510,6 @@ void Hal::init(const MetaButtonCodes* metaButtons, const KeyCodes& keyCodes)
     newHalFloat(HAL_OUT, &(memory->out.axisCJogScale), mHalCompId, "%s.axis.5.jog-scale", mComponentPrefix);
     newHalBit(HAL_OUT, &(memory->out.axisCSetVelocityMode), mHalCompId, "%s.axis.5.jog-vel-mode", mComponentPrefix);
 
-    newHalBit(HAL_OUT, &(memory->out.isPendantSleeping), mHalCompId, "%s.pendant.is-sleeping", mComponentPrefix);
-    newHalBit(HAL_OUT, &(memory->out.isPendantConnected), mHalCompId, "%s.pendant.is-connected", mComponentPrefix);
-
-    newHalFloat(HAL_IN, &(memory->in.axisXPosition), mHalCompId, "%s.halui.axis.0.pos-feedback", mComponentPrefix);
-    newHalFloat(HAL_IN, &(memory->in.axisYPosition), mHalCompId, "%s.halui.axis.1.pos-feedback", mComponentPrefix);
-    newHalFloat(HAL_IN, &(memory->in.axisZPosition), mHalCompId, "%s.halui.axis.2.pos-feedback", mComponentPrefix);
-    newHalFloat(HAL_IN, &(memory->in.axisAPosition), mHalCompId, "%s.halui.axis.3.pos-feedback", mComponentPrefix);
-    newHalFloat(HAL_IN, &(memory->in.axisBPosition), mHalCompId, "%s.halui.axis.4.pos-feedback", mComponentPrefix);
-    newHalFloat(HAL_IN, &(memory->in.axisCPosition), mHalCompId, "%s.halui.axis.5.pos-feedback", mComponentPrefix);
-
-    newHalFloat(HAL_IN, &(memory->in.axisXPositionRelative), mHalCompId, "%s.halui.axis.0.pos-relative",
-                mComponentPrefix);
-    newHalFloat(HAL_IN, &(memory->in.axisYPositionRelative), mHalCompId, "%s.halui.axis.1.pos-relative",
-                mComponentPrefix);
-    newHalFloat(HAL_IN, &(memory->in.axisZPositionRelative), mHalCompId, "%s.halui.axis.2.pos-relative",
-                mComponentPrefix);
-    newHalFloat(HAL_IN, &(memory->in.axisAPositionRelative), mHalCompId, "%s.halui.axis.3.pos-relative",
-                mComponentPrefix);
-    newHalFloat(HAL_IN, &(memory->in.axisBPositionRelative), mHalCompId, "%s.halui.axis.4.pos-relative",
-                mComponentPrefix);
-    newHalFloat(HAL_IN, &(memory->in.axisCPositionRelative), mHalCompId, "%s.halui.axis.5.pos-relative",
-                mComponentPrefix);
-
     newHalFloat(HAL_IN, &(memory->in.stepgenXMaxVelocity), mHalCompId, "%s.stepgen.00.maxvel", mComponentPrefix);
     newHalFloat(HAL_IN, &(memory->in.stepgenXPositionScale), mHalCompId, "%s.stepgen.00.position-scale",
                 mComponentPrefix);
@@ -555,12 +534,43 @@ void Hal::init(const MetaButtonCodes* metaButtons, const KeyCodes& keyCodes)
     newHalFloat(HAL_IN, &(memory->in.stepgenCPositionScale), mHalCompId, "%s.stepgen.05.position-scale",
                 mComponentPrefix);
 
-    newHalBit(HAL_OUT, &(memory->out.feedValueSelected0_001), mHalCompId, "%s.halui.feed.selected-0.001",
+    newHalBit(HAL_OUT, &(memory->out.isPendantSleeping), mHalCompId, "%s.pendant.is-sleeping", mComponentPrefix);
+    newHalBit(HAL_OUT, &(memory->out.isPendantConnected), mHalCompId, "%s.pendant.is-connected", mComponentPrefix);
+
+    newHalFloat(HAL_IN, &(memory->in.axisXPosition), mHalCompId, "%s.halui.axis.0.pos-feedback", mComponentPrefix);
+    newHalFloat(HAL_IN, &(memory->in.axisYPosition), mHalCompId, "%s.halui.axis.1.pos-feedback", mComponentPrefix);
+    newHalFloat(HAL_IN, &(memory->in.axisZPosition), mHalCompId, "%s.halui.axis.2.pos-feedback", mComponentPrefix);
+    newHalFloat(HAL_IN, &(memory->in.axisAPosition), mHalCompId, "%s.halui.axis.3.pos-feedback", mComponentPrefix);
+    newHalFloat(HAL_IN, &(memory->in.axisBPosition), mHalCompId, "%s.halui.axis.4.pos-feedback", mComponentPrefix);
+    newHalFloat(HAL_IN, &(memory->in.axisCPosition), mHalCompId, "%s.halui.axis.5.pos-feedback", mComponentPrefix);
+
+    newHalFloat(HAL_IN, &(memory->in.axisXPositionRelative), mHalCompId, "%s.halui.axis.0.pos-relative",
+                mComponentPrefix);
+    newHalFloat(HAL_IN, &(memory->in.axisYPositionRelative), mHalCompId, "%s.halui.axis.1.pos-relative",
+                mComponentPrefix);
+    newHalFloat(HAL_IN, &(memory->in.axisZPositionRelative), mHalCompId, "%s.halui.axis.2.pos-relative",
+                mComponentPrefix);
+    newHalFloat(HAL_IN, &(memory->in.axisAPositionRelative), mHalCompId, "%s.halui.axis.3.pos-relative",
+                mComponentPrefix);
+    newHalFloat(HAL_IN, &(memory->in.axisBPositionRelative), mHalCompId, "%s.halui.axis.4.pos-relative",
+                mComponentPrefix);
+    newHalFloat(HAL_IN, &(memory->in.axisCPositionRelative), mHalCompId, "%s.halui.axis.5.pos-relative",
+                mComponentPrefix);
+
+    newHalBit(HAL_OUT, &(memory->out.feedValueSelected_0_001), mHalCompId, "%s.halui.feed.selected-0.001",
               mComponentPrefix);
-    newHalBit(HAL_OUT, &(memory->out.feedValueSelected0_01), mHalCompId, "%s.halui.feed.selected-0.01",
+    newHalBit(HAL_OUT, &(memory->out.feedValueSelected_0_01), mHalCompId, "%s.halui.feed.selected-0.01",
               mComponentPrefix);
-    newHalBit(HAL_OUT, &(memory->out.feedValueSelected0_1), mHalCompId, "%s.halui.feed.selected-0.1", mComponentPrefix);
-    newHalBit(HAL_OUT, &(memory->out.feedValueSelected1_0), mHalCompId, "%s.halui.feed.selected-1.0", mComponentPrefix);
+    newHalBit(HAL_OUT, &(memory->out.feedValueSelected_0_1), mHalCompId, "%s.halui.feed.selected-0.1",
+              mComponentPrefix);
+    newHalBit(HAL_OUT, &(memory->out.feedValueSelected_1_0), mHalCompId, "%s.halui.feed.selected-1.0",
+              mComponentPrefix);
+    newHalBit(HAL_OUT, &(memory->out.feedValueSelected_60), mHalCompId, "%s.halui.feed.selected-60",
+              mComponentPrefix);
+    newHalBit(HAL_OUT, &(memory->out.feedValueSelected_100), mHalCompId, "%s.halui.feed.selected-100",
+              mComponentPrefix);
+    newHalBit(HAL_OUT, &(memory->out.feedValueSelected_lead), mHalCompId, "%s.halui.feed.selected-lead",
+              mComponentPrefix);
 
     newHalFloat(HAL_OUT, &(memory->out.feedOverrideScale), mHalCompId, "%s.halui.feed-override.scale",
                 mComponentPrefix);
@@ -591,6 +601,7 @@ void Hal::init(const MetaButtonCodes* metaButtons, const KeyCodes& keyCodes)
               mComponentPrefix);
     newHalBit(HAL_OUT, &(memory->out.spindleOverrideDoDecrease), mHalCompId, "%s.halui.spindle-override.decrease",
               mComponentPrefix);
+    newHalBit(HAL_OUT, &(memory->out.spindleStart), mHalCompId, "%s.halui.spindle.start", mComponentPrefix);
     newHalBit(HAL_IN, &(memory->in.spindleIsOn), mHalCompId, "%s.halui.spindle.is-on", mComponentPrefix);
     newHalBit(HAL_OUT, &(memory->out.spindleStop), mHalCompId, "%s.halui.spindle.stop", mComponentPrefix);
     newHalBit(HAL_OUT, &(memory->out.spindleDoRunForward), mHalCompId, "%s.halui.spindle.forward", mComponentPrefix);
@@ -627,8 +638,6 @@ void Hal::init(const MetaButtonCodes* metaButtons, const KeyCodes& keyCodes)
     newHalBit(HAL_OUT, &(memory->out.jointASelect), mHalCompId, "%s.halui.joint.a.select", mComponentPrefix);
     newHalBit(HAL_OUT, &(memory->out.jointBSelect), mHalCompId, "%s.halui.joint.b.select", mComponentPrefix);
     newHalBit(HAL_OUT, &(memory->out.jointCSelect), mHalCompId, "%s.halui.joint.c.select", mComponentPrefix);
-
-    newHalFloat(HAL_OUT, &(memory->out.jogSpeedValue), mHalCompId, "%s.halui.jog-speed", mComponentPrefix);
 
     newHalBit(HAL_OUT, &(memory->out.homeAll), mHalCompId, "%s.halui.home-all", mComponentPrefix);
     mIsInitialized = true;
@@ -710,7 +719,7 @@ hal_float_t Hal::getAxisCPosition(bool absolute) const
 
 // ----------------------------------------------------------------------
 
-void Hal::setEnableVerbose(bool enable)
+void Hal::enableVerbose(bool enable)
 {
     if (enable)
     {
@@ -986,28 +995,49 @@ void Hal::setFeedOverrideCounts(hal_s32_t counts)
 
 void Hal::setFeedValueSelected0_001(bool selected)
 {
-    *memory->out.feedValueSelected0_001 = selected;
+    *memory->out.feedValueSelected_0_001 = selected;
 }
 
 // ----------------------------------------------------------------------
 
 void Hal::setFeedValueSelected0_01(bool selected)
 {
-    *memory->out.feedValueSelected0_01 = selected;
+    *memory->out.feedValueSelected_0_01 = selected;
 }
 
 // ----------------------------------------------------------------------
 
 void Hal::setFeedValueSelected0_1(bool selected)
 {
-    *memory->out.feedValueSelected0_1 = selected;
+    *memory->out.feedValueSelected_0_1 = selected;
 }
 
 // ----------------------------------------------------------------------
 
 void Hal::setFeedValueSelected1_0(bool selected)
 {
-    *memory->out.feedValueSelected1_0 = selected;
+    *memory->out.feedValueSelected_1_0 = selected;
+}
+
+// ----------------------------------------------------------------------
+
+void Hal::setFeedValueSelected60(bool selected)
+{
+    *memory->out.feedValueSelected_60 = selected;
+}
+
+// ----------------------------------------------------------------------
+
+void Hal::setFeedValueSelected100(bool selected)
+{
+    *memory->out.feedValueSelected_100 = selected;
+}
+
+// ----------------------------------------------------------------------
+
+void Hal::setFeedValueSelectedLead(bool selected)
+{
+    *memory->out.feedValueSelected_lead = selected;
 }
 
 // ----------------------------------------------------------------------
@@ -1139,11 +1169,13 @@ void Hal::toggleSpindleOnOff(bool isButtonPressed)
             {
                 *memory->out.spindleDoRunReverse = true;
             }
+            *memory->out.spindleStart = true;
         }
     }
     else
     {
         // on button released
+        *memory->out.spindleStart        = false;
         *memory->out.spindleStop         = false;
         *memory->out.spindleDoRunForward = false;
         *memory->out.spindleDoRunReverse = false;

--- a/src/hal/user_comps/xhc-whb04b-6/hal.h
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.h
@@ -203,10 +203,13 @@ public:
         //! to be connected to \ref axis.5.jog-vel-mode
         hal_bit_t* axisCSetVelocityMode{nullptr};
 
-        hal_bit_t* feedValueSelected0_001{nullptr};
-        hal_bit_t* feedValueSelected0_01{nullptr};
-        hal_bit_t* feedValueSelected0_1{nullptr};
-        hal_bit_t* feedValueSelected1_0{nullptr};
+        hal_bit_t* feedValueSelected_0_001{nullptr};
+        hal_bit_t* feedValueSelected_0_01{nullptr};
+        hal_bit_t* feedValueSelected_0_1{nullptr};
+        hal_bit_t* feedValueSelected_1_0{nullptr};
+        hal_bit_t* feedValueSelected_60{nullptr};
+        hal_bit_t* feedValueSelected_100{nullptr};
+        hal_bit_t* feedValueSelected_lead{nullptr};
 
         //! to be connected to \ref  \ref halui.feed-override.scale
         hal_float_t* feedOverrideScale{nullptr};
@@ -221,6 +224,8 @@ public:
         //! to be connected to \ref halui.feed-override.increase
         hal_bit_t  * feedOverrideIncrease{nullptr};
 
+        //! to be connected to \ref halui.spindle.start
+        hal_bit_t* spindleStart{nullptr};
         //! to be connected to \ref halui.spindle.stop
         hal_bit_t* spindleStop{nullptr};
         //! to be connected to \ref halui.spindle.forward
@@ -235,9 +240,6 @@ public:
         hal_bit_t* spindleOverrideDoDecrease{nullptr};
         //! to be connected to halui.spindle-override.increase
         hal_bit_t* spindleOverrideDoIncrease{nullptr};
-
-        //! to be connected to \ref halui.jog-speed
-        hal_float_t* jogSpeedValue{nullptr};
 
         //! to be connected to \ref halui.home-all
         hal_bit_t* homeAll{nullptr};
@@ -321,7 +323,7 @@ public:
     const char* getHalComponentName() const;
     //! Enables verbose hal output.
     //! \param enable true to enable hal messages, disable otherwise
-    void setEnableVerbose(bool enable);
+    void enableVerbose(bool enable);
     //! If set indicates that no other axis is active.
     //! \param enabled true if no axis is active, false otherwise
     void setNoAxisActive(bool enabled);
@@ -405,21 +407,36 @@ public:
     hal_float_t getFeedUps() const;
 
     //! Propagates the feed value 0.001 selection state to hal.
-    //! \sa Hal::Out::feedValueSelected0_001
+    //! \sa Hal::Out::feedValueSelected_0_001
     //! \param selected true if 0.001 is selected, false otherwise
     void setFeedValueSelected0_001(bool selected);
     //! Propagates the feed value 0.01 selection state to hal.
-    //! \sa Hal::Out::feedValueSelected0_01
+    //! \sa Hal::Out::feedValueSelected_0_01
     //! \param selected true if 0.01 is selected, false otherwise
     void setFeedValueSelected0_01(bool selected);
     //! Propagates the feed value 0.1 selection state to hal.
-    //! \sa Hal::Out::feedValueSelected0_1
+    //! \sa Hal::Out::feedValueSelected_0_1
     //! \param selected true if 0.1 is selected, false otherwise
     void setFeedValueSelected0_1(bool selected);
     //! Propagates the feed value 1.0 selection state to hal.
-    //! \sa Hal::Out::feedValueSelected1_0
+    //! \sa Hal::Out::feedValueSelected_1_0
     //! \param selected true if 1.0 is selected, false otherwise
     void setFeedValueSelected1_0(bool selected);
+
+    //! Propagates the feed value 60% selection state to hal.
+    //! \sa Hal::Out::feedValueSelected_60
+    //! \param selected true if 60% is selected, false otherwise
+    void setFeedValueSelected60(bool selected);
+
+    //! Propagates the feed value 100% selection state to hal.
+    //! \sa Hal::Out::feedValueSelected_100
+    //! \param selected true if 100% is selected, false otherwise
+    void setFeedValueSelected100(bool selected);
+
+    //! Propagates the feed value Lead selection state to hal.
+    //! \sa Hal::Out::feedValueSelected_lead
+    //! \param selected true if Lead is selected, false otherwise
+    void setFeedValueSelectedLead(bool selected);
 
     //! Returns the spindle speed.
     //! \return the spindle speed in rounds per second

--- a/src/hal/user_comps/xhc-whb04b-6/main.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/main.cc
@@ -101,18 +101,18 @@ static int printUsage(const char* programName, const char* deviceName, bool isEr
         << endl
         << "EXAMPLES" << endl
         << programName << " -ue" << endl
-        << "    Prints incoming USB data transfer and generated key pressed/released events." << endl
+        << "    Start in userspace mode (simulation) and prints incoming USB data transfer and generated key pressed/released events." << endl
         << endl
         << programName << " -p" << endl
-        << "    Prints hal pin names and events distributed to HAL memory." << endl
+        << "    Start in userspace mode (simulation) and prints HAL pin names and events distributed to HAL memory." << endl
         << endl
-        << programName << " -Ha" << endl
+        << programName << " -Hn" << endl
         << "    Start in HAL mode and avoid output, except of errors." << endl
         << endl
         << "AUTHORS" << endl
-        << "    This component was started by Raoul Rubien (github.com/rubienr) based on predecessor "
-            "device's component xhc-hb04.cc. https://github.com/machinekit/machinekit/graphs/contributors "
-            "gives you a more complete list of contributors."
+        << "    This component was started by Raoul Rubien based on predecessor "
+           "device's component xhc-hb04.cc. https://github.com/machinekit/machinekit/graphs/contributors "
+           "gives you a more complete list of contributors."
         << endl;
 
     if (isError)
@@ -172,6 +172,7 @@ int main(int argc, char** argv)
                 WhbComponent->setWaitWithTimeout(3);
                 break;
             case 'e':
+                WhbComponent->enableVerbosePendant(true);
                 WhbComponent->setEnableVerboseKeyEvents(true);
                 break;
             case 'u':
@@ -189,6 +190,7 @@ int main(int argc, char** argv)
                 break;
             case 'a':
                 WhbComponent->enableVerboseInit(true);
+                WhbComponent->enableVerbosePendant(true);
                 WhbComponent->setEnableVerboseKeyEvents(true);
                 WhbComponent->enableVerboseRx(true);
                 WhbComponent->enableVerboseTx(true);

--- a/src/hal/user_comps/xhc-whb04b-6/pendant.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant.cc
@@ -700,7 +700,7 @@ void FeedRotaryButton::update()
     {
         auto enumValue = mContinuousKeycodeLut.find(mKey);
         assert(enumValue != mContinuousKeycodeLut.end());
-        auto second = enumValue->second;
+        auto second  = enumValue->second;
         mStepSize    = mContinuousSizeMapper.getStepSize(second);
         mIsPermitted = mContinuousSizeMapper.isPermitted(second);
     }
@@ -708,7 +708,7 @@ void FeedRotaryButton::update()
     {
         auto enumValue = mStepKeycodeLut.find(mKey);
         assert(enumValue != mStepKeycodeLut.end());
-        auto second = enumValue->second;
+        auto second  = enumValue->second;
         mStepSize    = mStepStepSizeMapper.getStepSize(second);
         mIsPermitted = mStepStepSizeMapper.isPermitted(second);
     }
@@ -797,9 +797,8 @@ std::ostream& operator<<(std::ostream& os, const Handwheel& data)
 
 const HandWheelCounters& Handwheel::counters() const
 {
-    return static_cast<const HandWheelCounters& >(
-        static_cast<Handwheel>(*this).counters()
-    );
+    Handwheel* self = const_cast<Handwheel*>(this);
+    return static_cast<const HandWheelCounters&>(self->counters());
 }
 
 // ----------------------------------------------------------------------
@@ -813,6 +812,20 @@ void Handwheel::setEnabled(bool enabled)
 HandWheelCounters& Handwheel::counters()
 {
     return mCounters;
+}
+
+// ----------------------------------------------------------------------
+
+void Handwheel::enableVerbose(bool enable)
+{
+    if (enable)
+    {
+        mWheelCout = &std::cout;
+    }
+    else
+    {
+        mWheelCout = &mDevNull;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -1081,6 +1094,21 @@ void Pendant::shiftButtonState()
 {
     mPreviousButtonsState = mCurrentButtonsState;
     mCurrentButtonsState.clearPressedButtons();
+}
+
+// ----------------------------------------------------------------------
+
+void Pendant::enableVerbose(bool enable)
+{
+    mHandWheel.enableVerbose(enable);
+    if (enable)
+    {
+        mPendantCout = &std::cout;
+    }
+    else
+    {
+        mPendantCout = &mDevNull;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -1507,6 +1535,18 @@ void Pendant::dispatchActiveFeedToHal(const KeyCode& feed, bool isActive)
     {
         mHal.setFeedValueSelected1_0(isActive);
     }
+    else if (feed.code == KeyCodes::Feed.percent_60.code)
+    {
+        mHal.setFeedValueSelected60(isActive);
+    }
+    else if (feed.code == KeyCodes::Feed.percent_100.code)
+    {
+        mHal.setFeedValueSelected100(isActive);
+    }
+    else if (feed.code == KeyCodes::Feed.lead.code)
+    {
+        mHal.setFeedValueSelectedLead(isActive);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -1846,4 +1886,3 @@ void Display::clearData()
     mDisplayData.row3Coordinate.clear();
 }
 }
-

--- a/src/hal/user_comps/xhc-whb04b-6/pendant.h
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant.h
@@ -24,6 +24,7 @@
 
 // system includes
 #include <type_traits>
+#include <ostream>
 #include <stdint.h>
 #include <list>
 
@@ -452,6 +453,7 @@ class Handwheel
 public:
     Handwheel(const FeedRotaryButton& feedButton, KeyEventListener* listener = nullptr);
     ~Handwheel();
+    void enableVerbose(bool enable);
     void setMode(HandWheelCounters::CounterNameToIndex mode);
     void count(int8_t delta);
     const HandWheelCounters& counters() const;
@@ -465,6 +467,7 @@ private:
     bool              mIsEnabled{false};
     const FeedRotaryButton& mFeedButton;
     KeyEventListener      * mEventListener;
+    std::ostream          mDevNull{nullptr};
     std::ostream          * mWheelCout;
     const char            * mPrefix;
 };
@@ -575,6 +578,7 @@ public:
     void updateDisplayData();
     void clearDisplayData();
 
+    void enableVerbose(bool enable);
     const ButtonsState& currentButtonsState() const;
     const ButtonsState& previousButtonsState() const;
     const Handwheel& handWheel() const;
@@ -599,6 +603,7 @@ private:
     float mMaxVelocity;
 
     const char  * mPrefix;
+    std::ostream  mDevNull{nullptr};
     std::ostream* mPendantCout;
 
     void shiftButtonState();

--- a/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.cc
@@ -309,18 +309,20 @@ XhcWhb04b6Component::XhcWhb04b6Component() :
                  MetaButtonCodes(mKeyCodes.Buttons.undefined, mKeyCodes.Buttons.undefined)
     },
     mUsb(mName, *this, mHal),
-    mTxCout(&mDevNull),
+    //mTxCout(&mDevNull),
     mRxCout(&mDevNull),
-    mKeyEventCout(&mDevNull),
-    mHalInitCout(&mDevNull),
+    //mKeyEventCout(&mDevNull),
+    //mHalInitCout(&mDevNull),
     mInitCout(&mDevNull),
     packageReceivedEventReceiver(*this),
     mPendant(mHal, mUsb.getOutputPackageData())
 {
     setSimulationMode(true);
+    enableVerbosePendant(false);
     enableVerboseRx(false);
     enableVerboseTx(false);
     enableVerboseInit(false);
+    setEnableVerboseKeyEvents(false);
     enableVerboseHal(false);
 }
 
@@ -595,6 +597,13 @@ void XhcWhb04b6Component::teardownUsb()
 
 // ----------------------------------------------------------------------
 
+void XhcWhb04b6Component::enableVerbosePendant(bool enable)
+{
+    mPendant.enableVerbose(enable);
+}
+
+// ----------------------------------------------------------------------
+
 void XhcWhb04b6Component::enableVerboseRx(bool enable)
 {
     mUsb.enableVerboseRx(enable);
@@ -613,30 +622,29 @@ void XhcWhb04b6Component::enableVerboseRx(bool enable)
 void XhcWhb04b6Component::enableVerboseTx(bool enable)
 {
     mUsb.enableVerboseTx(enable);
-    if (enable)
+    /*if (enable)
     {
         mTxCout = &std::cout;
     }
     else
     {
         mTxCout = &mDevNull;
-    }
+    }*/
 }
 
 // ----------------------------------------------------------------------
 
 void XhcWhb04b6Component::enableVerboseHal(bool enable)
 {
-    mHal.setEnableVerbose(enable);
-
-    if (enable)
+    mHal.enableVerbose(enable);
+    /*if (enable)
     {
         mHalInitCout = &std::cout;
     }
     else
     {
         mHalInitCout = &mDevNull;
-    }
+    }*/
 }
 
 // ----------------------------------------------------------------------
@@ -701,14 +709,14 @@ bool XhcWhb04b6Component::isSimulationModeEnabled() const
 void XhcWhb04b6Component::setEnableVerboseKeyEvents(bool enable)
 {
     mUsb.enableVerboseRx(enable);
-    if (enable)
+    /*if (enable)
     {
         mKeyEventCout = &std::cout;
     }
     else
     {
         mKeyEventCout = &mDevNull;
-    }
+    }*/
 }
 
 // ----------------------------------------------------------------------

--- a/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.h
+++ b/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.h
@@ -67,6 +67,7 @@ public:
     bool isSimulationModeEnabled() const;
     void setSimulationMode(bool enableSimulationMode);
     void setEnableVerboseKeyEvents(bool enable);
+    void enableVerbosePendant(bool enable);
     void enableVerboseRx(bool enable);
     void enableVerboseTx(bool enable);
     void enableVerboseHal(bool enable);
@@ -85,10 +86,10 @@ private:
     bool                  mIsRunning{false};
     bool                  mIsSimulationMode{false};
     std::ostream          mDevNull{nullptr};
-    std::ostream             * mTxCout;
+    //std::ostream             * mTxCout;
     std::ostream             * mRxCout;
-    std::ostream             * mKeyEventCout;
-    std::ostream             * mHalInitCout;
+    //std::ostream             * mKeyEventCout;
+    //std::ostream             * mHalInitCout;
     std::ostream             * mInitCout;
     OnUsbInputPackageListener& packageReceivedEventReceiver;
     bool    mIsCrcDebuggingEnabled{false};


### PR DESCRIPTION
Wen updating component's documentation a few minor things popped up and were fixed on the fly: 

1. refined `--help` output
1. fixed compiler warning when const method `foo() const {...}` called non-const `foo(){...}` implementation
1. fixed issue with log output where log was not silent upon cli request `-n`
1. added missing rotary button output signals to component
1. added `whb.halui.spindle.start` signal upon user request
1. minor cleanup
