### PR TITLE
rtapi_support.c:  Temp. silence `rtapi_print()`

### DIFF
--- a/src/rtapi/rtapi_support.c
+++ b/src/rtapi/rtapi_support.c
@@ -239,7 +239,7 @@ void rtapi_print(const char *fmt, ...) {
     va_list args;
 
     va_start(args, fmt);
-    rtapi_msg_handler(RTAPI_MSG_ERR, fmt, args);
+    rtapi_msg_handler(RTAPI_MSG_ALL, fmt, args);
     va_end(args);
 }
 


### PR DESCRIPTION
This reverts part of commit 77a23d3 from PR #1452.

The `rtapi_print()` function was set to never print, and that PR
changed it to always print, as the comments in `rtapi.h` indicate it
should.  However, the result was that it spews messages out the error
channel, which show up in Axis.  That's bad.

This reverts back to the "never print" behavior until a better
solution comes along.
