### PR TITLE
Add docs build option directly to build_docker script

### DIFF
--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -162,7 +162,15 @@ case $CMD in
 	    ${RUN_TESTS} ${TEST_ARGS}"
 	)
 	;;
-    *)   echo "Unkown command '$CMD'" >&2; exit 1 ;;
+    "docs") # Just build docs
+	BUILD_CL=( bash -xec "
+	    cd src ;
+	    ./autogen.sh ;
+	    ./configure --enable-build-documentation ;
+	    make docpages i_docpages ;"
+	)
+	;;
+    *)   echo "Unknown command '$CMD'" >&2; exit 1 ;;
 esac
 
 ###########################################################


### PR DESCRIPTION
Enables use of normal docker for machinekit-manpages production

The current Jenkins manpages job uses a docker within a proot shell, which has proved problematic.
This will enable the same system as other dockers, with the UID/GID set in a custom container at runtime.

Signed-off-by: Mick <arceye@mgware.co.uk>