### PR TITLE
rtapi/rtapi_pci.c: Fix PCI resource file parsing

### DIFF
--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -67,8 +67,7 @@ esac
 # Distro specific warnings level
 case ${TAG} in
     *_8|*_9)
-	WERROR_FLAG=""  # Remove for now until possible to satisfy 32 and 64 bit
-			# with same data type and have rtapi_pci work
+	WERROR_FLAG="-Werror"
 	;;
     *)
 	WERROR_FLAG=""  # Buster and above have many as yet unresolved warnings

--- a/src/machinetalk/support/unionread.c
+++ b/src/machinetalk/support/unionread.c
@@ -58,7 +58,8 @@ bool print_container(pb_istream_t *stream)
     if (!pb_decode_varint(stream, &length)) {
 	printf("Parsing field#2 failed: %s\n", PB_GET_ERROR(stream));
     }
-    printf("submessage length=%lu\n", length);
+    printf("submessage length=%"PRIu64"\n", length);
+
     printf("submessage: %s NML; %s Motion\n",
 	   is_NML_container(tag) ? "is" : "not",
 	   is_Motion_container(tag) ? "is" : "not");

--- a/src/rtapi/rtapi_pci.c
+++ b/src/rtapi/rtapi_pci.c
@@ -682,7 +682,7 @@ int pci_enable_device(struct pci_dev *dev)
         
     /* ...and read in the data */
     for (i=0; i < 6; i++) {
-        r=fscanf(stream, "%p %p %lu", &L1, &L2, &L3);
+        r=fscanf(stream, "%p %p %lx", &L1, &L2, &L3);
         if (r != 3) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,"Failed to parse \"%s\"\n", path);
             fclose(stream);

--- a/src/rtapi/rtapi_pci.c
+++ b/src/rtapi/rtapi_pci.c
@@ -653,7 +653,8 @@ int pci_enable_device(struct pci_dev *dev)
     FILE *stream;
     char path[256];
     int i,r;
-    unsigned long long L1, L2, L3;
+    void *L1, *L2;
+    unsigned long L3;
 
     rtapi_print_msg(RTAPI_MSG_DBG, "RTAPI_PCI: Enabling Device %s\n", dev->dev_name);
 
@@ -681,7 +682,7 @@ int pci_enable_device(struct pci_dev *dev)
         
     /* ...and read in the data */
     for (i=0; i < 6; i++) {
-	r=fscanf(stream, "%Lx %Lx %Lx", &L1, &L2, &L3);
+        r=fscanf(stream, "%p %p %lu", &L1, &L2, &L3);
         if (r != 3) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,"Failed to parse \"%s\"\n", path);
             fclose(stream);

--- a/src/rtapi/rtapi_pci.c
+++ b/src/rtapi/rtapi_pci.c
@@ -653,8 +653,6 @@ int pci_enable_device(struct pci_dev *dev)
     FILE *stream;
     char path[256];
     int i,r;
-    void *L1, *L2;
-    unsigned long L3;
 
     rtapi_print_msg(RTAPI_MSG_DBG, "RTAPI_PCI: Enabling Device %s\n", dev->dev_name);
 
@@ -682,15 +680,15 @@ int pci_enable_device(struct pci_dev *dev)
         
     /* ...and read in the data */
     for (i=0; i < 6; i++) {
-        r=fscanf(stream, "%p %p %lx", &L1, &L2, &L3);
+        r=fscanf(stream, "%p %p %lx",
+                 &dev->resource[i].start,
+                 &dev->resource[i].end,
+                 &dev->resource[i].flags);
         if (r != 3) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,"Failed to parse \"%s\"\n", path);
             fclose(stream);
 	    return -1;
         }
-        dev->resource[i].start = (void*) L1;
-        dev->resource[i].end   = (void*) L2;
-        dev->resource[i].flags = (unsigned long) L3;
 
         rtapi_print_msg(RTAPI_MSG_DBG,"Resource %d: %p %p %08lx\n", i,
             dev->resource[i].start,


### PR DESCRIPTION
Fixes a problem introduced in commit e207745f.  Thanks to Dennis for
reporting the problem and locating the problematic commit on the [ML][1].

[1]:  https://groups.google.com/d/msg/machinekit/KQFyNEsnblE/gX_-g36tCQAJ

Also submitted as machinekit/machinekit-hal#188
