### PR TITLE
Fixed some missed changes in Xylotex.ini, Xylotex.hal and setup.sh.

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.bbio
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.bbio
@@ -1,9 +1,26 @@
 # File generated with BB pin configurator
-# title: Xylotex
+# title: BeBoPr-Bridge
+# Export GPIO pins:
+# One pin needs to be exported to enable the low-level clocks for the GPIO
+# modules (there is probably a better way to do this)
+# 
+# Any GPIO pins driven by the PRU need to have their direction set properly
+# here.  The PRU does not do any setup of the GPIO, it just yanks on the
+# pins and assumes you have the output enables configured already
+# 
+# Direct PRU inputs and outputs do not need to be configured here, the pin
+# mux setup (which is handled by the device tree overlay) should be all
+# the setup needed.
+# 
+# Any GPIO pins driven by the hal_bb_gpio driver do not need to be
+# configured here.  The hal_bb_gpio module handles setting the output
+# enable bits properly.  These pins _can_ however be set here without
+# causing problems.  You may wish to do this for documentation or to make
+# sure the pin starts with a known value as soon as possible.
 overlay cape-universal
 overlay cape-bone-iio
 #overlay cape-univ-emmc
- P8_03 low #gpio1.06 Enable
+#P8_03 low #gpio1.06 Enable
  P8_05 high #gpio1.02 Enable_n
  P8_07 high #gpio2.02 Enable_n (ECO location)
  P8_08 high #gpio2.03 

--- a/configs/ARM/BeagleBone/CRAMPS/CRAMPS.bbio
+++ b/configs/ARM/BeagleBone/CRAMPS/CRAMPS.bbio
@@ -1,5 +1,23 @@
 # File generated with BB pin configurator
 # title: CRAMPS
+# Export GPIO pins:
+# One pin needs to be exported to enable the low-level clocks for the GPIO
+# modules (there is probably a better way to do this)
+# 
+# Any GPIO pins driven by the PRU need to have their direction set properly
+# here.  The PRU does not do any setup of the GPIO, it just yanks on the
+# pins and assumes you have the output enables configured already
+# 
+# Direct PRU inputs and outputs do not need to be configured here, the pin
+# mux setup (which is handled by the device tree overlay) should be all
+# the setup needed.
+# 
+# Any GPIO pins driven by the hal_bb_gpio driver do not need to be
+# configured here.  The hal_bb_gpio module handles setting the output
+# enable bits properly.  These pins _can_ however be set here without
+# causing problems.  You may wish to do this for documentation or to make
+# sure the pin starts with a known value as soon as possible.
+
 overlay cape-universal
 overlay cape-bone-iio
 #overlay cape-univ-emmc

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.hal
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.hal
@@ -57,7 +57,7 @@ addf motion-controller                    servo-thread
 addf pid.0.do-pid-calcs                   servo-thread
 addf pid.1.do-pid-calcs                   servo-thread
 addf pid.2.do-pid-calcs                   servo-thread
-#addf pid.3.do-pid-calcs                   servo-thread
+addf pid.3.do-pid-calcs                   servo-thread
 addf limit1.0                             servo-thread
 addf limit1.1                             servo-thread
 addf hpg.update                           servo-thread
@@ -231,6 +231,57 @@ net both-home-z => axis.2.home-sw-in
 net both-home-z => axis.2.neg-lim-sw-in
 net both-home-z => axis.2.pos-lim-sw-in
 #setp bb_gpio.p8.in-18.invert 1
+
+# ################
+# A [3] Axis
+# ################
+# axis enable chain
+newsig emcmot.03.enable bit
+sets emcmot.03.enable FALSE
+
+net emcmot.03.enable <= axis.3.amp-enable-out
+net emcmot.03.enable => hpg.stepgen.03.enable pid.3.enable
+
+# position command and feedback
+net emcmot.03.pos-cmd axis.3.motor-pos-cmd => pid.3.command
+net emcmot.03.vel-cmd axis.3.joint-vel-cmd => pid.3.command-deriv
+net motor.03.pos-fb <= hpg.stepgen.03.position-fb axis.3.motor-pos-fb pid.3.feedback
+net motor.03.command pid.3.output hpg.stepgen.03.velocity-cmd
+setp pid.3.error-previous-target true
+setp pid.3.maxerror .001
+
+# timing parameters
+setp hpg.stepgen.03.dirsetup        [AXIS_3]DIRSETUP
+setp hpg.stepgen.03.dirhold         [AXIS_3]DIRHOLD
+
+setp hpg.stepgen.03.steplen         [AXIS_3]STEPLEN
+setp hpg.stepgen.03.stepspace       [AXIS_3]STEPSPACE
+
+setp hpg.stepgen.03.position-scale  [AXIS_3]SCALE
+
+setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
+setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
+
+setp hpg.stepgen.03.control-type    1
+setp hpg.stepgen.03.stepinvert      [AXIS_3]STEP_INVERT
+#setp hpg.stepgen.03.step_type       0
+setp hpg.stepgen.03.steppin         911
+setp hpg.stepgen.03.dirpin          913
+
+# set PID loop gains from inifile
+setp pid.3.Pgain [AXIS_3]P
+setp pid.3.Igain [AXIS_3]I
+setp pid.3.Dgain [AXIS_3]D
+setp pid.3.bias [AXIS_3]BIAS
+setp pid.3.FF0 [AXIS_3]FF0
+setp pid.3.FF1 [AXIS_3]FF1
+setp pid.3.FF2 [AXIS_3]FF2
+setp pid.3.deadband [AXIS_3]DEADBAND
+setp pid.3.maxoutput [AXIS_3]MAX_OUTPUT
+
+
+# Add A home switch input
+#net home-a bb_gpio.p9.in-41 => axis.3.home-sw-in
 
 # ##################################################
 # Standard I/O - EStop, Enables, Limit Switches, Etc

--- a/configs/ARM/BeagleBone/Xylotex/Xylotex.ini
+++ b/configs/ARM/BeagleBone/Xylotex/Xylotex.ini
@@ -114,7 +114,6 @@ SERVO_PERIOD =          1000000
 # Hardware Abstraction Layer section
 ###############################################################################
 [HAL]
-HALUI = halui
 # The run script first uses halcmd to execute any HALFILE
 # files, and then to execute any individual HALCMD commands.
 HALFILE =                Xylotex.hal
@@ -149,9 +148,9 @@ DEFAULT_ANGULAR_VELOCITY = 4.50
 LINEAR_UNITS =             inch
 ANGULAR_UNITS =            degree
 CYCLE_TIME =               0.010
-DEFAULT_VELOCITY =         2.0
+DEFAULT_VELOCITY =         1.0
 DEFAULT_ACCELERATION =    15.0
-MAX_LINEAR_VELOCITY =      2.6
+MAX_LINEAR_VELOCITY =      1.6
 NO_FORCE_HOMING =          1
 # POSITION_FILE = position.txt
 #PROBE_INDEX =           0


### PR DESCRIPTION
Fixed setup.sh for CRAMPS — needs to be executable.
Both CRAMPS and BeBoPr-Bridge were missing .bbio files.

Signed-off-by: Mick <arceye@mgware.co.uk>
