### PR TITLE
Linkage of tcl/hal.so against libtclstub.a is necessary for tcl

### DIFF
--- a/src/hal/utils/Submakefile
+++ b/src/hal/utils/Submakefile
@@ -16,7 +16,7 @@ $(call TOOBJSDEPS, hal/utils/halsh.c) : EXTRAFLAGS += $(TCL_CFLAGS)
 	../lib/libmtalk.so.0 \
 	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
-	$(Q)$(CC) $(LDFLAGS) -shared $^  -o $@
+	$(Q)$(CC) $(LDFLAGS) -shared $^  -o $@ $(TCL_LIBS) -o $@ -ltclstub
 TARGETS += ../tcl/hal.so
 
 $(call TOOBJSDEPS, $(HALCMDCCSRCS)) : EXTRAFLAGS =  \


### PR DESCRIPTION
This commit removed the linkage against libtclstub.a because it produced warnings
of possible unused symbols.
machinekit/machinekit@d1fed9c#diff-b95f3ce6cb4f8632848c66ea2be6b1f5

Reverting machinekit, so that it has the same linkage in tcl/hal.so
that machinekit-hal does, removes the 'undefined reference to tclStubPtr' error.

Signed-off-by: Mick <arceye@mgware.co.uk>

