### PR TITLE
Fix BeBoPr-Bridge pin assignments

### DIFF
--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.bbio
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.bbio
@@ -20,40 +20,31 @@
 overlay cape-universal
 overlay cape-bone-iio
 #overlay cape-univ-emmc
-#P8_03 low #gpio1.06 Enable
- P8_05 high #gpio1.02 Enable_n
  P8_07 high #gpio2.02 Enable_n (ECO location)
- P8_08 high #gpio2.03 
- P8_09 in #gpio2.05 
- P8_10 in #gpio2.04 
+ P8_08 high #gpio2.03 X_MIN
+ P8_09 in #gpio2.05 X_MAX
+ P8_10 in #gpio2.04 Y_MIN
+ P8_11 out #gpio1.13 X_DIR Used in PRU
+ P8_12 out #gpio1.12 X_STP Used in PRU
  P8_13 low #gpio0.23 J2.PWM0-Heater
- P8_14 in #gpio0.26 
- P8_17 in #gpio0.27 
- P8_18 in #gpio2.01 
+ P8_14 in #gpio0.26 Y_Max
+ P8_15 out #gpio1.15 Y_DIR Used in PRU
+ P8_16 out #gpio1_14 Y_STP Used in PRU
+ P8_17 in #gpio0.27 Z_MIN
+ P8_18 in #gpio2.01 Z_MAX
  P8_19 low #gpio0.22 J3.PWM1-Heater
- P8_20 out #gpio1.31 E_ENA
- P8_21 out #gpio1.30 E_DIR Used in PRU
- P8_25 out #gpio1.00 STATUS_LED
- P8_27 out #gpio2.22 Z_Step Used in PRU
- P8_28 out #gpio2.24 Z_Ena
- P8_29 out #gpio2.23 Z_Dir Used in PRU
- P8_30 out #gpio0.10 E_Step Used in PRU
- P8_31 in #gpio0.10 X_Min
- P8_32 in #gpio0.11 X_Max
- P8_33 in #gpio0.09 Y_Max
- P8_35 in #gpio0.08 Y_Min
- P8_36 out #gpio2.16 J4.PWM
- P8_37 in #gpio2.14 Z_Max
- P8_38 in #gpio2.15 Z_Min
- P8_39 out #gpio2.12 Y_Dir Used in PRU
- P8_40 out #gpio2.13 Y_Ena
- P8_41 out #gpio2.10 X_Ena
- P8_42 out #gpio2.11 Y_Step Used in PRU
- P8_43 out #gpio2.08 X_Step Used in PRU
- P8_44 out #gpio2.09 X_Dir Used in PRU
- P8_45 low #gpio2.06 PWM1 Used in PRU
- P8_46 low #gpio2.07 PWM0 Used in PRU
+ P8_26 out #gpio1.29 STATUS_LED
  P9_14 low #gpio1.18 J4.PWM2-Heater
+ P9_15 out #gpio1.16 Z_STP Used in PRU
+ P9_17 out #gpio0.05 B_DIR Used in PRU
+ P9_18 out #gpio0.04 B_STP Used in PRU
+ P9_21 out #gpio0.03 A_DIR Used in PRU
+ P9_22 out #gpio0.02 A_STP Used in PRU
+ P9_23 out #gpio1_17 Z_DIR Used in PRU
+ P9_24 out #gpio0.15 SPINDLE
+ P9_26 out #gpio0.14 AXES_ENA
+# P9_32 high #VDD_ADC
+# P9_33 in #THRM0
+# P9_34 high #GNDA_ADC
+# P9_35 in #THRM1
 # P9_36 in #THRM2
-# P9_38 in #THRM1
-# P9_40 in #THRM0

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
@@ -88,10 +88,10 @@ setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
 setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.00.step_type       0
-# P8.43 PRU1.out2
-setp hpg.stepgen.00.steppin         843
-# P8.44 PRU1.out4
-setp hpg.stepgen.00.dirpin          844
+# P8.12 PRU1.out2
+setp hpg.stepgen.00.steppin         812
+# P8.11 PRU1.out4
+setp hpg.stepgen.00.dirpin          811
 
 
 # ################
@@ -127,10 +127,10 @@ setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
 setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.01.step_type       0
-# P8.42 PRU1.out5
-setp hpg.stepgen.01.steppin         842
-# P8.39 PRU1.out6
-setp hpg.stepgen.01.dirpin          839
+# P8.16 PRU1.out5
+setp hpg.stepgen.01.steppin         816
+# P8.15 PRU1.out6
+setp hpg.stepgen.01.dirpin          815
 
 
 # ################
@@ -166,10 +166,10 @@ setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
 setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.02.step_type       0
-# P8.27 PRU1.out8
-setp hpg.stepgen.02.steppin         827
-# P8.29 PRU1.out9
-setp hpg.stepgen.02.dirpin          829
+# P9.15 PRU1.out8
+setp hpg.stepgen.02.steppin         915
+# P9.23 PRU1.out9
+setp hpg.stepgen.02.dirpin          923
 
 
 # ################
@@ -205,10 +205,10 @@ setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
 setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.03.step_type       0
-# P8.30 GPIO2.25
-setp hpg.stepgen.03.steppin         830
-# P8.21 GPIO1.30
-setp hpg.stepgen.03.dirpin          821
+# P9.22 GPIO0.02
+setp hpg.stepgen.03.steppin         922
+# P9.21 GPIO0.03
+setp hpg.stepgen.03.dirpin          921
 
 
 # ##################################################
@@ -223,14 +223,15 @@ net tool-prep-loop iocontrol.0.tool-prepare => iocontrol.0.tool-prepared
 net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
 
 # Axis enable signals
-net emcmot.00.enable => bb_gpio.p9.out-18
+#net emcmot.00.enable => bb_gpio.p9.out-18
+net emcmot.00.enable => bb_gpio.p9.out-18 bb_gpio.p9.out-17 bb_gpio.p9.out-26 bb_gpio.p9.out-24
 setp bb_gpio.p9.out-18.invert 1
-net emcmot.01.enable => bb_gpio.p9.out-17
-setp bb_gpio.p9.out-17.invert 1
-net emcmot.02.enable => bb_gpio.p9.out-26
-setp bb_gpio.p9.out-26.invert 1
-net emcmot.03.enable => bb_gpio.p9.out-24
-setp bb_gpio.p9.out-24.invert 1
+#net emcmot.01.enable => bb_gpio.p9.out-17
+#setp bb_gpio.p9.out-17.invert 1
+#net emcmot.02.enable => bb_gpio.p9.out-26
+#setp bb_gpio.p9.out-26.invert 1
+#net emcmot.03.enable => bb_gpio.p9.out-24
+#setp bb_gpio.p9.out-24.invert 1
 
 # Machine power (BeBoPr Enable)
 # Enable tied to system Reset_n line (P9.10)

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/BeBoPr-Bridge.hal
@@ -7,7 +7,8 @@
 # ########################################
 
 # Launch the setup script to make sure hardware setup looks good
-loadusr -w ./setup.bridge.sh
+#loadusr -w ./setup.bridge.sh
+loadusr -w ./setup.sh
 loadusr -w config-pin -f ./BeBoPr-Bridge.bbio
 
 
@@ -39,7 +40,7 @@ loadusr -Wn Therm ./ReadTemp.py -n Therm --num_chan 2 -t 1 1 -a 4 5
 # ################################################
 # THREADS
 # ################################################
-# hpg = [PRUCONF](DRIVER)
+
 addf hpg.capture-position                 servo-thread
 addf bb_gpio.read                         servo-thread
 addf motion-command-handler               servo-thread

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/lineardelta.hal
@@ -7,13 +7,14 @@
 # ########################################
 
 # Launch the setup script to make sure hardware setup looks good
-loadusr -w ./setup.bridge.sh
+#loadusr -w ./setup.bridge.sh
+loadusr -w ./setup.sh
+loadusr -w config-pin -f ./BeBoPr-Bridge.bbio
 
 
 # ###################################
 # Core EMC/HAL Loads
 # ###################################
-
 # kinematics
 #loadrt trivkins
 loadrt lineardeltakins
@@ -27,8 +28,7 @@ setp lineardeltakins.R [MACHINE]DELTA_R
 loadrt tp
 loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES tp=tp kins=lineardeltakins
 
-# load low-level drivers
-#loadrt hal_bb_gpio output_pins=107,126,217,218,224,226 input_pins=108,109,110,114,117,118
+# load low-level drivers (Must not include pins used in PRU)
 loadrt hal_bb_gpio output_pins=807,826,917,918,924,926 input_pins=808,809,810,814,817,818
 loadrt [PRUCONF](DRIVER) prucode=$(HAL_RTMOD_DIR)/[PRUCONF](PRUBIN) [PRUCONF](CONFIG)
 loadrt pid count=2
@@ -68,12 +68,9 @@ addf sum2.1                               servo-thread
 # ######################################################
 # Axis-of-motion Specific Configs (not the GUI)
 # ######################################################
-
-
 # ################
 # X [0] Axis = column C
 # ################
-
 # axis enable chain
 newsig emcmot.00.enable bit
 sets emcmot.00.enable FALSE
@@ -103,10 +100,10 @@ setp hpg.stepgen.00.maxvel          [AXIS_0]STEPGEN_MAX_VEL
 setp hpg.stepgen.00.maxaccel        [AXIS_0]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.00.step_type       0
-# P8.43 PRU1.out2
-setp hpg.stepgen.00.steppin         843
-# P8.44 PRU1.out4
-setp hpg.stepgen.00.dirpin          844
+# P8.12 PRU1.out2
+setp hpg.stepgen.00.steppin         812
+# P8.11 PRU1.out4
+setp hpg.stepgen.00.dirpin          811
 
 # because column C is connected to the X-axis output
 # the bebopr-bridge signal needs to be X-max means P8.9
@@ -146,10 +143,10 @@ setp hpg.stepgen.01.maxvel          [AXIS_1]STEPGEN_MAX_VEL
 setp hpg.stepgen.01.maxaccel        [AXIS_1]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.01.step_type       0
-# P8.42 PRU1.out5
-setp hpg.stepgen.01.steppin         842
-# P8.39 PRU1.out6
-setp hpg.stepgen.01.dirpin          839
+# P8.16 PRU1.out5
+setp hpg.stepgen.01.steppin         816
+# P8.15 PRU1.out6
+setp hpg.stepgen.01.dirpin          815
 
 
 # because column A is connected to the Y-axis output
@@ -190,10 +187,10 @@ setp hpg.stepgen.02.maxvel          [AXIS_2]STEPGEN_MAX_VEL
 setp hpg.stepgen.02.maxaccel        [AXIS_2]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.02.step_type       0
-# P8.27 PRU1.out8
-setp hpg.stepgen.02.steppin         827
-# P8.29 PRU1.out9
-setp hpg.stepgen.02.dirpin          829
+# P9.15 PRU1.out8
+setp hpg.stepgen.02.steppin         915
+# P9.23 PRU1.out9
+setp hpg.stepgen.02.dirpin          923
 
 # because column B is connected to the Z-axis output
 # the bebopr-bridge signal needs to be Z-max means P8.18
@@ -233,10 +230,10 @@ setp hpg.stepgen.03.maxvel          [AXIS_3]STEPGEN_MAX_VEL
 setp hpg.stepgen.03.maxaccel        [AXIS_3]STEPGEN_MAX_ACC
 
 #setp hpg.stepgen.03.step_type       0
-# P8.30 GPIO2.25
-setp hpg.stepgen.03.steppin         830
-# P8.21 GPIO1.30
-setp hpg.stepgen.03.dirpin          821
+# P9.22 GPIO0.02
+setp hpg.stepgen.03.steppin         922
+# P9.21 GPIO0.03
+setp hpg.stepgen.03.dirpin          921
 
 
 # ##################################################
@@ -251,14 +248,15 @@ net tool-prep-loop iocontrol.0.tool-prepare => iocontrol.0.tool-prepared
 net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
 
 # Axis enable signals
-net emcmot.00.enable => bb_gpio.p9.out-18
+#net emcmot.00.enable => bb_gpio.p9.out-18
+net emcmot.00.enable => bb_gpio.p9.out-18 bb_gpio.p9.out-17 bb_gpio.p9.out-26 bb_gpio.p9.out-24
 setp bb_gpio.p9.out-18.invert 1
-net emcmot.01.enable => bb_gpio.p9.out-17
-setp bb_gpio.p9.out-17.invert 1
-net emcmot.02.enable => bb_gpio.p9.out-26
-setp bb_gpio.p9.out-26.invert 1
-net emcmot.03.enable => bb_gpio.p9.out-24
-setp bb_gpio.p9.out-24.invert 1
+#net emcmot.01.enable => bb_gpio.p9.out-17
+#setp bb_gpio.p9.out-17.invert 1
+#net emcmot.02.enable => bb_gpio.p9.out-26
+#setp bb_gpio.p9.out-26.invert 1
+#net emcmot.03.enable => bb_gpio.p9.out-24
+#setp bb_gpio.p9.out-24.invert 1
 
 # Machine power (BeBoPr Enable)
 # Enable tied to system Reset_n line (P9.10)

--- a/configs/ARM/BeagleBone/BeBoPr-Bridge/setup.sh
+++ b/configs/ARM/BeagleBone/BeBoPr-Bridge/setup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2013
+# Charles Steinkuehler <charles@steinkuehler.net>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+dtbo_err () {
+	echo "Error loading device tree overlay file: $DTBO" >&2
+	exit 1
+}
+
+pin_err () {
+	echo "Error exporting pin:$PIN" >&2
+	exit 1
+}
+
+dir_err () {
+	echo "Error setting direction:$DIR on pin:$PIN" >&2
+	exit 1
+}
+
+PRU=/sys/class/uio/uio0
+echo -n "Waiting for $PRU "
+
+while [ ! -r $PRU ]
+do
+    echo -n "."
+    sleep 1
+done
+echo OK
+
+if [ ! -r $PRU ] ; then
+	echo PRU control files not found in $PRU >&2
+	exit 1;
+fi
+


### PR DESCRIPTION
Pin assignments in BeBoPr-Bridge.hal and lineardelta.hal were for BBB with BeBoPr rather that BBB with BeBoPr+Bridge. Hopefully someone with hardware that actually runs on the BeBoPr+Bridge can test it. All I can test is that machine kit starts and runs on a BeBoPr+Bridge without attached hardware.