### PR TITLE
Fix logging problems

### DIFF
--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -1229,9 +1229,8 @@ int loadrt(const int use_halmutex, char *mod_path, char *args[])
 
     retval = rtapi_loadrt(rtapi_instance, mod_path, (const char **)args);
     if ( retval != 0 ) {
-	halcmd_error("insmod failed, returned %d:\n%s\n"
-		     "See %s for more information.\n",
-		     retval, rtapi_rpcerror(), logpath);
+	halcmd_error("insmod failed, returned %d:\n%s\n",
+		     retval, rtapi_rpcerror());
 	return -1;
     }
 

--- a/src/rtapi/rtapi_app.cc
+++ b/src/rtapi/rtapi_app.cc
@@ -1711,7 +1711,7 @@ int main(int argc, char **argv)
     }
 
     openlog_async(argv[0], option, LOG_LOCAL1);
-    // setlogmask_async(LOG_UPTO(LOG_DEBUG));
+    setlogmask_async(LOG_UPTO(LOG_DEBUG));
     // max out async syslog buffers for slow system in debug mode
     tunelog_async(99,10);
 

--- a/src/rtapi/rtapi_support.c
+++ b/src/rtapi/rtapi_support.c
@@ -97,7 +97,7 @@ int vs_ringlogfv(const msg_level_t level,
 
     if (get_msg_level() == RTAPI_MSG_NONE)
 	return 0;
-    if (level >= get_msg_level())
+    if (level > get_msg_level())
 	return 0;
 
     msg.hdr.origin = origin;
@@ -211,8 +211,13 @@ static int set_msg_level(int new_level)
     }
     return old_level;
 #else
-    old_level = ulapi_msg_level;
-    ulapi_msg_level = new_level;
+    if (global_data) {
+	old_level = global_data->user_msg_level;
+        global_data->user_msg_level = new_level;
+    } else {
+        old_level = ulapi_msg_level;
+        ulapi_msg_level = new_level;
+    }
     return old_level;
 #endif
 }
@@ -234,7 +239,7 @@ void rtapi_print(const char *fmt, ...) {
     va_list args;
 
     va_start(args, fmt);
-    rtapi_msg_handler(RTAPI_MSG_ALL, fmt, args);
+    rtapi_msg_handler(RTAPI_MSG_ERR, fmt, args);
     va_end(args);
 }
 


### PR DESCRIPTION
The big problem was when `DEBUG=1`, errors weren't being logged; for
example, in `sampler.c`, the "SAMPLER: ERROR: depth too large" message
wasn't printed, and the only information in the logs was the
mysterious "rtapi_app_main(sampler): -12 Cannot allocate memory".

This patch also reverts a line commented out in 2694a4b1, causes
`rtapi_print()` to always print, and fixes `set_msg_level()` for
ULAPI.