### PR TITLE
debian/rules:  Remove obsolete `dh_python2 --no-ext-rename` arg

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -228,7 +228,7 @@ binary-arch: build install
 	dh_compress -X.pdf -X.txt -X.hal -X.ini -X.clp -X.var -X.nml \
 	    -X.tbl -X.xml -Xsample-configs
 	dh_fixperms -X/linuxcnc_module_helper -X/rtapi_app_
-	dh_python2 --ignore-shebangs --no-guessing-versions --no-ext-rename
+	dh_python2 --ignore-shebangs --no-guessing-versions
 	dh_makeshlibs
 	dh_installdeb
 


### PR DESCRIPTION
On Buster, causes package build failures:

    dh_python2 --ignore-shebangs --no-guessing-versions --no-ext-rename
    [...]
    dh_python2: error: no such option: --no-ext-rename

This option isn't in manual pages since Wheezy.


