### PR TITLE
Lead mode can be used to manipulate spindle speed or feed override

### DIFF
--- a/src/hal/user_comps/xhc-whb04b-6/main.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/main.cc
@@ -2,7 +2,7 @@
    XHC-WHB04B-6 Wireless MPG pendant LinuxCNC HAL module for LinuxCNC.
    Based on XHC-HB04.
 
-   Copyright (C) 2017 Raoul Rubien (github.com/rubienr).
+   Copyright (C) 2018 Raoul Rubien (github.com/rubienr).
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -34,8 +34,6 @@
 // local includes
 #include "./xhc-whb04b6.h"
 
-using std::endl;
-
 // forward declarations
 
 // globals
@@ -51,69 +49,77 @@ static int printUsage(const char* programName, const char* deviceName, bool isEr
     {
         os = &std::cerr;
     }
-    *os << programName << " version " << PACKAGE_VERSION << " " << __DATE__ << " " << __TIME__ << endl
-        << endl
-        << "SYNOPSIS" << endl
-        << "    " << programName << " [-h | --help] | [-H] [OPTIONS] " << endl
-        << endl
-        << "NAME" << endl
-        << "    " << programName << " - jog dial HAL component for the " << deviceName << " device" << endl
-        << endl
-        << "DESCRIPTION" << endl
+    *os << programName << " version " << PACKAGE_VERSION << " " << __DATE__ << " " << __TIME__ << "\n"
+        << "\n"
+        << "SYNOPSIS\n"
+        << "    " << programName << " [-h | --help] | [-H] [OPTIONS]\n"
+        << "\n"
+        << "NAME\n"
+        << "    " << programName << " - jog dial HAL component for the " << deviceName << " device\n"
+        << "\n"
+        << "DESCRIPTION\n"
         << "    " << programName << " is a HAL component that receives events from the " << deviceName << " device "
-        << "and exposes them to HAL via HAL pins." << endl
-        << endl
-        << "OPTIONS" << endl
-        << " -h, --help" << endl
-        << "    Prints the synopsis and the most commonly used commands." << endl
-        << endl
-        << " -H " << endl
+        << "and exposes them to HAL via HAL pins.\n"
+        << "\n"
+        << "OPTIONS\n"
+        << " -h, --help\n"
+        << "    Prints the synopsis and the most commonly used commands.\n"
+        << "\n"
+        << " -H\n"
         << "    Run " << programName << " in HAL-mode instead of interactive mode. When in HAL mode "
         << "commands from device will be exposed to HAL's shred memory. Interactive mode is useful for "
-        << "testing device connectivity and debugging." << endl
-        << endl
-        << " -t" << endl
+        << "testing device connectivity and debugging.\n"
+        << "\n"
+        << " -t\n"
         << "    Wait with timeout for USB device then proceed, exit otherwise. Without -t the timeout is "
-        << "implicitly infinite." << endl
-        << endl
-        << " -u, -U" << endl
+        << "implicitly infinite.\n"
+        << "\n"
+        << " -s, \n"
+        << "    Lead in Spindle mode: "
+        << "Lead + jogwheel changes the spindle speed. Each tick will increase/decrease the spindle speed.\n"
+        << "\n"
+        << " -f, \n"
+        << "    Lead in Feed mode: "
+        << "Lead + jogwheel changes the feed override. Each tick will increment/decrement the feed override.\n"
+        << "\n"
+        << " -u, -U\n"
         << "    Show received data from device. With -U received and transmitted data will be printed. "
-        << "Output is prefixed with \"usb\"." << endl
-        << endl
-        << " -p" << endl
-        << "    Show HAL pins and HAL related messages. Output is prefixed with \"hal\"." << endl
-        << endl
-        << " -e" << endl
+        << "Output is prefixed with \"usb\".\n"
+        << "\n"
+        << " -p\n"
+        << "    Show HAL pins and HAL related messages. Output is prefixed with \"hal\".\n"
+        << "\n"
+        << " -e\n"
         << "    Show captured events such as button pressed/released, jog dial, axis rotary button, and "
-            "feed rotary button event. Output is prefixed with \"event\"." << endl
-        << endl
-        << " -a" << endl
-        << "    Enable all logging facilities without explicitly specifying each." << endl
+            "feed rotary button event. Output is prefixed with \"event\".\n"
+        << "\n"
+        << " -a\n"
+        << "    Enable all logging facilities without explicitly specifying each.\n"
         //! this feature must be removed when checksum check is implemented
-        << endl
-        << " -c" << endl
+        << "\n"
+        << " -c\n"
         << "    Enable checksum output which is necessary for debugging the checksum generator function. Do not rely "
-            "on this feature since it will be removed once the generator is implemented." << endl
-        << endl
-        << " -n " << endl
+            "on this feature since it will be removed once the generator is implemented.\n"
+        << "\n"
+        << " -n\n"
         << "    Force being silent and not printing any output except of errors. This will also inhibit messages "
-            "prefixed with \"init\"." << endl
-        << endl
-        << "EXAMPLES" << endl
-        << programName << " -ue" << endl
-        << "    Prints incoming USB data transfer and generated key pressed/released events." << endl
-        << endl
-        << programName << " -p" << endl
-        << "    Prints hal pin names and events distributed to HAL memory." << endl
-        << endl
-        << programName << " -Ha" << endl
-        << "    Start in HAL mode and avoid output, except of errors." << endl
-        << endl
-        << "AUTHORS" << endl
-        << "    This component was started by Raoul Rubien (github.com/rubienr) based on predecessor "
-            "device's component xhc-hb04.cc. https://github.com/machinekit/machinekit/graphs/contributors "
-            "gives you a more complete list of contributors."
-        << endl;
+            "prefixed with \"init\".\n"
+        << "\n"
+        << "EXAMPLES\n"
+        << programName << " -ue\n"
+        << "    Start in userspace mode (simulation) and prints incoming USB data transfer and generated key pressed/released events.\n"
+        << "\n"
+        << programName << " -p\n"
+        << "    Start in userspace mode (simulation) and prints HAL pin names and events distributed to HAL memory.\n"
+        << "\n"
+        << programName << " -Hn\n"
+        << "    Start in HAL mode and avoid output, except of errors.\n"
+        << "\n"
+        << "AUTHORS\n"
+        << "    This component was started by Raoul Rubien based on predecessor "
+           "device's component xhc-hb04.cc. https://github.com/machinekit/machinekit/graphs/contributors "
+           "gives you a more complete list of contributors."
+        << "\n";
 
     if (isError)
     {
@@ -148,7 +154,7 @@ bool parseFloat(const char* str, float& out)
     std::istringstream iss(str);
     if (!(iss >> out))
     {
-        std::cerr << "no valid value specified: " << str << endl;
+        std::cerr << "no valid value specified: " << str << "\n";
         return false;
     }
     return true;
@@ -172,6 +178,7 @@ int main(int argc, char** argv)
                 WhbComponent->setWaitWithTimeout(3);
                 break;
             case 'e':
+                WhbComponent->enableVerbosePendant(true);
                 WhbComponent->setEnableVerboseKeyEvents(true);
                 break;
             case 'u':
@@ -189,6 +196,7 @@ int main(int argc, char** argv)
                 break;
             case 'a':
                 WhbComponent->enableVerboseInit(true);
+                WhbComponent->enableVerbosePendant(true);
                 WhbComponent->setEnableVerboseKeyEvents(true);
                 WhbComponent->enableVerboseRx(true);
                 WhbComponent->enableVerboseTx(true);
@@ -196,6 +204,12 @@ int main(int argc, char** argv)
                 break;
             case 'c':
                 WhbComponent->enableCrcDebugging(true);
+                break;
+            case 's':
+                WhbComponent->setLeadModeSpindle();
+                break;
+            case 'f':
+                WhbComponent->setLeadModeFeed();
                 break;
             case 'n':
                 break;

--- a/src/hal/user_comps/xhc-whb04b-6/pendant-types.h
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant-types.h
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2017 Raoul Rubien (github.com/rubienr)
+   Copyright (C) 2018 Raoul Rubien (github.com/rubienr)
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public

--- a/src/hal/user_comps/xhc-whb04b-6/pendant.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant.cc
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2017 Raoul Rubien (github.com/rubienr)
+   Copyright (C) 2018 Raoul Rubien (github.com/rubienr)
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <functional>
 #include <limits>
+#include <cmath>
 
 // 3rd party includes
 
@@ -35,8 +36,6 @@
 #include "./hal.h"
 #include "./xhc-whb04b6.h"
 #include "./usb.h"
-
-using std::endl;
 
 namespace XhcWhb04b6 {
 
@@ -314,8 +313,7 @@ const MetaButtonCodes& MetaButtonsCodes::find(const KeyCode& keyCode, const KeyC
 
     if (button == buttons.end())
     {
-        std::cerr << "failed to find metaButton={ keyCode={" << keyCode << "} modifierCode={" << modifierCode << "}}"
-                  << endl;
+        std::cerr << "failed to find metaButton={ keyCode={" << keyCode << "} modifierCode={" << modifierCode << "}}\n";
     }
     assert(button != buttons.end());
 
@@ -700,7 +698,7 @@ void FeedRotaryButton::update()
     {
         auto enumValue = mContinuousKeycodeLut.find(mKey);
         assert(enumValue != mContinuousKeycodeLut.end());
-        auto second = enumValue->second;
+        auto second  = enumValue->second;
         mStepSize    = mContinuousSizeMapper.getStepSize(second);
         mIsPermitted = mContinuousSizeMapper.isPermitted(second);
     }
@@ -708,7 +706,7 @@ void FeedRotaryButton::update()
     {
         auto enumValue = mStepKeycodeLut.find(mKey);
         assert(enumValue != mStepKeycodeLut.end());
-        auto second = enumValue->second;
+        auto second  = enumValue->second;
         mStepSize    = mStepStepSizeMapper.getStepSize(second);
         mIsPermitted = mStepStepSizeMapper.isPermitted(second);
     }
@@ -797,9 +795,8 @@ std::ostream& operator<<(std::ostream& os, const Handwheel& data)
 
 const HandWheelCounters& Handwheel::counters() const
 {
-    return static_cast<const HandWheelCounters& >(
-        static_cast<Handwheel>(*this).counters()
-    );
+    Handwheel* self = const_cast<Handwheel*>(this);
+    return static_cast<const HandWheelCounters&>(self->counters());
 }
 
 // ----------------------------------------------------------------------
@@ -813,6 +810,20 @@ void Handwheel::setEnabled(bool enabled)
 HandWheelCounters& Handwheel::counters()
 {
     return mCounters;
+}
+
+// ----------------------------------------------------------------------
+
+void Handwheel::enableVerbose(bool enable)
+{
+    if (enable)
+    {
+        mWheelCout = &std::cout;
+    }
+    else
+    {
+        mWheelCout = &mDevNull;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -836,8 +847,7 @@ void Handwheel::count(int8_t delta)
 
     std::ios init(NULL);
     init.copyfmt(*mWheelCout);
-    *mWheelCout << mPrefix << "handwheel total counts " << std::setfill(' ') << std::setw(5) << mCounters
-                << endl;
+    *mWheelCout << mPrefix << "wheel  total counts " << std::setfill(' ') << std::setw(5) << mCounters << "\n";
     mWheelCout->copyfmt(init);
 }
 
@@ -1006,7 +1016,7 @@ std::ostream& operator<<(std::ostream& os, const Pendant& data)
 
     os << "{currentButtonState=" << data.currentButtonsState() << " "
        << "previousButtonState=" << data.previousButtonsState() << " "
-       << "handwheel= " << data.handWheel() << "}";
+       << "wheel= " << data.handWheel() << "}";
     return os;
 }
 
@@ -1027,19 +1037,19 @@ void Pendant::processEvent(uint8_t keyCode,
 
     if (key == KeyCodes::Buttons.codeMap.end())
     {
-        *mPendantCout << mPrefix << "failed to interpret key code keyCode={" << keyCode << "}" << endl;
+        *mPendantCout << mPrefix << "failed to interpret key code keyCode={" << keyCode << "}\n";
     }
     if (modifier == KeyCodes::Buttons.codeMap.end())
     {
-        *mPendantCout << mPrefix << "failed to interpret modifier code keyCode={" << modifierCode << "}" << endl;
+        *mPendantCout << mPrefix << "failed to interpret modifier code keyCode={" << modifierCode << "}\n";
     }
     if (axis == KeyCodes::Axis.codeMap.end())
     {
-        *mPendantCout << mPrefix << "failed to interpret axis code axisCode={" << modifierCode << "}" << endl;
+        *mPendantCout << mPrefix << "failed to interpret axis code axisCode={" << modifierCode << "}\n";
     }
     if (feed == KeyCodes::Feed.codeMap.end())
     {
-        *mPendantCout << mPrefix << "failed to interpret axis code axisCode={" << modifierCode << "}" << endl;
+        *mPendantCout << mPrefix << "failed to interpret axis code axisCode={" << modifierCode << "}\n";
     }
 
     processEvent(*key->second, *modifier->second, *axis->second, *feed->second, handWheelStepCount);
@@ -1053,12 +1063,10 @@ void Pendant::processEvent(const KeyCode& keyCode,
                            const KeyCode& rotaryButtonFeedKeyCode,
                            int8_t handWheelStepCount)
 {
-    mHal.trySetManualMode(true);
     mHandWheel.setEnabled(mHal.getIsMachineOn());
     mCurrentButtonsState.update(keyCode, modifierCode, rotaryButtonAxisKeyCode, rotaryButtonFeedKeyCode);
     mHandWheel.count(handWheelStepCount);
     mDisplay.updateData();
-    mHal.trySetManualMode(false);
 }
 
 // ----------------------------------------------------------------------
@@ -1081,6 +1089,21 @@ void Pendant::shiftButtonState()
 {
     mPreviousButtonsState = mCurrentButtonsState;
     mCurrentButtonsState.clearPressedButtons();
+}
+
+// ----------------------------------------------------------------------
+
+void Pendant::enableVerbose(bool enable)
+{
+    mHandWheel.enableVerbose(enable);
+    if (enable)
+    {
+        mPendantCout = &std::cout;
+    }
+    else
+    {
+        mPendantCout = &mDevNull;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -1115,7 +1138,7 @@ Handwheel& Pendant::handWheel()
 
 bool Pendant::onButtonPressedEvent(const MetaButtonCodes& metaButton)
 {
-    *mPendantCout << mPrefix << "button pressed  event metaButton=" << metaButton << endl;
+    *mPendantCout << mPrefix << "button pressed  event metaButton=" << metaButton << "\n";
     bool isHandled = false;
     if (metaButton == KeyCodes::Meta.reset)
     {
@@ -1154,7 +1177,7 @@ bool Pendant::onButtonPressedEvent(const MetaButtonCodes& metaButton)
     }
     else if (metaButton == KeyCodes::Meta.machine_home)
     {
-        mHal.setMachineHome(true);
+        mHal.requestMachineGoHome(true);
         isHandled = true;
     }
     else if (metaButton == KeyCodes::Meta.safe_z)
@@ -1179,6 +1202,7 @@ bool Pendant::onButtonPressedEvent(const MetaButtonCodes& metaButton)
     }
     else if (metaButton == KeyCodes::Meta.macro10)
     {
+        mHal.requestMachineHomingAll(true);
         mHal.setMacro10(true);
         isHandled = true;
     }
@@ -1281,7 +1305,7 @@ bool Pendant::onButtonPressedEvent(const MetaButtonCodes& metaButton)
 
 bool Pendant::onButtonReleasedEvent(const MetaButtonCodes& metaButton)
 {
-    *mPendantCout << mPrefix << "button released event metaButton=" << metaButton << endl;
+    *mPendantCout << mPrefix << "button released event metaButton=" << metaButton << "\n";
     bool isHandled = false;
     if (metaButton == KeyCodes::Meta.reset)
     {
@@ -1320,7 +1344,7 @@ bool Pendant::onButtonReleasedEvent(const MetaButtonCodes& metaButton)
     }
     else if (metaButton == KeyCodes::Meta.machine_home)
     {
-        mHal.setMachineHome(false);
+        mHal.requestMachineGoHome(false);
         isHandled = true;
     }
     else if (metaButton == KeyCodes::Meta.safe_z)
@@ -1345,6 +1369,7 @@ bool Pendant::onButtonReleasedEvent(const MetaButtonCodes& metaButton)
     }
     else if (metaButton == KeyCodes::Meta.macro10)
     {
+        mHal.requestMachineHomingAll(false);
         mHal.setMacro10(false);
         isHandled = true;
     }
@@ -1444,7 +1469,7 @@ bool Pendant::onButtonReleasedEvent(const MetaButtonCodes& metaButton)
 void Pendant::onAxisActiveEvent(const KeyCode& axis)
 {
     *mPendantCout << mPrefix << "axis   active   event axis=" << axis
-                  << " axisButton=" << mCurrentButtonsState.axisButton() << endl;
+                  << " axisButton=" << mCurrentButtonsState.axisButton() << "\n";
     dispatchAxisEventToHandwheel(axis, true);
     dispatchAxisEventToHal(axis, true);
     mDisplay.onAxisActiveEvent(axis);
@@ -1455,7 +1480,7 @@ void Pendant::onAxisActiveEvent(const KeyCode& axis)
 void Pendant::onAxisInactiveEvent(const KeyCode& axis)
 {
     *mPendantCout << mPrefix << "axis   inactive event axis=" << axis
-                  << " axisButton=" << mCurrentButtonsState.axisButton() << endl;
+                  << " axisButton=" << mCurrentButtonsState.axisButton() << "\n";
     dispatchAxisEventToHandwheel(axis, false);
     dispatchAxisEventToHal(axis, false);
     mDisplay.onAxisInactiveEvent(axis);
@@ -1466,7 +1491,7 @@ void Pendant::onAxisInactiveEvent(const KeyCode& axis)
 void Pendant::onFeedActiveEvent(const KeyCode& feed)
 {
     (*mPendantCout) << mPrefix << "feed   active   event feed=" << feed
-                    << " feedButton=" << mCurrentButtonsState.feedButton() << endl;
+                    << " feedButton=" << mCurrentButtonsState.feedButton() << "\n";
 
     dispatchFeedEventToHandwheel(feed, true);
     dispatchFeedValueToHal(feed);
@@ -1506,6 +1531,18 @@ void Pendant::dispatchActiveFeedToHal(const KeyCode& feed, bool isActive)
     else if (feed.code == KeyCodes::Feed.speed_1.code)
     {
         mHal.setFeedValueSelected1_0(isActive);
+    }
+    else if (feed.code == KeyCodes::Feed.percent_60.code)
+    {
+        mHal.setFeedValueSelected60(isActive);
+    }
+    else if (feed.code == KeyCodes::Feed.percent_100.code)
+    {
+        mHal.setFeedValueSelected100(isActive);
+    }
+    else if (feed.code == KeyCodes::Feed.lead.code)
+    {
+        mHal.setFeedValueSelectedLead(isActive);
     }
 }
 
@@ -1584,7 +1621,7 @@ void Pendant::dispatchFeedValueToHal()
 void Pendant::onFeedInactiveEvent(const KeyCode& feed)
 {
     *mPendantCout << mPrefix << "feed   inactive event feed=" << feed
-                  << " feedButton=" << mCurrentButtonsState.feedButton() << endl;
+                  << " feedButton=" << mCurrentButtonsState.feedButton() << "\n";
     dispatchFeedEventToHandwheel(feed, false);
     dispatchActiveFeedToHal(feed, false);
     mDisplay.onFeedInactiveEvent(feed);
@@ -1596,17 +1633,47 @@ bool Pendant::onJogDialEvent(const HandWheelCounters& counters, int8_t delta)
 {
 
     if (HandWheelCounters::CounterNameToIndex::UNDEFINED != counters.activeCounter() &&
-        counters.counts() != 0)
+        0 != counters.counts())
     {
-        *mPendantCout << mPrefix << "wheel  event " << counters.counts() << endl;
+        *mPendantCout << mPrefix << "wheel  event " << counters.counts() << "\n";
 
-        if (HandWheelCounters::CounterNameToIndex::LEAD != counters.activeCounter())
+        if (mIsLeadModeSpindle)
         {
-            mHandWheel.counters().setLeadValueLimit(
-                mHal.getFeedOverrideMinValue() * 100,
-                mHal.getFeedOverrideMaxValue() * 100);
+            if (counters.isLeadCounterActive())
+            {
+              mHandWheel.counters().setLeadValueLimit(
+                  std::numeric_limits<int32_t>::min(),
+                  std::numeric_limits<int32_t>::max());
+            }
         }
-        mHal.setJogCounts(counters);
+        else
+        {
+            if (!counters.isLeadCounterActive())
+            {
+                mHandWheel.counters().setLeadValueLimit(
+                    mHal.getFeedOverrideMinValue() * 100,
+                    mHal.getFeedOverrideMaxValue() * 100);
+            }
+        }
+
+        if (0 != delta)
+        {
+            if (counters.isLeadCounterActive() && mIsLeadModeSpindle)
+            {
+                if (delta > 0)
+                {
+                    mHal.toggleSpindleIncrease();
+                }
+                else
+                {
+                    mHal.toggleSpindleDecrease();
+                }
+            }
+            else // lead mode is feed
+            {
+                mHal.setJogCounts(counters);
+            }
+        }
         mDisplay.onJogDialEvent(counters, delta);
         return true;
     }
@@ -1691,6 +1758,20 @@ void Pendant::dispatchAxisEventToHal(const KeyCode& axis, bool isActive)
     {
         mHal.setNoAxisActive(isActive);
     }
+}
+
+// ----------------------------------------------------------------------
+
+void Pendant::setLeadModeSpindle()
+{
+    mIsLeadModeSpindle = true;
+}
+
+// ----------------------------------------------------------------------
+
+void Pendant::setLeadModeFeed()
+{
+    mIsLeadModeSpindle = false;
 }
 
 // ----------------------------------------------------------------------
@@ -1846,4 +1927,3 @@ void Display::clearData()
     mDisplayData.row3Coordinate.clear();
 }
 }
-

--- a/src/hal/user_comps/xhc-whb04b-6/pendant.h
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant.h
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2017 Raoul Rubien (github.com/rubienr)
+   Copyright (C) 2018 Raoul Rubien (github.com/rubienr)
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -24,6 +24,7 @@
 
 // system includes
 #include <type_traits>
+#include <ostream>
 #include <stdint.h>
 #include <list>
 
@@ -452,6 +453,7 @@ class Handwheel
 public:
     Handwheel(const FeedRotaryButton& feedButton, KeyEventListener* listener = nullptr);
     ~Handwheel();
+    void enableVerbose(bool enable);
     void setMode(HandWheelCounters::CounterNameToIndex mode);
     void count(int8_t delta);
     const HandWheelCounters& counters() const;
@@ -465,6 +467,7 @@ private:
     bool              mIsEnabled{false};
     const FeedRotaryButton& mFeedButton;
     KeyEventListener      * mEventListener;
+    std::ostream          mDevNull{nullptr};
     std::ostream          * mWheelCout;
     const char            * mPrefix;
 };
@@ -575,6 +578,7 @@ public:
     void updateDisplayData();
     void clearDisplayData();
 
+    void enableVerbose(bool enable);
     const ButtonsState& currentButtonsState() const;
     const ButtonsState& previousButtonsState() const;
     const Handwheel& handWheel() const;
@@ -588,17 +592,32 @@ public:
     virtual void onFeedInactiveEvent(const KeyCode& axis) override;
     virtual bool onJogDialEvent(const HandWheelCounters& counters, int8_t delta) override;
 
+    //! Sets Lead mode to spindle: Jog dial will change spindle speed.
+    //! Note: Switching Lead mode is not supported at runtime, only at start.
+    //! \sa mIsLeadModeSpindle
+    //! \sa setLeadModeFeed()
+    void setLeadModeSpindle();
+
+    //! Sets Lead mode to feed: Jog dial will change feed override.
+    //! Note: Switching Lead mode is not supported at runtime, only at start.
+    //! \sa mIsLeadModeSpindle
+    //! \sa setLeadModeSpindle()
+    void setLeadModeFeed();
+
 private:
     Hal& mHal;
     ButtonsState mPreviousButtonsState;
     ButtonsState mCurrentButtonsState;
     Handwheel    mHandWheel;
     Display      mDisplay;
+    //! if in Lead mode: if true jog wheel changes the spindle speed, changes the feed overide otherwise
+    bool         mIsLeadModeSpindle = true;
 
     float mScale;
     float mMaxVelocity;
 
     const char  * mPrefix;
+    std::ostream  mDevNull{nullptr};
     std::ostream* mPendantCout;
 
     void shiftButtonState();

--- a/src/hal/user_comps/xhc-whb04b-6/usb.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/usb.cc
@@ -35,8 +35,6 @@
 #include "./hal.h"
 #include "./xhc-whb04b6.h"
 
-using std::endl;
-
 namespace XhcWhb04b6 {
 
 
@@ -253,9 +251,9 @@ void Usb::sendDisplayData()
 
     if (mIsSimulationMode)
     {
-        *verboseTxOut << "out   0x" << outputPackageBuffer.asBlocks << endl <<
+        *verboseTxOut << "out   0x" << outputPackageBuffer.asBlocks << "\n" <<
                       std::dec << "out   size " << sizeof(outputPackageBuffer.asBlockArray) << "B " << outputPackageData
-                      << endl;
+                      << "\n";
     }
 
     for (size_t idx = 0; idx < (sizeof(outputPackageBuffer.asBlockArray) / sizeof(UsbOutPackageBlockFields)); idx++)
@@ -284,7 +282,7 @@ void Usb::sendDisplayData()
 
         if (r < 0)
         {
-            std::cerr << "transmission failed, try to reconnect ..." << endl;
+            std::cerr << "transmission failed, try to reconnect ...\n";
             setDoReconnect(true);
             return;
         }
@@ -395,7 +393,7 @@ void UsbOutPackageBlocks::init(const UsbOutPackageData* data)
     const uint8_t* d = reinterpret_cast<const uint8_t*>(data);
     block0.init(d += 0);
     block1.init(d += 7);
-    block2.init(d + 7);
+    block2.init(d += 7);
 }
 
 // ----------------------------------------------------------------------
@@ -441,13 +439,13 @@ std::ostream& operator<<(std::ostream& os, const UsbOutPackageData& data)
     bool enableMultiLine = false;
     if (enableMultiLine)
     {
-        os << std::hex << std::setfill('0') << "header       0x" << std::setw(2) << data.header << endl
+        os << std::hex << std::setfill('0') << "header       0x" << std::setw(2) << data.header << "\n"
            << "day of month   0x"
            << std::setw(2)
-           << static_cast<unsigned short>(data.seed) << endl << "status 0x" << std::setw(2)
-           << static_cast<unsigned short>(data.displayModeFlags.asByte) << endl << std::dec << "coordinate1  "
-           << data.row1Coordinate << endl << "coordinate2  " << data.row2Coordinate << endl << "coordinate3  "
-           << data.row3Coordinate << endl << "feed rate        " << data.feedRate << endl << "spindle rps      "
+           << static_cast<unsigned short>(data.seed) <<  "\nstatus 0x" << std::setw(2)
+           << static_cast<unsigned short>(data.displayModeFlags.asByte) << "\n" << std::dec << "coordinate1  "
+           << data.row1Coordinate << "\ncoordinate2  " << data.row2Coordinate << "\ncoordinate3  "
+           << data.row3Coordinate << "\nfeed rate        " << data.feedRate << "\nspindle rps      "
            << data.spindleSpeed;
     }
     else
@@ -470,12 +468,12 @@ UsbOutPackageBuffer::UsbOutPackageBuffer() :
 {
     if (false)
     {
-        std::cout << "sizeof usb data " << sizeof(UsbOutPackageData) << endl
-                  << " blocks count   " << sizeof(UsbOutPackageBlocks) / sizeof(UsbOutPackageBlockFields) << endl
-                  << " sizeof block   " << sizeof(UsbOutPackageBlockFields) << endl
-                  << " sizeof blocks  " << sizeof(UsbOutPackageBlocks) << endl
-                  << " sizeof array   " << sizeof(asBlockArray) << endl
-                  << " sizeof package " << sizeof(UsbOutPackageData) << endl;
+        std::cout << "sizeof usb data " << sizeof(UsbOutPackageData) << "\n"
+                  << " blocks count   " << sizeof(UsbOutPackageBlocks) / sizeof(UsbOutPackageBlockFields) << "\n"
+                  << " sizeof block   " << sizeof(UsbOutPackageBlockFields) << "\n"
+                  << " sizeof blocks  " << sizeof(UsbOutPackageBlocks) << "\n"
+                  << " sizeof array   " << sizeof(asBlockArray) << "\n"
+                  << " sizeof package " << sizeof(UsbOutPackageData) << "\n";
     }
     assert(sizeof(UsbOutPackageBlocks) == sizeof(asBlockArray));
     size_t blocksCount = sizeof(UsbOutPackageBlocks) / sizeof(UsbOutPackageBlockFields);
@@ -571,7 +569,7 @@ void Usb::onUsbDataReceived(struct libusb_transfer* transfer)
                                   << std::setw(2)
                                   << static_cast<unsigned short>(Usb::ConstantPackages.sleepPackage.header)
                                   << " but got " << std::hex << std::setfill('0') << std::setw(2)
-                                  << static_cast<unsigned short>(inputPackageBuffer.asFields.header) << endl;
+                                  << static_cast<unsigned short>(inputPackageBuffer.asFields.header) << "\n";
                     verboseTxOut->copyfmt(init);
                 }
 
@@ -594,7 +592,7 @@ void Usb::onUsbDataReceived(struct libusb_transfer* transfer)
                         struct timeval now;
                         gettimeofday(&now, nullptr);
                         *verboseTxOut << "event going to sleep: device was idle for "
-                                      << (now.tv_sec - sleepState.mLastWakeupTimestamp.tv_sec) << " seconds" << endl;
+                                      << (now.tv_sec - sleepState.mLastWakeupTimestamp.tv_sec) << " seconds\n";
                     }
                 }
                     // on regular package
@@ -608,8 +606,7 @@ void Usb::onUsbDataReceived(struct libusb_transfer* transfer)
                             struct timeval now;
                             gettimeofday(&now, nullptr);
                             *verboseTxOut << "woke up: device was sleeping for "
-                                          << (now.tv_sec - sleepState.mLastWakeupTimestamp.tv_sec) << " seconds"
-                                          << endl;
+                                          << (now.tv_sec - sleepState.mLastWakeupTimestamp.tv_sec) << " seconds\n";
                         }
                         gettimeofday(&sleepState.mLastWakeupTimestamp, nullptr);
                     }
@@ -620,7 +617,7 @@ void Usb::onUsbDataReceived(struct libusb_transfer* transfer)
             else
             {
                 std::cerr << "received unexpected package size: expected=" << (transfer->actual_length) << ", current="
-                          << expectedPackageSize << endl;
+                          << expectedPackageSize << "\n";
             }
 
             if (mIsRunning)
@@ -645,12 +642,12 @@ void Usb::onUsbDataReceived(struct libusb_transfer* transfer)
         case (LIBUSB_TRANSFER_NO_DEVICE):
         case (LIBUSB_TRANSFER_OVERFLOW):
         case (LIBUSB_TRANSFER_ERROR):
-            std::cerr << "transfer error: " << transfer->status << endl;
+            std::cerr << "transfer error: " << transfer->status << "\n";
             requestTermination();
             break;
 
         default:
-            std::cerr << "unknown transfer status: " << transfer->status << endl;
+            std::cerr << "unknown transfer status: " << transfer->status << "\n";
             requestTermination();
             break;
     }
@@ -719,17 +716,17 @@ bool Usb::init()
             sleep(1);
         }
         setDoReconnect(false);
-        *verboseInitOut << " done" << endl;
+        *verboseInitOut << " done\n";
     }
 
     *verboseInitOut << "init  usb context ...";
     int r = libusb_init(&context);
     if (r != 0)
     {
-        std::cerr << endl << "failed to initialize usb context" << endl;
+        std::cerr << "\nfailed to initialize usb context\n";
         return false;
     }
-    *verboseInitOut << " ok" << endl;
+    *verboseInitOut << " ok\n";
 
     libusb_log_level logLevel = LIBUSB_LOG_LEVEL_INFO;
     //logLevel = LIBUSB_LOG_LEVEL_DEBUG;
@@ -758,7 +755,7 @@ bool Usb::init()
         ssize_t devicesCount = libusb_get_device_list(context, &devicesReference);
         if (devicesCount < 0)
         {
-            std::cerr << endl << "failed to get device list" << endl;
+            std::cerr << "\nfailed to get device list\n";
             return false;
         }
 
@@ -773,15 +770,15 @@ bool Usb::init()
                 *verboseInitOut << "." << std::flush;
                 if ((mWaitSecs--) <= 0)
                 {
-                    std::cerr << endl << "timeout exceeded, exiting" << endl;
+                    std::cerr << "\ntimeout exceeded, exiting\n";
                     return false;
                 }
             }
             sleep(1);
         }
     } while (!isDeviceOpen() && mIsRunning);
-    *verboseInitOut << " ok" << endl
-                    << "init  " << mName << " device found" << endl;
+    *verboseInitOut << " ok\n"
+                    << "init  " << mName << " device found\n";
 
     if (isDeviceOpen())
     {
@@ -790,20 +787,20 @@ bool Usb::init()
         {
             int r = libusb_detach_kernel_driver(deviceHandle, 0);
             assert(0 == r);
-            *verboseInitOut << " ok" << endl;
+            *verboseInitOut << " ok\n";
         }
         else
         {
-            *verboseInitOut << " already detached" << endl;
+            *verboseInitOut << " already detached\n";
         }
         *verboseInitOut << "init  claiming interface ...";
         int r = libusb_claim_interface(deviceHandle, 0);
         if (r != 0)
         {
-            std::cerr << endl << "failed to claim interface" << endl;
+            std::cerr << "\nfailed to claim interface\n";
             return false;
         }
-        *verboseInitOut << " ok" << endl;
+        *verboseInitOut << " ok\n";
     }
     return true;
 }

--- a/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.cc
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2017 Raoul Rubien (github.com/rubienr)
+   Copyright (C) 2018 Raoul Rubien (github.com/rubienr)
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -31,8 +31,6 @@
 // local library includes
 
 // local includes
-
-using std::endl;
 
 namespace XhcWhb04b6 {
 
@@ -86,7 +84,7 @@ void XhcWhb04b6Component::printCrcDebug(const UsbInPackage& inPackage, const Usb
         }
         else
         {
-            *mRxCout << "warn  checksum error" << endl;
+            *mRxCout << "warn  checksum error\n";
         }
         mRxCout->copyfmt(init);
         return;
@@ -110,16 +108,16 @@ void XhcWhb04b6Component::printCrcDebug(const UsbInPackage& inPackage, const Usb
 
     if (mIsCrcDebuggingEnabled)
     {
-        *mRxCout << endl;
+        *mRxCout << "\n";
         *mRxCout << "0x key " << std::setw(8) << static_cast<unsigned short>(inPackage.buttonKeyCode1)
                  << " random " << std::setw(8) << static_cast<unsigned short>(inPackage.randomByte)
                  << " crc " << std::setw(8) << static_cast<unsigned short>(inPackage.crc)
-                 << " delta " << std::setw(8) << static_cast<unsigned short>(delta.to_ulong()) << endl;
+                 << " delta " << std::setw(8) << static_cast<unsigned short>(delta.to_ulong()) << "\n";
 
         *mRxCout << "0b key " << buttonKeyCode
                  << " random " << random
                  << " crc " << crc
-                 << " delta " << delta << endl;
+                 << " delta " << delta << "\n";
     }
 
     //! \brief On button pressed checksum calculation.
@@ -138,18 +136,18 @@ void XhcWhb04b6Component::printCrcDebug(const UsbInPackage& inPackage, const Usb
 
     if (mIsCrcDebuggingEnabled)
     {
-        *mRxCout << endl
-                 << "~seed                  " << nonSeed << endl
-                 << "random                 " << random << endl
-                 << "                       -------- &" << endl
-                 << "~seed & random         " << nonSeedAndRandom << endl
-                 << "key                    " << buttonKeyCode << endl
-                 << "                       -------- ^" << endl
+        *mRxCout << "\n"
+                 << "~seed                  " << nonSeed << "\n"
+                 << "random                 " << random << "\n"
+                 << "                       -------- &\n"
+                 << "~seed & random         " << nonSeedAndRandom << "\n"
+                 << "key                    " << buttonKeyCode << "\n"
+                 << "                       -------- ^\n"
                  << "key ^ (~seed & random) " << keyXorNonSeedAndRandom
                  << " = calculated delta " << std::setw(2)
                  << static_cast<unsigned short>(keyXorNonSeedAndRandom.to_ulong())
                  << " vs " << std::setw(2) << static_cast<unsigned short>(delta.to_ulong())
-                 << ((keyXorNonSeedAndRandom == delta) ? " OK" : " FAIL") << endl
+                 << ((keyXorNonSeedAndRandom == delta) ? " OK" : " FAIL") << "\n"
                  << "calculated crc         " << calculatedCrcBitset << " " << std::setw(2) << calculatedCrc << " vs "
                  << std::setw(2)
                  << expectedCrc << ((isValid) ? "                    OK" : "                    FAIL")
@@ -189,7 +187,7 @@ void XhcWhb04b6Component::onInputDataReceived(const UsbInPackage& inPackage)
     *mRxCout << " => ";
     printInputData(inPackage);
     printCrcDebug(inPackage, mUsb.getOutputPackageData());
-    *mRxCout << endl;
+    *mRxCout << "\n";
 
     uint8_t keyCode      = inPackage.buttonKeyCode1;
     uint8_t modifierCode = inPackage.buttonKeyCode2;
@@ -251,11 +249,11 @@ void XhcWhb04b6Component::requestTermination(int signal)
 {
     if (signal >= 0)
     {
-        *mInitCout << "termination requested upon signal number " << signal << " ..." << endl;
+        *mInitCout << "termination requested upon signal number " << signal << " ...\n";
     }
     else
     {
-        *mInitCout << "termination requested ... " << endl;
+        *mInitCout << "termination requested ...\n";
     }
     mUsb.requestTermination();
     mIsRunning = false;
@@ -309,18 +307,20 @@ XhcWhb04b6Component::XhcWhb04b6Component() :
                  MetaButtonCodes(mKeyCodes.Buttons.undefined, mKeyCodes.Buttons.undefined)
     },
     mUsb(mName, *this, mHal),
-    mTxCout(&mDevNull),
+    //mTxCout(&mDevNull),
     mRxCout(&mDevNull),
-    mKeyEventCout(&mDevNull),
-    mHalInitCout(&mDevNull),
+    //mKeyEventCout(&mDevNull),
+    //mHalInitCout(&mDevNull),
     mInitCout(&mDevNull),
     packageReceivedEventReceiver(*this),
     mPendant(mHal, mUsb.getOutputPackageData())
 {
     setSimulationMode(true);
+    enableVerbosePendant(false);
     enableVerboseRx(false);
     enableVerboseTx(false);
     enableVerboseInit(false);
+    setEnableVerboseKeyEvents(false);
     enableVerboseHal(false);
 }
 
@@ -455,7 +455,7 @@ int XhcWhb04b6Component::run()
 {
     if (mHal.isSimulationModeEnabled())
     {
-        *mInitCout << "init  starting in simulation mode" << endl;
+        *mInitCout << "init  starting in simulation mode\n";
     }
 
     bool isHalReady = false;
@@ -491,10 +491,10 @@ int XhcWhb04b6Component::run()
             *mInitCout << "init  enabling reception ...";
             if (!enableReceiveAsyncTransfer())
             {
-                std::cerr << endl << "failed to enable reception" << endl;
+                std::cerr << "\nfailed to enable reception\n";
                 return EXIT_FAILURE;
             }
-            *mInitCout << " ok" << endl;
+            *mInitCout << " ok\n";
         }
         process();
         teardownUsb();
@@ -572,7 +572,7 @@ void XhcWhb04b6Component::process()
         updateDisplay();
 
         mHal.setIsPendantConnected(false);
-        *mInitCout << "connection lost, cleaning up" << endl;
+        *mInitCout << "connection lost, cleaning up\n";
         struct timeval tv;
         tv.tv_sec  = 1;
         tv.tv_usec = 0;
@@ -595,6 +595,13 @@ void XhcWhb04b6Component::teardownUsb()
 
 // ----------------------------------------------------------------------
 
+void XhcWhb04b6Component::enableVerbosePendant(bool enable)
+{
+    mPendant.enableVerbose(enable);
+}
+
+// ----------------------------------------------------------------------
+
 void XhcWhb04b6Component::enableVerboseRx(bool enable)
 {
     mUsb.enableVerboseRx(enable);
@@ -613,30 +620,29 @@ void XhcWhb04b6Component::enableVerboseRx(bool enable)
 void XhcWhb04b6Component::enableVerboseTx(bool enable)
 {
     mUsb.enableVerboseTx(enable);
-    if (enable)
+    /*if (enable)
     {
         mTxCout = &std::cout;
     }
     else
     {
         mTxCout = &mDevNull;
-    }
+    }*/
 }
 
 // ----------------------------------------------------------------------
 
 void XhcWhb04b6Component::enableVerboseHal(bool enable)
 {
-    mHal.setEnableVerbose(enable);
-
-    if (enable)
+    mHal.enableVerbose(enable);
+    /*if (enable)
     {
         mHalInitCout = &std::cout;
     }
     else
     {
         mHalInitCout = &mDevNull;
-    }
+    }*/
 }
 
 // ----------------------------------------------------------------------
@@ -701,14 +707,14 @@ bool XhcWhb04b6Component::isSimulationModeEnabled() const
 void XhcWhb04b6Component::setEnableVerboseKeyEvents(bool enable)
 {
     mUsb.enableVerboseRx(enable);
-    if (enable)
+    /*if (enable)
     {
         mKeyEventCout = &std::cout;
     }
     else
     {
         mKeyEventCout = &mDevNull;
-    }
+    }*/
 }
 
 // ----------------------------------------------------------------------
@@ -717,4 +723,19 @@ void XhcWhb04b6Component::enableCrcDebugging(bool enable)
 {
     mIsCrcDebuggingEnabled = enable;
 }
+
+// ----------------------------------------------------------------------
+
+void XhcWhb04b6Component::setLeadModeSpindle()
+{
+    mPendant.setLeadModeSpindle();
+}
+
+// ----------------------------------------------------------------------
+
+void XhcWhb04b6Component::setLeadModeFeed()
+{
+    mPendant.setLeadModeFeed();
+}
+
 }

--- a/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.h
+++ b/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.h
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2017 Raoul Rubien (github.com/rubienr)
+   Copyright (C) 2018 Raoul Rubien (github.com/rubienr)
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -67,6 +67,7 @@ public:
     bool isSimulationModeEnabled() const;
     void setSimulationMode(bool enableSimulationMode);
     void setEnableVerboseKeyEvents(bool enable);
+    void enableVerbosePendant(bool enable);
     void enableVerboseRx(bool enable);
     void enableVerboseTx(bool enable);
     void enableVerboseHal(bool enable);
@@ -74,7 +75,8 @@ public:
     void enableCrcDebugging(bool enable);
     void setWaitWithTimeout(uint8_t waitSecs = 3);
     void printCrcDebug(const UsbInPackage& inPackage, const UsbOutPackageData& outPackageBuffer) const;
-    void offerHalMemory();
+    void setLeadModeSpindle();
+    void setLeadModeFeed();
 
 private:
     const char* mName;
@@ -85,10 +87,10 @@ private:
     bool                  mIsRunning{false};
     bool                  mIsSimulationMode{false};
     std::ostream          mDevNull{nullptr};
-    std::ostream             * mTxCout;
+    //std::ostream             * mTxCout;
     std::ostream             * mRxCout;
-    std::ostream             * mKeyEventCout;
-    std::ostream             * mHalInitCout;
+    //std::ostream             * mKeyEventCout;
+    //std::ostream             * mHalInitCout;
     std::ostream             * mInitCout;
     OnUsbInputPackageListener& packageReceivedEventReceiver;
     bool    mIsCrcDebuggingEnabled{false};


### PR DESCRIPTION
**Implemented new Lead mode: Lead + jogwheel manipulates spindle speed.**

In Lead mode, the jog dial operated the feed override. Now it is possible to switch the Lead mode to operate the spindle speed. This is done via command line switch `-f` (feed override) or `-s` (spindle speed).

**How it works**
1. start the xhc-whb04b-6 component with `-s` switch
1. turn spindle on
1. move right hand rotary button to Lead position
1. turn jogwheel: this will increase/decrease the spindle speed

**Other fixes**
* Fixed unreliable switching to modes manual/auto/mdi: Mode switch is requested upon button press depending whether the button executes a mdi command (mdi mode) or a manual command (manual mode) or operates in automatic mode (auto mode).