### PR TITLE
Fix linuxcnc script bug

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -594,7 +594,7 @@ function Cleanup() {
 
     for i in `seq 10`; do
         # (the one component is the halcmd itself)
-        if [ `$HALCMD list comp | wc -w` = 1 ]; then break; fi
+        if [ "`$HALCMD list comp | wc -w`" = 1 ]; then break; fi
         sleep .2
     done
 


### PR DESCRIPTION
Here's a little patch that could save someone else time someday when `linuxcnc` exits ungracefully.

-----

When things are really broken, `$HALCMD list comp` may output nothing,
yielding the error:

    /usr/bin/linuxcnc: line 582: [: =: unary operator expected