### PR TITLE
moved spindle increase/decrease step size to parameter

### DIFF
--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -1671,23 +1671,43 @@ int emcmotCommandHandler(void *arg, const hal_funct_args_t *fa)
 	    emcmotStatus->spindle.locked = 0;
 	    break;
 
-	case EMCMOT_SPINDLE_INCREASE:
-	    rtapi_print_msg(RTAPI_MSG_DBG, "SPINDLE_INCREASE");
-	    if (emcmotStatus->spindle.speed > 0) {
-		emcmotStatus->spindle.speed += 100; //FIXME - make the step a HAL parameter
-	    } else if (emcmotStatus->spindle.speed < 0) {
-		emcmotStatus->spindle.speed -= 100;
-	    }
-	    break;
+  case EMCMOT_SPINDLE_INCREASE:
+      rtapi_print_msg(RTAPI_MSG_DBG, "SPINDLE_INCREASE");
+      {
+          int32_t speed = emcmotStatus->spindle.speed;
+          int32_t speed_max = emcmot_hal_data->spindle_speed_max_abs;
+          int32_t speed_step = emcmot_hal_data->spindle_speed_change_step_abs;
 
-	case EMCMOT_SPINDLE_DECREASE:
-	    rtapi_print_msg(RTAPI_MSG_DBG, "SPINDLE_DECREASE");
-	    if (emcmotStatus->spindle.speed > 100) {
-		emcmotStatus->spindle.speed -= 100; //FIXME - make the step a HAL parameter
-	    } else if (emcmotStatus->spindle.speed < -100) {
-		emcmotStatus->spindle.speed += 100;
-	    }
-	    break;
+          if (speed > 0) {
+              speed += speed_step;
+              speed = (speed > speed_max) ? speed_max : speed;
+          } else {
+              speed -= speed_step;
+              speed = (speed < -speed_max) ? -speed_max : speed;
+          }
+
+          emcmotStatus->spindle.speed = speed;
+      }
+    break;
+
+  case EMCMOT_SPINDLE_DECREASE:
+      rtapi_print_msg(RTAPI_MSG_DBG, "SPINDLE_DECREASE");
+      {
+          int32_t speed = emcmotStatus->spindle.speed;
+          int32_t speed_min = emcmot_hal_data->spindle_speed_min_abs;
+          int32_t speed_step = emcmot_hal_data->spindle_speed_change_step_abs;
+
+          if (speed > 0) {
+              speed -= speed_step;
+              speed = (speed < speed_min) ? speed_min : speed;
+          } else {
+              speed += speed_step;
+              speed = (speed > -speed_min) ? -speed_min : speed;
+          }
+
+          emcmotStatus->spindle.speed = speed;
+      }
+    break;
 
 	case EMCMOT_SPINDLE_BRAKE_ENGAGE:
 	    rtapi_print_msg(RTAPI_MSG_DBG, "SPINDLE_BRAKE_ENGAGE");

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -160,6 +160,11 @@ typedef struct {
     hal_bit_t   *spindle_is_oriented;	/* in: orientation completed */
     hal_s32_t   *spindle_orient_fault;	/* in: error code of failed operation */
 
+    // spindle increase / decrease parameters
+    hal_u32_t spindle_speed_change_step_abs;	/* in: absolute step to increase or decrease spindle speed */
+    hal_u32_t spindle_speed_max_abs;	/* in: on increase, absolute spindle speed is capped to max value */
+    hal_u32_t spindle_speed_min_abs;	/* in: on decrease, absolute spindle speed is capped to min value */
+
     // FIXME - debug only, remove later
     hal_float_t traj_pos_out;	/* RPA: traj internals, for debugging */
     hal_float_t traj_vel_out;	/* RPA: traj internals, for debugging */

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -456,6 +456,29 @@ static int init_hal_io(void)
     if (retval != 0) {
 	return retval;
     }
+
+    /* export spindle parameters */
+    retval =
+	hal_param_u32_new("motion.spindle.speed-change-step-abs", HAL_RW, &(emcmot_hal_data->spindle_speed_change_step_abs),
+	mot_comp_id);
+    if (retval != 0) {
+	return retval;
+    }
+
+    retval =
+	hal_param_u32_new("motion.spindle.speed-change-max-abs", HAL_RW, &(emcmot_hal_data->spindle_speed_max_abs),
+	mot_comp_id);
+    if (retval != 0) {
+	return retval;
+    }
+
+    retval =
+	hal_param_u32_new("motion.spindle.speed-change-min-abs", HAL_RW, &(emcmot_hal_data->spindle_speed_min_abs),
+	mot_comp_id);
+    if (retval != 0) {
+	return retval;
+    }
+
     /* export debug parameters */
     /* these can be used to view any internal variable, simply change a line
        in control.c:output_to_hal() and recompile */
@@ -672,6 +695,11 @@ static int init_hal_io(void)
     *(emcmot_hal_data->teleop_mode) = 0;
     *(emcmot_hal_data->coord_error) = 0;
     *(emcmot_hal_data->on_soft_limit) = 0;
+
+    /* init spindle parameters */
+    emcmot_hal_data->spindle_speed_change_step_abs = 100;
+    emcmot_hal_data->spindle_speed_max_abs = 48000;
+    emcmot_hal_data->spindle_speed_min_abs = 0;
 
     /* init debug parameters */
     emcmot_hal_data->debug_bit_0 = 0;


### PR DESCRIPTION
**Spindle increase/decrease via `halui.spindle.increase/decrease`**

For high speed spindles increment only by 100 rpms per button press can be annoying. Found respective place in source and also found this note: `FIXME - make the step a HAL parameter`.

**Created new parameters**
* `motion.spindle.speed-change-step-abs`: (u32, RW) Step size to increment/decrement on spindle 
increase/decrease speed (default 100).
* `motion.spindle.speed-change-max-abs`: (u32, RW) Absolute spindle speed limit for increment either directions (default 48000).
* `motion.spindle.speed-change-min-abs`: (u32, RW) Absolute spindle speed limit for decrement either directions (default 0).

**Example**
```
setp motion.spindle.speed-change-step-abs 400
setp motion.spindle.speed-change-max-abs  24000
setp motion.spindle.speed-change-min-abs  800
```
then toggle these pins accordingly
```
halui.spindle.decrease
halui.spindle.increase
```