### PR TITLE
DO NOT MERGE YET - WILL BREAK DOCKER BUILDERS

### DIFF
--- a/debian/control.buster.in
+++ b/debian/control.buster.in
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 6),
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
     python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
     python-simplejson, libtk-img, libboost-thread-dev,
-    python-pyftpdlib, tcl8.6-dev, tk8.6-dev, libcgroup-dev @BUILD_DEPS@
+    python-pyftpdlib, tcl8.6-dev, tk8.6-dev, tcl-dev, libcgroup-dev, @BUILD_DEPS@
 Standards-Version: 2.1.0
 
 #########################################################################

--- a/debian/control.in
+++ b/debian/control.in
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 6),
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
     python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
     python-simplejson, libtk-img, libboost-thread-dev,
-    python-pyftpdlib, tcl8.6-dev, tk8.6-dev, libcgroup-dev @BUILD_DEPS@
+    python-pyftpdlib, tcl8.6-dev, tk8.6-dev, tcl-dev, libcgroup-dev, @BUILD_DEPS@
 Standards-Version: 2.1.0
 
 #########################################################################

--- a/debian/control.sid.in
+++ b/debian/control.sid.in
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 6),
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
     python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
     python-simplejson, libtk-img, libboost-thread-dev,
-    python-pyftpdlib, tcl8.6-dev, tk8.6-dev @BUILD_DEPS@
+    python-pyftpdlib, tcl8.6-dev, tk8.6-dev, tcl-dev, @BUILD_DEPS@
 Standards-Version: 2.1.0
 
 #########################################################################

--- a/debian/control.stretch.in
+++ b/debian/control.stretch.in
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 6),
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
     python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
     python-simplejson, libtk-img, libboost-thread-dev,
-    python-pyftpdlib, tcl8.6-dev, tk8.6-dev, libcgroup-dev @BUILD_DEPS@
+    python-pyftpdlib, tcl8.6-dev, tk8.6-dev, tcl-dev, libcgroup-dev, @BUILD_DEPS@
 Standards-Version: 2.1.0
 
 #########################################################################

--- a/src/hal/utils/Submakefile
+++ b/src/hal/utils/Submakefile
@@ -7,6 +7,9 @@ HALCMDSRCS += hal/utils/halcmd_completion.c
 endif
 USERSRCS += $(sort $(HALCMDSRCS) $(HALSHSRCS) $(HALCMDCCSRCS))
 
+## since Dec 2014 tcl8.x-dev has not cotained code for tclstubs
+## now in package tcl-dev containing libtclstub.a
+## without this linked, some tcl programs (halshow) will not work
 $(call TOOBJSDEPS, $(HALSHSRCS)) : EXTRAFLAGS = -fPIC
 $(call TOOBJSDEPS, hal/utils/halsh.c) : EXTRAFLAGS += $(TCL_CFLAGS)
 ../tcl/hal.so: $(call TOOBJS, $(HALSHSRCS)) \
@@ -14,9 +17,9 @@ $(call TOOBJSDEPS, hal/utils/halsh.c) : EXTRAFLAGS += $(TCL_CFLAGS)
 	../lib/liblinuxcnchal.so.0 \
 	../lib/libmachinetalk-pb2++.so.0 \
 	../lib/libmtalk.so.0 \
-	../lib/librtapi_math.so.0
+	../lib/librtapi_math.so.0 
 	$(ECHO) Linking $(notdir $@)
-	$(Q)$(CC) $(LDFLAGS) -shared $^  -o $@
+	$(Q)$(CC) $(LDFLAGS) -shared $^ -o $@ -ltclstub
 TARGETS += ../tcl/hal.so
 
 $(call TOOBJSDEPS, $(HALCMDCCSRCS)) : EXTRAFLAGS =  \


### PR DESCRIPTION
Until the tcl-dev package is added to the mk-cross-builder dockers,
building this commit will fail.

For possibly 4 years, the tcl program halshow has not worked.

The root of the problem is that tclStubsPtr was removed from the tcl8.x-dev package
https://alioth-lists.debian.net/pipermail/pkg-tcltk-devel/2014-October/002697.html

Without a new package tcl-dev installed and a link instruction to libtclstub.a
hal.so will not export a symbol `tclStubPtr` required by halshow and launch fails.

Fixes https://github.com/machinekit/machinekit-cnc/issues/70

Signed-off-by: Mick <arceye@mgware.co.uk>

