### PR TITLE
Add specific -lzmq to CFLAGS to prevent DSO errors in later distros.

### DIFF
--- a/src/machinetalk/haltalk/Submakefile
+++ b/src/machinetalk/haltalk/Submakefile
@@ -20,7 +20,7 @@ HALTALK_LDFLAGS := \
 	$(CZMQ_LIBS) 		\
 	$(JANSSON_LIBS) 	\
 	$(AVAHI_LIBS) 	\
-	-lstdc++ -lm
+	-lstdc++ -lm -lzmq
 
 $(call TOOBJSDEPS, $(HALTALK_SRCS)) : EXTRAFLAGS += $(HALTALK_CXXFLAGS)
 

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -375,10 +375,10 @@ $(call TOOBJSDEPS, $(RTAPI_MSGD_SRCS)): \
 	../lib/liblinuxcncshm.so \
 	../lib/liblinuxcncini.so \
 	../lib/libmtalk.so.0 \
-	../lib/libmachinetalk-pb2++.so
+	../lib/libmachinetalk-pb2++.so 
 	$(ECHO) Linking $(notdir $@)
 	@mkdir -p $(dir $@)
-	$(Q)$(CC)  $(LDFLAGS) -o $@ $^ $(RTAPI_MSGD_LDFLAGS) -lrt
+	$(Q)$(CC)  $(LDFLAGS) -o $@ $^ $(RTAPI_MSGD_LDFLAGS) -lrt -lzmq
 
 USERSRCS += $(RTAPI_MSGD_SRCS)
 TARGETS += ../libexec/rtapi_msgd


### PR DESCRIPTION
Prevent DSO errors in later versions of gcc

Cherry-picked from machinekit-hal, this prevents errors when building on sid
