### PR TITLE
HAL: mDNS Service Announcement Name Normalization Wait to Merge

### DIFF
--- a/lib/python/machinekit/service.py
+++ b/lib/python/machinekit/service.py
@@ -3,6 +3,7 @@ import avahi
 import dbus
 import os
 import uuid
+import re
 
 
 class ZeroconfService(object):
@@ -12,7 +13,7 @@ class ZeroconfService(object):
 
     def __init__(
         self,
-        name,
+        headline,
         port,
         stype="_http._tcp",
         subtype=None,
@@ -23,7 +24,7 @@ class ZeroconfService(object):
     ):
         if text is None:
             text = []
-        self.name = name
+        self.headline = headline
         self.stype = stype
         self.domain = domain
         self.host = host
@@ -48,7 +49,7 @@ class ZeroconfService(object):
         # insert fqdn in announcement
         fqdn = str(server.GetHostNameFqdn())
         text = [t % {'fqdn': fqdn} for t in self.text]
-        name = self.name % {'fqdn': fqdn}
+        headline = self.headline % {'fqdn': fqdn}
 
         iface = avahi.IF_UNSPEC
         if self.loopback:
@@ -58,7 +59,7 @@ class ZeroconfService(object):
             iface,
             avahi.PROTO_INET,
             dbus.UInt32(0),
-            name,
+            headline,
             self.stype,
             self.domain,
             self.host,
@@ -71,7 +72,7 @@ class ZeroconfService(object):
                 iface,
                 avahi.PROTO_INET,
                 dbus.UInt32(0),
-                name,
+                headline,
                 self.stype,
                 self.domain,
                 self.subtype,
@@ -89,6 +90,24 @@ class Service(object):
     A simple class to publish a Machinekit network service using zeroconf.
     """
 
+    # See https://gist.github.com/bgusach/a967e0587d6e01e889fd1d776c5f3729
+    def __multi_replace(self, string, replacements, ignore_case=False):
+        """
+        Given a string and a dict, replaces occurrences of the dict keys found in the 
+        string, with their corresponding values. The replacements will occur in "one pass", 
+        i.e. there should be no clashes.
+        :param str string: string to perform replacements on
+        :param dict replacements: replacement dictionary {str_to_find: str_to_replace_with}
+        :param bool ignore_case: whether to ignore case when looking for matches
+        :rtype: str the replaced string
+        """
+        if ignore_case:
+            replacements = dict((pair[0].lower(), pair[1]) for pair in sorted(replacements.iteritems()))
+        rep_sorted = sorted(replacements, key=lambda s: (len(s), s), reverse=True)
+        rep_escaped = [re.escape(replacement) for replacement in rep_sorted]
+        pattern = re.compile("|".join(rep_escaped), re.I if ignore_case else 0)
+        return pattern.sub(lambda match: replacements[match.group(0).lower() if ignore_case else match.group(0)], string) 
+
     def __init__(
         self,
         type_,
@@ -97,6 +116,8 @@ class Service(object):
         port,
         name=None,
         host=None,
+        announce_format=None,
+        headline=None,
         loopback=False,
         debug=False,
     ):
@@ -105,6 +126,7 @@ class Service(object):
         self.type = type_
         self.port = port
         self.name = name
+        self.headline = headline
         self.host = host
         self.loopback = loopback
         self.debug = debug
@@ -112,9 +134,24 @@ class Service(object):
         self.stype = '_machinekit._tcp'
         self.subtype = '_%s._sub.%s' % (self.type, self.stype)
 
+        if announce_format is None:
+            announce_format = 'MK $SRVNAME on $HOSTNAME'
+
         if name is None:
-            pid = os.getpid()
-            self.name = '%s service on %s pid %i' % (self.type.title(), self.host, pid)
+            self.name = self.type.title()
+
+        formatdict = {
+            "$MKUUID" : self.svc_uuid,
+            "$HOSTNAME" : self.host,
+            "$SRVNAME" : self.name,
+            "$SRVTYPE" : self.type
+        }
+
+        if headline is None:
+            self.headline = self.__multi_replace(announce_format, formatdict, True)
+
+        # Truncate the headline to fit in the DNS length limit
+        self.headline = self.headline[:63]
 
         me = uuid.uuid1()
         self.status_txtrec = [
@@ -132,7 +169,7 @@ class Service(object):
             )
 
         self.statusService = ZeroconfService(
-            self.name,
+            self.headline,
             self.port,
             stype=self.stype,
             subtype=self.subtype,

--- a/scripts/machinekit.ini.tmpl.in
+++ b/scripts/machinekit.ini.tmpl.in
@@ -99,8 +99,8 @@ REMOTE=0
 #
 # Valid key values for subsitution at publication are:
 # $MKUUID - The MKUUID specified above
-# $HOSTNAME - The instance hostname reported by avahi
-# $SRVNAME - The pretty name of the service (HAL RCOMP, Launcher, ...)
+# $HOSTNAME - The instance fully qualified domain name
+# $SRVNAME - The pretty name of the service (HAL RComp, Launcher, ...)
 # $SRVTYPE - The type of service published (launcher, status, ...)
 #
 # An example using MKUUID instead of hostname:

--- a/scripts/machinekit.ini.tmpl.in
+++ b/scripts/machinekit.ini.tmpl.in
@@ -89,8 +89,23 @@ REMOTE=0
 #ANNOUNCE_IPV4=1
 #ANNOUNCE_IPV6=1
 
-
-
+# DNS records announcing services are normalized for clarity, and to avoid
+# accidental collisions in the local domain between multiple instances.
+#
+# ANNOUNCE_FORMAT is prepended to the standard machinekit service type
+# designation. The full DNS record announced in the domain is:
+#
+# ANNOUNCE_FORMAT._machinekit._tcp.local.
+#
+# Valid key values for subsitution at publication are:
+# $MKUUID - The MKUUID specified above
+# $HOSTNAME - The instance hostname reported by avahi
+# $SRVNAME - The pretty name of the service (HAL RCOMP, Launcher, ...)
+# $SRVTYPE - The type of service published (launcher, status, ...)
+#
+# An example using MKUUID instead of hostname:
+# ANNOUNCE_FORMAT="MK $SRVTYPE [$MKUUID]"
+ANNOUNCE_FORMAT="MK $SRVNAME on $HOSTNAME"
 
 
 

--- a/src/machinetalk/haltalk/haltalk_main.cc
+++ b/src/machinetalk/haltalk/haltalk_main.cc
@@ -176,7 +176,7 @@ zmq_init(htself_t *self)
     if (mk_bindsocket(np, ms))
 	return -1;
     assert(ms->port > -1);
-    if (mk_announce(np, ms, "HAL Group service", NULL))
+    if (mk_announce(np, ms, "HAL Group", NULL))
 	return -1;
     rtapi_print_msg(RTAPI_MSG_DBG, "%s: talking HALGroup on '%s'",
 		    conf.progname, ms->announced_uri);
@@ -192,7 +192,7 @@ zmq_init(htself_t *self)
     if (mk_bindsocket(np, ms))
 	return -1;
     assert(ms->port > -1);
-    if (mk_announce(np, ms, "HAL Rcomp service", NULL))
+    if (mk_announce(np, ms, "HAL Rcomp", NULL))
 	return -1;
     rtapi_print_msg(RTAPI_MSG_DBG, "%s: talking HALRcomp on '%s'",
 		    conf.progname, ms->announced_uri);
@@ -208,7 +208,7 @@ zmq_init(htself_t *self)
     if (mk_bindsocket(np, ms))
 	return -1;
     assert(ms->port > -1);
-    if (mk_announce(np, ms, "HAL Rcommand service", NULL))
+    if (mk_announce(np, ms, "HAL Rcommand", NULL))
 	return -1;
     rtapi_print_msg(RTAPI_MSG_DBG, "%s: talking HALComand on '%s'",
 		    conf.progname, ms->announced_uri);

--- a/src/machinetalk/include/mk-service.hh
+++ b/src/machinetalk/include/mk-service.hh
@@ -28,6 +28,7 @@ typedef struct {
     char     *process_uuid;     // server instance (this process)
     uuid_t   svc_uuid;          // binary forms of the above
     uuid_t   proc_uuid;
+    const char *fqdn;
     const char *hostname;       // without domain suffix
 
     // filled in by mk_getnetopts() by inspecting $MACHINEKIT_INI:
@@ -40,6 +41,9 @@ typedef struct {
     // handling of mDNS announcements:
     int announce_ipv4;
     int announce_ipv6;
+
+    // Formatting of mDNS announcements:
+    const char *announce_format;
 } mk_netopts_t;
 
 // per-czmq-socket of a daemon:

--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -58,10 +58,11 @@ class CustomFTPHandler(FTPHandler):
 
 class FileService(threading.Thread):
     def __init__(
-        self, ini_file=None, host='', svc_uuid=None, loopback=False, debug=False
+        self, ini_file=None, host='', announce_format=None, svc_uuid=None, loopback=False, debug=False
     ):
         self.debug = debug
         self.host = host
+        self.announce_format=announce_format
         self.loopback = loopback
         self.shutdown = threading.Event()
         self.running = False
@@ -85,6 +86,7 @@ class FileService(threading.Thread):
             dsn=self.file_dsname,
             port=self.file_port,
             host=self.host,
+            announce_format=self.announce_format,
             loopback=self.loopback,
             debug=self.debug,
         )
@@ -417,6 +419,7 @@ class LinuxCNCWrapper(object):
         self,
         context,
         host='',
+        announce_format=None,
         loopback=False,
         ini_file=None,
         svc_uuid=None,
@@ -426,6 +429,7 @@ class LinuxCNCWrapper(object):
     ):
         self.debug = debug
         self.host = host
+        self.announce_format=announce_format
         self.loopback = loopback
         self.ping_interval = ping_interval
         self.shutdown = threading.Event()
@@ -601,6 +605,7 @@ class LinuxCNCWrapper(object):
             dsn=self.status_dsname,
             port=self.status_port,
             host=self.host,
+            announce_format=self.announce_format,
             loopback=self.loopback,
             debug=self.debug,
         )
@@ -610,6 +615,7 @@ class LinuxCNCWrapper(object):
             dsn=self.error_dsname,
             port=self.error_port,
             host=self.host,
+            announce_format=self.announce_format,
             loopback=self.loopback,
             debug=self.debug,
         )
@@ -619,6 +625,7 @@ class LinuxCNCWrapper(object):
             dsn=self.command_dsname,
             port=self.command_port,
             host=self.host,
+            announce_format=self.announce_format,
             loopback=self.loopback,
             debug=self.debug,
         )
@@ -628,15 +635,18 @@ class LinuxCNCWrapper(object):
             dsn=self.preview_dsname,
             port=self.preview_port,
             host=self.host,
+            announce_format=self.announce_format,
             loopback=self.loopback,
             debug=self.debug,
         )
         self.previewstatus_service = service.Service(
+            name='Preview Status',
             type_='previewstatus',
             svc_uuid=svc_uuid,
             dsn=self.previewstatus_dsname,
             port=self.previewstatus_port,
             host=self.host,
+            announce_format=self.announce_format,
             loopback=self.loopback,
             debug=self.debug,
         )
@@ -2617,6 +2627,8 @@ def main():
     mki = configparser.ConfigParser()
     mki.read(mkini)
     mk_uuid = mki.get("MACHINEKIT", "MKUUID")
+    aformat = mki.has_option("MACHINEKIT", "ANNOUNCE_FORMAT") and \
+        mki.get("MACHINEKIT", "ANNOUNCE_FORMAT") or None
     remote = mki.getint("MACHINEKIT", "REMOTE")
 
     if remote == 0:
@@ -2641,6 +2653,7 @@ def main():
             ini_file=ini_file,
             svc_uuid=mk_uuid,
             host=hostname,
+            announce_format=aformat,
             loopback=(not remote),
             debug=debug,
         )
@@ -2649,6 +2662,7 @@ def main():
         mkwrapper = LinuxCNCWrapper(
             context,
             host=hostname,
+            announce_format=aformat,
             loopback=(not remote),
             ini_file=ini_file,
             svc_uuid=mk_uuid,

--- a/src/machinetalk/videoserver/videoserver.py
+++ b/src/machinetalk/videoserver/videoserver.py
@@ -34,11 +34,12 @@ class VideoDevice(object):
 
 
 class VideoServer(threading.Thread):
-    def __init__(self, inifile, host='', loopback=False, svc_uuid=None, debug=False):
+    def __init__(self, inifile, host='', loopback=False, announce_format=None, svc_uuid=None, debug=False):
         threading.Thread.__init__(self)
         self.inifile = inifile
         self.host = host
         self.loopback = loopback
+        self.announce_format=announce_format
         self.svc_uuid = svc_uuid
         self.debug = debug
 
@@ -123,6 +124,7 @@ class VideoServer(threading.Thread):
                 dsn=video_device.dsname,
                 port=video_device.port,
                 host=self.host,
+                announce_format=self.announce_format,
                 loopback=self.loopback,
                 debug=self.debug,
             )
@@ -180,6 +182,8 @@ def main():
     mki = configparser.ConfigParser()
     mki.read(mkini)
     mk_uuid = mki.get("MACHINEKIT", "MKUUID")
+    aformat = mki.has_option("MACHINEKIT", "ANNOUNCE_FORMAT") and \
+        mki.get("MACHINEKIT", "ANNOUNCE_FORMAT") or None
     remote = mki.getint("MACHINEKIT", "REMOTE")
 
     if remote == 0:
@@ -193,7 +197,7 @@ def main():
 
     hostname = '%(fqdn)s'  # replaced by service announcement
     video = VideoServer(
-        args.ini, svc_uuid=mk_uuid, host=hostname, loopback=(not remote), debug=debug
+        args.ini, svc_uuid=mk_uuid, host=hostname, loopback=(not remote), announce_format=aformat, debug=debug
     )
     video.setDaemon(True)
     video.start()

--- a/src/rtapi/rtapi_msgd.cc
+++ b/src/rtapi/rtapi_msgd.cc
@@ -1108,7 +1108,7 @@ int main(int argc, char **argv)
 	return -1;
     //    assert(logpub.port > -1);
 
-    if (mk_announce(&netopts, &logpub, "Log service", NULL))
+    if (mk_announce(&netopts, &logpub, "Log", NULL))
 	return -1;
 
     zmq_pollitem_t signal_poller =  { 0, signal_fd,   ZMQ_POLLIN };


### PR DESCRIPTION
This PR addresses https://github.com/machinekit/machinekit-hal/issues/170. 

Previously, the published mDNS record was hard-coded by each service that implemented the functionality, sometimes providing the ability for command line options to include hostname, etc. These changes move the formatting to the common `machinekit.ini` file, allowing for configuration changes to affect all services globally instead of through independent switches. 

I have also updated some of the previous services were announced as "Machinekit", where duplication was possible. The new default service format is specified as:

```
(Prefix) (Service Name) on (FQDN).(Service Type).(Domain)
```
An example for mklauncher status service is:

```
MK Launcher on machinekit.local._machinekit._tcp.local
```

By adjusting the format string in `machinekit.ini`, the services can also publish using the MKUUID rather than hostname. An example using mkuuid and srvtype instead of srvname:

```
# Format string is "MK $SRVTYPE [$MKUUID]" in machinekit.ini
MK launchercmd [UUID-Removed]._machinekit._tcp.local
```
