### PR TITLE
Update machinekit-rt-preempt.install.in

### DIFF
--- a/debian/machinekit-rt-preempt.install.in
+++ b/debian/machinekit-rt-preempt.install.in
@@ -8,4 +8,3 @@ usr/lib/*.so
 usr/bin/comp
 usr/share/linuxcnc/Makefile.modinc
 usr/share/linuxcnc/Makefile.inc
-usr/share/linuxcnc/udev/*.rules


### PR DESCRIPTION
Remove duplicated udev rules already in machinekit package

