### PR TITLE
Silence compiler warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -388,7 +388,7 @@ endif
 
 BASE_CXXFLAGS:= $(INCLUDE) $(CXXFLAGS) \
 		$(CK_CFLAGS) \
-		$(DEBUG) $(OPT) \
+		$(DEBUG) $(DPKG_CFLAGS) $(OPT) \
 		$(PROFILE_CFLAGS) \
 		 -DGIT_BUILD_SHA=\"'$(GIT_BUILD_SHA)'\" \
 		$(ARCH_CFLAGS)

--- a/src/hal/user_comps/xhc-whb04b-6/Submakefile
+++ b/src/hal/user_comps/xhc-whb04b-6/Submakefile
@@ -9,7 +9,7 @@ XHC_WHB04B6_SRC = hal/user_comps/xhc-whb04b-6/hal.cc \
                   hal/user_comps/xhc-whb04b-6/main.cc
 
 XHC_WHB04B6_DEBUG = -g -funwind-tables
-XHC_WHB04B6_CFLAGS += $(LIBUSB10_CFLAGS) $(XHC_WHB04B6_DEBUG) -Wall -pedantic
+XHC_WHB04B6_CFLAGS += $(LIBUSB10_CFLAGS) $(XHC_WHB04B6_DEBUG) -Wall
 XHC_WHB04B6_LIBS = -lstdc++ $(LIBUSB10_LIBS) $(PROTOBUF_LIBS)
 
 $(call TOOBJSDEPS, $(XHC_WHB04B6_SRC)) : EXTRAFLAGS += $(XHC_WHB04B6_CFLAGS)

--- a/src/rtapi/rtapi.h
+++ b/src/rtapi/rtapi.h
@@ -498,7 +498,7 @@ typedef struct {
     int pid;                 // if User RT or ULAPI; 0 for kernel
     int level;               // as passed in to rtapi_print_msg()
     char tag[TAGSIZE];       // eg program or module name
-    char buf[0];             // actual message
+    char buf[];              // actual message
 } rtapi_msgheader_t;
 
 #define rtapi2syslog(level) (level+2)

--- a/src/rtapi/rtapi_global.h
+++ b/src/rtapi/rtapi_global.h
@@ -126,7 +126,7 @@ typedef struct {
     struct rtapi_heap heap;
     //size_t heap_size;
 
-    unsigned char arena[0] __attribute__((aligned(RTAPI_CACHELINE)));
+    unsigned char arena[] __attribute__((aligned(RTAPI_CACHELINE)));
 
 } global_data_t;
 

--- a/src/rtapi/rtapi_io.h
+++ b/src/rtapi/rtapi_io.h
@@ -68,7 +68,7 @@ static inline unsigned char rtapi_inb(unsigned int port)
 static inline void rtapi_outw(unsigned short word, unsigned int port)
 {
     outw(word,port);
-};
+}
 
 /** 'rtapi_inw() gets a word from 'port'.  Returns the word.  May
     be called from init/cleanup code, and from within realtime tasks.


### PR DESCRIPTION
Warnings in C++ sources aren't halting build when
`DPKG_CFLAGS=-Werror` set.  See mk-cnc issue 45.

https://github.com/machinekit/machinekit-cnc/issues/45
