### PR TITLE
Backport #456555d from mk-hal to accomodate Fedora builds

### DIFF
--- a/src/hal/utils/Submakefile
+++ b/src/hal/utils/Submakefile
@@ -16,7 +16,7 @@ $(call TOOBJSDEPS, hal/utils/halsh.c) : EXTRAFLAGS += $(TCL_CFLAGS)
 	../lib/libmtalk.so.0 \
 	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
-	$(Q)$(CC) $(LDFLAGS) -shared $^  -o $@ $(TCL_LIBS) -o $@ -ltclstub
+	$(Q)$(CC) $(LDFLAGS) -shared $^  -o $@ $(TCL_LIBS)
 TARGETS += ../tcl/hal.so
 
 $(call TOOBJSDEPS, $(HALCMDCCSRCS)) : EXTRAFLAGS =  \


### PR DESCRIPTION
signed off by mick (arceye@mgware.co.uk)