### PR TITLE
Expose interp synch command through python/machinetalk

### DIFF
--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -1128,6 +1128,15 @@ static PyObject *reset_interpreter(pyCommandChannel *s, PyObject *o) {
     return Py_None;
 }
 
+static PyObject *synch_interpreter(pyCommandChannel *s, PyObject *o) {
+    EMC_TASK_PLAN_SYNCH m;
+    m.serial_number = next_serial(s);
+    s->c->write(m);
+    emcWaitCommandReceived(s->serial, s->s);
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
 static PyObject *program_open(pyCommandChannel *s, PyObject *o) {
     EMC_TASK_PLAN_OPEN m;
     char *file;
@@ -1379,6 +1388,7 @@ static PyMethodDef Command_methods[] = {
     {"unhome", (PyCFunction)unhome, METH_VARARGS},
     {"jog", (PyCFunction)jog, METH_VARARGS},
     {"reset_interpreter", (PyCFunction)reset_interpreter, METH_NOARGS},
+    {"synch_interpreter", (PyCFunction)synch_interpreter, METH_NOARGS},
     {"program_open", (PyCFunction)program_open, METH_VARARGS},
     {"auto", (PyCFunction)emcauto, METH_VARARGS},
     {"set_home_parameters", (PyCFunction)set_home_parameters, METH_VARARGS},

--- a/src/machinetalk/mkwrapper/mkwrapper.py
+++ b/src/machinetalk/mkwrapper/mkwrapper.py
@@ -2270,6 +2270,15 @@ class LinuxCNCWrapper(object):
                 else:
                     self.send_command_wrong_params(identity)
 
+            elif self.rx.type == MT_EMC_TASK_PLAN_SYNCH:
+                if self.rx.HasField('interp_name'):
+                    if self.rx.interp_name == 'execute':
+                        self.command.synch_interpreter()
+                        if self.rx.HasField('ticket'):
+                            self.wait_complete(identity, self.rx.ticket)
+                else:
+                    self.send_command_wrong_params(identity)
+
             elif self.rx.type == MT_EMC_MOTION_ADAPTIVE:
                 if self.rx.HasField(
                     'emc_command_params'


### PR DESCRIPTION
This little change allows remote interfaces to ask the active interpreter to synchronize state on demand.