### PR TITLE
Revert e207745 and b55b544 and remove -Werror CFLAG

### DIFF
--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -67,10 +67,11 @@ esac
 # Distro specific warnings level
 case ${TAG} in
     *_8|*_9)
-	WERROR_FLAG="-Werror"
+	WERROR_FLAG=""  # Remove for now until possible to satisfy 32 and 64 bit
+			# with same data type and have rtapi_pci work
 	;;
     *)
-	WERROR_FLAG=""    # Buster and above have many as yet unresolved warnings
+	WERROR_FLAG=""  # Buster and above have many as yet unresolved warnings
 	;;
 esac
 

--- a/src/machinetalk/support/unionread.c
+++ b/src/machinetalk/support/unionread.c
@@ -58,8 +58,7 @@ bool print_container(pb_istream_t *stream)
     if (!pb_decode_varint(stream, &length)) {
 	printf("Parsing field#2 failed: %s\n", PB_GET_ERROR(stream));
     }
-    printf("submessage length=%"PRIu64"\n", length);
-
+    printf("submessage length=%lu\n", length);
     printf("submessage: %s NML; %s Motion\n",
 	   is_NML_container(tag) ? "is" : "not",
 	   is_Motion_container(tag) ? "is" : "not");

--- a/src/rtapi/rtapi_pci.c
+++ b/src/rtapi/rtapi_pci.c
@@ -653,8 +653,7 @@ int pci_enable_device(struct pci_dev *dev)
     FILE *stream;
     char path[256];
     int i,r;
-    void *L1, *L2;
-    unsigned long L3;
+    unsigned long long L1, L2, L3;
 
     rtapi_print_msg(RTAPI_MSG_DBG, "RTAPI_PCI: Enabling Device %s\n", dev->dev_name);
 
@@ -682,11 +681,11 @@ int pci_enable_device(struct pci_dev *dev)
         
     /* ...and read in the data */
     for (i=0; i < 6; i++) {
-        r=fscanf(stream, "%p %p %lu", &L1, &L2, &L3);
+	r=fscanf(stream, "%Lx %Lx %Lx", &L1, &L2, &L3);
         if (r != 3) {
-		    rtapi_print_msg(RTAPI_MSG_ERR,"Failed to parse \"%s\"\n", path);
+	    rtapi_print_msg(RTAPI_MSG_ERR,"Failed to parse \"%s\"\n", path);
             fclose(stream);
-		    return -1;
+	    return -1;
         }
         dev->resource[i].start = (void*) L1;
         dev->resource[i].end   = (void*) L2;


### PR DESCRIPTION
Commits attempt to remove warnings arising from data types having
different sizes under 32 and 64 bit.
    
However assigning void pointers instead of `long long uint`
and casting to `void *` where reqd , to avoid a warning, 
resulted in non functioning rtapi_pci, preventing hm2_pci from working.
    
scripts/build_docker CFLAGS addition of -Werror removed for now.

Fixes https://groups.google.com/forum/#!topic/machinekit/KQFyNEsnblE
