### PR TITLE
scripts/build_docker:  run `docker pull`

### DIFF
--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -166,7 +166,9 @@ case $CMD in
 esac
 
 ###########################################################
-# Update container image with custom /etc/passwd
+# Update new container image and add custom /etc/passwd
+
+docker pull ${IMAGE}:${TAG}
 
 if test ${UID_GID/:*/} != 1000; then
     echo "Updating /etc/passwd for UID $TRAVIS_UID" >&2


### PR DESCRIPTION
Ensure that the Docker image isn't stale by running `docker pull`.

Just now, even though the CI images on Docker hub are refreshed (see machinekit/machinekit-hal#163), the Jenkins run on PR #1426 failed because that PR depends on some cgroups-related packages that aren't in the old CI images.  This PR fixes that kind of issue.